### PR TITLE
Fix minor typo (qs written as qp)

### DIFF
--- a/4x/en/api/app-settings.md
+++ b/4x/en/api/app-settings.md
@@ -61,7 +61,7 @@ Express application settings can be set using [`app.set()`](#app.set), and retri
 * `view cache` Enables view template compilation caching, enabled in production by default.
 * `view engine` The default engine extension to use when omitted.
 * `views` The view directory path, defaulting to `"process.cwd() + '/views'"`.
-* `query parser` The query parser to use - "simple" or "extended", defaults to "extended". The simple query parser is based on node's native query parser, [querystring](http://nodejs.org/api/querystring.html). The extended query parser is based on [qp](https://www.npmjs.org/package/qs).
+* `query parser` The query parser to use - "simple" or "extended", defaults to "extended". The simple query parser is based on node's native query parser, [querystring](http://nodejs.org/api/querystring.html). The extended query parser is based on [qs](https://www.npmjs.org/package/qs).
 * `x-powered-by` Enables the "X-Powered-By: Express" HTTP header, enabled by default.
 * `etag` Set the ETag response header.
   <table class="doctable" border="1">


### PR DESCRIPTION
Fixes a minor typo in the docs for query parser that refers to the qs package as qp.
