### PR TITLE
Remove extra ']'

### DIFF
--- a/4x/en/api/res-sendfile.jade
+++ b/4x/en/api/res-sendfile.jade
@@ -1,5 +1,5 @@
 section
-  h3(id='res.sendfile') res.sendfile(path, [options], [fn]])
+  h3(id='res.sendfile') res.sendfile(path, [options], [fn])
 
   p Transfer the file at the given <code>path</code>.
 


### PR DESCRIPTION
There were two closing square brackets in the header for res.sendfile.
