### PR TITLE
Fix typo in api.html

### DIFF
--- a/api.html
+++ b/api.html
@@ -327,7 +327,7 @@ app.use(mw1, [mw2, r1, r2], subApp);
 </table>
 
 <p>Following are some examples of using the <a href="#express.static">express.static</a> middleware in an Express app.</p>
-<p>Serve static content for the apfrom the &quot;public&quot; directory in the application directory.</p>
+<p>Serve static content for the app from the &quot;public&quot; directory in the application directory.</p>
 <pre><code class="lang-js">// GET /style.css etc
 app.use(express.static(__dirname + &#39;/public&#39;));
 </code></pre>


### PR DESCRIPTION
changes line 330 from:

<p>Serve static content for the apfrom the &quot;public&quot; directory in the application directory.</p>


to:

<p>Serve static content for the app from the &quot;public&quot; directory in the application directory.</p>
