### PR TITLE
Clarify modification of req.params

### DIFF
--- a/4x/en/api/app-param.jade
+++ b/4x/en/api/app-param.jade
@@ -29,7 +29,7 @@ section
     });
 
   p.
-    The <code>req.param</code> object is generally not safely writable. Only keys which are original to the object can be modified.
+    The <code>req.params</code> object is generally not safely writable. Only keys which are original to the object can be modified.
   
   +js.
     app.param('user', function(req, res, next, id){

--- a/4x/en/api/app-param.jade
+++ b/4x/en/api/app-param.jade
@@ -29,6 +29,27 @@ section
     });
 
   p.
+    The <code>req.param</code> object is generally not safely writable. Only keys which are original to the object can be modified.
+  
+  +js.
+    app.param('user', function(req, res, next, id){
+      User.find(id, function(err, user){
+        //...
+        
+        //This is preferred
+        req.userParameter = user;
+        
+        //This should work as expected
+        req.params.user = user;
+        
+        //DO NOT USE - This will not be reliably available in routes
+        req.params.currentUser = user;
+        
+        //...
+      });
+    });
+
+  p.
     Alternatively you may pass only a <code>callback</code>, in which
     case you have the opportunity to alter the <code>app.param()</code> API.
     For example the <a href="http://github.com/visionmedia/express-params">express-params</a>


### PR DESCRIPTION
This clarifies the usage of req.params, including an anti-pattern example that will cause unexpected behavior.
