### PR TITLE
Fixes grammar mistake

### DIFF
--- a/3x/en/api/app-configure.jade
+++ b/3x/en/api/app-configure.jade
@@ -3,7 +3,7 @@ section
 
   p.
     Conditionally invoke <code>callback</code> when <code>env</code> matches <code>app.get('env')</code>,
-    aka <code>process.env.NODE_ENV</code>. This method remains for legacy reason, and is effectively
+    aka <code>process.env.NODE_ENV</code>. This method remains for legacy reasons, and is effectively
     an <code>if</code> statement as illustrated in the following snippets. These functions are <em>not</em>
     required in order to use <code>app.set()</code> and other configuration methods.
 


### PR DESCRIPTION
There is a minor grammar mistake in the app.configure method in the 3.x documentation. "This method remains for legacy reason" should be corrected to "This method remains for legacy reasons".
