### PR TITLE
Updated order of items in menu.jade

### DIFF
--- a/en/api/menu.jade
+++ b/en/api/menu.jade
@@ -11,9 +11,9 @@ ul#menu
       li: a(href='#app.disabled') app.disabled()
       li: a(href='#app.configure') app.configure()
       li: a(href='#app.use') app.use()
+      li: a(href='#app-settings') application settings
       li: a(href='#app.engine') app.engine()
       li: a(href='#app.param') app.param()
-      li: a(href='#app-settings') application settings
       li: a(href='#app.VERB') application routing
       li: a(href='#app.all') app.all()
       li: a(href='#app.locals') app.locals


### PR DESCRIPTION
Application setting was placed after app.engine() and app.param() in the menu, which wasn't matching that in en/api/app.jade.
