### PR TITLE
Fixes 404 when clicking on the logo in API and 4.x docs pages

### DIFF
--- a/includes/logo.jade
+++ b/includes/logo.jade
@@ -1,5 +1,5 @@
 section#logo
-  a.express(href='./') express
+  a.express(href='/') express
   span.description
     | web application framework for
     a(href='http://nodejs.org')  node


### PR DESCRIPTION
Go to http://expressjs.com/3x/api.html and click on the logo.

Changed the path to the root as the logo always seems to point to the homepage anyway.
