### PR TITLE
Fix typo in `express.basicAuth` documentation

### DIFF
--- a/en/api/mw-basicAuth.jade
+++ b/en/api/mw-basicAuth.jade
@@ -14,7 +14,7 @@ section
 
   +js.
      app.use(express.basicAuth(function(user, pass){
-       return 'tj' == user & 'wahoo' == pass;
+       return 'tj' == user && 'wahoo' == pass;
      }));
 
   p.


### PR DESCRIPTION
Missing `&`.
