### PR TITLE
Fixes Issue #250

### DIFF
--- a/4x/api.jade
+++ b/4x/api.jade
@@ -15,22 +15,27 @@ html
       #api-doc
 
         h1 4.x API
-        h2(id='application') Application
+        h2 Application
+        a(id='application')
         section
           h3(id='express') express()
           include:md ./en/api/express.md
         include ./en/api/app
 
-        h2(id='request') Request
+        h2 Request
+        a(id='request')
         include ./en/api/req
 
-        h2(id='response') Response
+        h2 Response
+        a(id='response')
         include ./en/api/res
 
-        h2(id='router') Router
+        h2 Router
+        a(id='router')
         include ./en/api/router
 
-        h2(id='middleware') Middleware
+        h2 Middleware
+        a(id='middleware')
         include ./en/api/middleware
 
     include ../includes/footer


### PR DESCRIPTION
There was an inconsistent structure between the 3.x documentation and the 4.x documentation on the `api.jade` page. This caused the side menu to show the incorrect side menu section when clicking on a sidebar section link.
