### PR TITLE
Old references to formerly bundled middleware

### DIFF
--- a/4x/en/api/res-cookie.jade
+++ b/4x/en/api/res-cookie.jade
@@ -27,7 +27,7 @@ section
   p.
     Signed cookies are also supported through this method. Simply
     pass the <code>signed</code> option. When given <code>res.cookie()</code>
-    will use the secret passed to <code>express.cookieParser(secret)</code>
+    will use the secret passed to <code>cookieParser(secret)</code>
     to sign the value.
 
   +js.

--- a/4x/en/api/router-use.jade
+++ b/4x/en/api/router-use.jade
@@ -44,10 +44,12 @@ section
   p.
     The order of which middleware are "defined" using <code>router.use()</code> is
     very important, they are invoked sequentially, thus this defines middleware
-    precedence. For example usually <code>express.logger()</code> is the very
+    precedence. For example usually a logger is the very
     first middleware you would use, logging every request:
 
   +js.
+    var logger = require('morgan');
+
     router.use(logger());
     router.use(express.static(__dirname + '/public'));
     router.use(function(req, res){

--- a/en/guide/error-handling.jade
+++ b/en/guide/error-handling.jade
@@ -17,8 +17,11 @@ section
     very last, below any other <code>app.use()</code> calls as shown here:
 
   +js.
-    app.use(express.bodyParser());
-    app.use(express.methodOverride());
+    var bodyParser = require('body-parser');
+    var methodOverride = require('method-override');
+
+    app.use(bodyParser());
+    app.use(methodOverride());
     app.use(app.router);
     app.use(function(err, req, res, next){
       // logic
@@ -36,8 +39,11 @@ section
     for requests made via XHR, and those without, you might do:
 
   +js.
-    app.use(express.bodyParser());
-    app.use(express.methodOverride());
+    var bodyParser = require('body-parser');
+    var methodOverride = require('method-override');
+
+    app.use(bodyParser());
+    app.use(methodOverride());
     app.use(app.router);
     app.use(logErrors);
     app.use(clientErrorHandler);


### PR DESCRIPTION
Cleaning up a few references to `express.bodyParser`, `express.methodOverride`, and `express.cookieParser`.
