### PR TITLE
Fix typo in app-use.md

### DIFF
--- a/4x/en/api/app-use.md
+++ b/4x/en/api/app-use.md
@@ -195,7 +195,7 @@ app.use(mw1, [mw2, r1, r2], subApp);
 
 Following are some examples of using the [express.static](#express.static) middleware in an Express app.
 
-Serve static content for the apfrom the "public" directory in the application directory.
+Serve static content for the app from the "public" directory in the application directory.
 
 ```js
 // GET /style.css etc


### PR DESCRIPTION
changes line 198

from:
Serve static content for the apfrom the "public" directory in the application directory.

to:
Serve static content for the app from the "public" directory in the application directory.
