### PR TITLE
Update router-Router documentation

### DIFF
--- a/4x/en/api/router-Router.md
+++ b/4x/en/api/router-Router.md
@@ -12,7 +12,7 @@ Options is an optional object to alter the behavior of the router.
 
 * `caseSensitive` Enable case sensitivity, disabled by default, treating "/Foo" and "/foo" as the same
 * `strict`  Enable strict routing, by default "/foo" and "/foo/" are treated the same by the router
-* `mergeParams` Ensure the `req.params` values from the parent router are preserved. If the parent and the child have conflicting param names, the child's value take precedence. Defaults to `false`.
+* `mergeParams` *Since Express.js v4.5.0.* Ensure the `req.params` values from the parent router are preserved. If the parent and the child have conflicting param names, the child's value take precedence. Defaults to `false`.
 
 The router can have middleware and http VERB routes added just like an application.
 


### PR DESCRIPTION
After trying to work out for 30 minutes why my parameters defined in middleware were not being carried over, I eventually found a thread on GitHub that indicated the parameter only existed since `4.5.0` (strongloop/express#2257). As I was using `4.2.0`, this parameter didn't work for me and it would quietly fail.

This fix changes the documentation for the `mergeParams` parameter to clearly indicate that it has only existed since `4.5.0`.

Submitting as a markdown-only GitHub edit rather than a regular pull request, because of local build issues (#297).
