### PR TITLE
Add Windows instructions. Fixes #243

### DIFF
--- a/starter/generator.md
+++ b/starter/generator.md
@@ -56,6 +56,8 @@ $ express myapp
 
    run the app:
      $ DEBUG=myapp ./bin/www
+   run the app (Windows):
+     $ set DEBUG=myapp & node .\bin\www
 ```
 
 The generated app directory structure looks like the following.


### PR DESCRIPTION
Based on question/answer/discussions over at http://stackoverflow.com/questions/26380025/nodejs-express-app-dont-start-in-windows
