### PR TITLE
Update app settings doc to include subdomain offset option

### DIFF
--- a/4x/en/api/app-settings.jade
+++ b/4x/en/api/app-settings.jade
@@ -12,6 +12,9 @@ section
       code trust proxy 
       | Enables reverse proxy support, disabled by default
     li
+      code subdomain offset
+      | The number of dot-separated parts of the host to remove to access subdomain, two by default
+    li
       code jsonp callback name 
       | Changes the default callback name of <code>?callback=</code>
     li


### PR DESCRIPTION
The `subdomain offset` option is useful, especially during dev when you have host like `en-us.localhost:5200`.
