### PR TITLE
remove duplicate app.use example

### DIFF
--- a/4x/api.html
+++ b/4x/api.html
@@ -189,11 +189,6 @@ app.use(&#39;/abc?d&#39;, function (req, res, next) {
   next();
 })
 
-// will match paths starting with /abcd and /abd
-app.use(&#39;/abc?d&#39;, function (req, res, next) {
-  next();
-})
-
 // will match paths starting with /abcd, /abbcd, /abbbbbcd and so on
 app.use(&#39;/ab+cd&#39;, function (req, res, next) {
   next();

--- a/4x/en/api/app-use.md
+++ b/4x/en/api/app-use.md
@@ -55,11 +55,6 @@ app.use('/abc?d', function (req, res, next) {
   next();
 })
 
-// will match paths starting with /abcd and /abd
-app.use('/abc?d', function (req, res, next) {
-  next();
-})
-
 // will match paths starting with /abcd, /abbcd, /abbbbbcd and so on
 app.use('/ab+cd', function (req, res, next) {
   next();

--- a/api.html
+++ b/api.html
@@ -189,11 +189,6 @@ app.use(&#39;/abc?d&#39;, function (req, res, next) {
   next();
 })
 
-// will match paths starting with /abcd and /abd
-app.use(&#39;/abc?d&#39;, function (req, res, next) {
-  next();
-})
-
 // will match paths starting with /abcd, /abbcd, /abbbbbcd and so on
 app.use(&#39;/ab+cd&#39;, function (req, res, next) {
   next();


### PR DESCRIPTION
It looks like the first app.use() "Path Pattern" example was duplicated. This PR just removes the duplicate.
