### PR TITLE
Update using-middleware.md

### DIFF
--- a/guide/using-middleware.md
+++ b/guide/using-middleware.md
@@ -163,7 +163,7 @@ var app = express();
 var cookieParser = require('cookie-parser');
 
 // load the cookie parsing middleware
-app.use(cookieParser);
+app.use(cookieParser());
 ```
 
 See [Third-party middleware](../resources/middleware.html) for a partial list of third-party middleware commonly used with Express.


### PR DESCRIPTION
Missing parenthesis => app.use(cookieParser);
I think it should be app.use(cookieParser());
