### PR TITLE
Put in a link to Connect Middleware

### DIFF
--- a/en/api/app-use.jade
+++ b/en/api/app-use.jade
@@ -85,3 +85,9 @@ section
     app.use(express.static(__dirname + '/public'));
     app.use(express.static(__dirname + '/files'));
     app.use(express.static(__dirname + '/uploads'));
+
+   p.
+    Many of the Express middleware packages come from Connect. 
+    Please consult 
+    a (href="http://www.senchalabs.org/connect/") their docs
+    if you want to learn more


### PR DESCRIPTION
Since Express bundles a bunch of Connect middleware I think a link to their middleware will help people who want to understand what the middleware does. It would be helpful to know if all the connect middleware is included with Express.
