### PR TITLE
Clarification that cookieParser and CookieParser(secret) are actually required

### DIFF
--- a/3x/en/api/req-cookies.jade
+++ b/3x/en/api/req-cookies.jade
@@ -2,9 +2,9 @@ section
   h3(id='req.cookies') req.cookies
 
   p.
-    When the <code>cookieParser()</code> middleware is used this object
-    defaults to <code>{}</code>, otherwise contains the cookies sent by
-    the user-agent.
+    This object requires the <code>cookieParser()</code> middleware for use.
+    It contains cookies sent by the user-agent. If no cookies are sent, it 
+    defaults to <code>{}</code>.
 
   +js.
     // Cookie: name=tj

--- a/3x/en/api/req-signedCookies.jade
+++ b/3x/en/api/req-signedCookies.jade
@@ -2,13 +2,13 @@ section
   h3(id='req.signedCookies') req.signedCookies
 
   p.
-    When the <code>cookieParser(secret)</code> middleware is used this object
-    defaults to <code>{}</code>, otherwise contains the signed cookies sent by
-    the user-agent, unsigned and ready for use. Signed cookies reside in a different
-    object to show developer intent, otherwise a malicious attack could be
-    placed on `req.cookie` values which are easy to spoof. Note that signing
-    a cookie does not mean it is "hidden" nor encrypted, this simply prevents
-    tampering as the secret used to sign is private.
+    This object requires the <code>cookieParser(secret)</code> middleware for use. 
+    It contains signed cookies sent by the user-agent, unsigned and ready for use. 
+    Signed cookies reside in a different object to show developer intent; otherwise, 
+    a malicious attack could be placed on `req.cookie` values (which are easy to spoof). 
+    Note that signing a cookie does not make it "hidden" or encrypted; this simply 
+    prevents tampering (because the secret used to sign is private). If no signed 
+    cookies are sent, it defaults to <code>{}</code>.
 
   +js.
     // Cookie: user=tobi.CP7AWaXDfAKIRfH49dQzKJx7sKzzSoPq7/AcBBRVwlI3

--- a/4x/en/api/req-cookies.md
+++ b/4x/en/api/req-cookies.md
@@ -1,4 +1,4 @@
-When the `cookieParser()` middleware is used, this object defaults to `{}`. Otherwise, it contains the cookies sent by the user-agent.
+This object requires the `cookieParser()` middleware for use. It contains cookies sent by the user-agent. If no cookies are sent, it defaults to `{}`.
 
 ```js
 // Cookie: name=tj

--- a/4x/en/api/req-signedCookies.md
+++ b/4x/en/api/req-signedCookies.md
@@ -1,4 +1,4 @@
-When the `cookieParser(secret)` middleware is used, this object defaults to `{}`. Otherwise, it contains the signed cookies sent by the user-agent, unsigned and ready for use. Signed cookies reside in a different object to show developer intent; otherwise, a malicious attack could be placed on `req.cookie` values (which are easy to spoof). Note that signing a cookie does not make it "hidden" or encrypted; this simply prevents tampering (because the secret used to sign is private).
+This object requires the `cookieParser(secret)` middleware for use. It contains signed cookies sent by the user-agent, unsigned and ready for use. Signed cookies reside in a different object to show developer intent; otherwise, a malicious attack could be placed on `req.cookie` values (which are easy to spoof). Note that signing a cookie does not make it "hidden" or encrypted; this simply prevents tampering (because the secret used to sign is private). If no signed cookies are sent, it defaults to `{}`.
 
 ```js
 // Cookie: user=tobi.CP7AWaXDfAKIRfH49dQzKJx7sKzzSoPq7/AcBBRVwlI3


### PR DESCRIPTION
I and a few other folks over at https://github.com/strongloop/express/issues/1859 expressed our concern about the documentation for cookieParser() and cookieParser(secret) not making sense. As it currently reads, it implies that when cookieParser() _isn't_ used, that's when you get cookie information, whereas the opposite is actually true. 

I hope you like our proposed solution.
