### PR TITLE
add missing close quote in migration guide code snippet

### DIFF
--- a/en/migrating-4.jade
+++ b/en/migrating-4.jade
@@ -161,7 +161,7 @@ section
         res.send('Add a book');
       })
       .put(function(req, res) {
-        res.send('Update the book);
+        res.send('Update the book');
       })
   
   h5(id='express-router') express.Router class


### PR DESCRIPTION
FYI this file also has a bunch of trailing whitespace you might want to remove.
