### PR TITLE
Fixed a lapse in style convention

### DIFF
--- a/api.html
+++ b/api.html
@@ -2,7 +2,7 @@
 <pre><code class="lang-js">var express = require(&#39;express&#39;);
 var app = express();
 
-app.get(&#39;/&#39;, function(req, res){
+app.get(&#39;/&#39;, function(req, res) {
   res.send(&#39;hello world&#39;);
 });
 


### PR DESCRIPTION
Hey, just noticed that you all typically had white spaces between the closing parentheses and the opening curly braces in functions, but that wasn't the case in the example for express() in the api.

Express rocks! :smile_cat: 
