### PR TITLE
Fix mismatched code tag

### DIFF
--- a/en/api/app-locals.jade
+++ b/en/api/app-locals.jade
@@ -29,7 +29,7 @@ section
     // => 'me@myapp.com'
 
   p.
-    By default Express exposes only a single app-level local variable, code>settings</code>.
+    By default Express exposes only a single app-level local variable, <code>settings</code>.
 
   +js.
     app.set('title', 'My App');


### PR DESCRIPTION
The code tag was missing an opening angle bracket.
