### PR TITLE
Dead link in the FAQ

### DIFF
--- a/en/faq.jade
+++ b/en/faq.jade
@@ -39,7 +39,7 @@ section
     examples for inspiration:
 
   ul
-    li: a(href='https://github.com/visionmedia/express/blob/master/examples/route-separation/app.js#L20') Route listings
+    li: a(href='https://github.com/visionmedia/express/blob/master/examples/route-separation/index.js#L19') Route listings
     li: a(href='https://github.com/visionmedia/express/blob/master/examples/route-map/index.js#L47') Route map
     li: a(href='https://github.com/visionmedia/express/tree/master/examples/route-loading') Route bootstrapping
     li: a(href='https://github.com/visionmedia/express/tree/master/examples/mvc') MVC style controllers


### PR DESCRIPTION
The link to 'Routes listing' in the FAQ is dead, this should fix it. I did not build, nor test, as I am currently on a machine without 'make'. It is a very simple change; it shouldn't break anything.
