### PR TITLE
Updated 4.x app.locals documentation. Fixes #136

### DIFF
--- a/4x/en/api/app-locals.jade
+++ b/4x/en/api/app-locals.jade
@@ -9,37 +9,18 @@ section
   +js.
     app.locals.title = 'My App';
     app.locals.strftime = require('strftime');
+    app.locals.email = 'me@myapp.com';
 
   p.
-    The <code>app.locals</code> object is a JavaScript <code>Function</code>,
-    which when invoked with an object will merge properties into itself, providing
-    a simple way to expose existing objects as local variables.
+    The <code>app.locals</code> object is a JavaScript <code>Object</code>. The
+    properties added to it will be exposed as local variables within the application.
 
   +js.
-    app.locals({
-      title: 'My App',
-      phone: '1-250-858-9990',
-      email: 'me@myapp.com'
-    });
-
     app.locals.title
     // => 'My App'
 
     app.locals.email
     // => 'me@myapp.com'
-
-  p.
-    A consequence of the <code>app.locals</code> Object being ultimately a Javascript Function Object is that you must not reuse existing (native) named properties for your own variable names, such as <code>name, apply, bind, call, arguments, length, constructor</code>.
-
-  +js.
-      app.locals({name: 'My App'});
-
-      app.locals.name
-      // => return 'app.locals' in place of 'My App' (app.locals is a Function !)
-      // => if name's variable is used in a template, a ReferenceError will be returned.
-
-  p.
-    The full list of native named properties can be found in many specifications. The <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference">JavaScript specification</a> introduced original properties, some of which still recognized by modern engines, and the <a href="http://www.ecma-international.org/ecma-262/5.1/">EcmaScript specification</a> then built on it and normalized the set of properties, adding new ones and removing deprecated ones. Check out properties for Functions and Objects if interested.
 
   p.
     By default Express exposes only a single app-level local variable, <code>settings</code>.


### PR DESCRIPTION
Removed the content related to app.locals being a Javascript Function.
Added/modified content (including examples) to state that app.locals is a Javascript Object.

It fixes visionmedia/expressjs.com#136
