### PR TITLE
Fix typo in "req.params" documentation

### DIFF
--- a/4x/en/api/req-params.jade
+++ b/4x/en/api/req-params.jade
@@ -2,7 +2,7 @@ section
   h3(id='req.params') req.params
 
   p.
-    This property is an array containing properties mapped to the named route "parameters".
+    This property is an object containing properties mapped to the named route "parameters".
     For example if you have the route <code>/user/:name</code>, then the "name" property
     is available to you as <code>req.params.name</code>. This object defaults to <code>{}</code>.
 


### PR DESCRIPTION
req.params is an object, not an array.
