### PR TITLE
added documentation for the `x-powered-by` setting

### DIFF
--- a/4x/en/api/app-settings.jade
+++ b/4x/en/api/app-settings.jade
@@ -22,7 +22,7 @@ section
       | Enable case sensitivity, disabled by default, treating "/Foo" and "/foo" as the same
     li
       code strict routing 
-      | Enable strict routing, by default "/foo" and "/foo/" are treated the same by the router 
+      | Enable strict routing, by default "/foo" and "/foo/" are treated the same by the router
     li
       code view cache 
       | Enables view template compilation caching, enabled in production by default
@@ -32,4 +32,7 @@ section
     li
       code views 
       | The view directory path, defaulting to "process.cwd() + '/views'"
+    li
+      code x-powered-by 
+      | Enables the <code>X-Powered-By: Express</code> HTTP header, enabled by default
     


### PR DESCRIPTION
I'm not the only one who was searching for this and the express website doesn't mention it at all.
