### PR TITLE
fix gross font-weight flickering issue in Safari

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -516,6 +516,7 @@ footer {
   color: #666;
   margin: 0 5px;
   padding-right: 15px;
+  -webkit-font-smoothing: subpixel-antialiased;
 }
 
 #navbar a.active {


### PR DESCRIPTION
`#navbar` links need to specify `subpixel-antialiased` to render consistently across all browsers
