### PR TITLE
Update to latest jade/deps

### DIFF
--- a/api.jade
+++ b/api.jade
@@ -1,4 +1,4 @@
-!!! 5
+doctype html5
 html
   head
     title Express - api reference
@@ -8,7 +8,7 @@ html
     section#content
       header
         include includes/logo
-        active = './api.html'
+        - active = './api.html'
         include includes/menu
 
       include includes/mixins

--- a/applications.jade
+++ b/applications.jade
@@ -1,4 +1,4 @@
-!!! 5
+doctype html5
 html
   head
     title Express - applications
@@ -8,7 +8,7 @@ html
     section#content
       header
         include includes/logo
-        active = './applications.html'
+        - active = './applications.html'
         include includes/menu
       include en/applications
     include includes/footer

--- a/community.jade
+++ b/community.jade
@@ -1,4 +1,4 @@
-!!! 5
+doctype html5
 html
   head
     title Express - community
@@ -8,7 +8,7 @@ html
     section#content
       header
         include includes/logo
-        active = './community.html'
+        - active = './community.html'
         include includes/menu
       include en/community
     include includes/footer

--- a/faq.jade
+++ b/faq.jade
@@ -1,4 +1,4 @@
-!!! 5
+doctype html5
 html
   head
     title Express - faq
@@ -8,7 +8,7 @@ html
     section#content
       header
         include includes/logo
-        active = './faq.html'
+        - active = './faq.html'
         include includes/menu
       #faq
         include en/faq

--- a/guide.jade
+++ b/guide.jade
@@ -1,4 +1,4 @@
-!!! 5
+doctype html5
 html
   head
     title Express - guide
@@ -8,7 +8,7 @@ html
     section#content
       header
         include includes/logo
-        active = './guide.html'
+        - active = './guide.html'
         include includes/menu
 
       include includes/mixins

--- a/includes/head.jade
+++ b/includes/head.jade
@@ -1,6 +1,6 @@
 link(rel='stylesheet', href='style.css')
 link(rel='stylesheet', href='//fonts.googleapis.com/css?family=Open+Sans:300,400,600,700&amp;subset=latin,latin-ext')
 meta(http-equiv='Content-Type', content='text/html; charset=UTF-8')
-script(src='http://ajax.googleapis.com/ajax/libs/jquery/1.7.0/jquery.min.js')
+script(src='http://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js')
 script(src='app.js')
 script(src='retina.js')

--- a/index.jade
+++ b/index.jade
@@ -1,4 +1,4 @@
-!!! 5
+doctype html5
 html
   head
     title Express - node.js web application framework
@@ -9,7 +9,7 @@ html
     section#content
       header
         include includes/logo
-        active = './'
+        - active = './'
         include includes/menu
      section#logos
        .content

--- a/package.json
+++ b/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "version": "0.0.0",
   "dependencies": {
-    "jade": "0.35.0"
+    "jade": "1.1.5"
   }
 }


### PR DESCRIPTION
The purpose of this is to make it super easy to contribute to the docs, which will only promote express all the more.

I've moved over from `make` to `gulp`, which will work on any os. I've also update to the latest jade, to be current to the docs. Also updated the `readme`, which includes one less for building. 

Note: In the future I'll probably setup a watch/reload on template change.
