### PR TITLE
typo fix in bodyParser doc

### DIFF
--- a/en/api/mw-bodyParser.jade
+++ b/en/api/mw-bodyParser.jade
@@ -4,7 +4,7 @@ section
   p.
     Request body parsing middleware supporting JSON, urlencoded,
     and multipart requests. This middleware is simply a wrapper
-    the <code>json()</code>, <code>urlencoded()</code>, and
+    for the <code>json()</code>, <code>urlencoded()</code>, and
     <code>multipart()</code> middleware.
 
   +js.


### PR DESCRIPTION
Tiny typo fixed in bodyParser explanation.
