### PR TITLE
module installation command fixed

### DIFF
--- a/migrating-4.html
+++ b/migrating-4.html
@@ -20,7 +20,7 @@ Express versioning and releases are not affected by updates in the
 dependent middleware. 
 </p><p>With the built-in middleware gone, you must explicitly add all the
 middleware required to run your app.  Simply follow these steps:
-</p><ol><li>Install the module: <code>npm install -save <module-name></code></li><li>In your app, require the module: <code>require('module-name');</code></li><li>Use the module according to its documentation: <code>app.use( ... );</code></li></ol><p>The following table lists Express 3 middleware and their counterparts in
+</p><ol><li>Install the module: <code>npm install --save &lt;module-name></code></li><li>In your app, require the module: <code>require('module-name');</code></li><li>Use the module according to its documentation: <code>app.use( ... );</code></li></ol><p>The following table lists Express 3 middleware and their counterparts in
 Express 4.
 </p><table class="doctable" style="width: 400px;" border="1">
 <tr><th>Express 3</th><th>Express 4</th></tr>


### PR DESCRIPTION
`--save` was missing one `-`, and `<module-name>` was being interpreted as literal HTML and not showing up on the page.
