### PR TITLE
Grammar Changes to the Docs

### DIFF
--- a/guide/using-middleware.html
+++ b/guide/using-middleware.html
@@ -9,7 +9,7 @@
 </ul>
 <p>If the current middleware does not end the request-response cycle, it must call <code>next()</code> to pass control to the next middleware, otherwise the request will be left hanging.</p>
 <p>With an optional mount path, middleware can be loaded at the application level or at the router level.
-Also, a series of middleware functions can be loaded together, creating a sub-stack of middleware system at a mount point.</p>
+Also, a series of middleware functions can be loaded together, creating a sub-stack of the middleware system at a mount point.</p>
 <p>An Express application can use the following kinds of middleware:</p>
 <ul>
 <li><a href="#middleware.application">Application-level middleware</a></li>
@@ -134,7 +134,7 @@ app.use(&#39;/&#39;, router);
 <p>The <code>root</code> argument refers to the root directory from which the static assets are to be served.</p>
 <p>The optional <code>options</code> object can have the following properties.</p>
 <ul>
-<li><code>dotfiles</code> option for serving dotfiles. Possible values are &quot;allow&quot;, &quot;deny&quot;, &quot;ignore&quot;; defaults to &quot;ignore&quot;.</li>
+<li><code>dotfiles</code> option for serving dotfiles. Possible values are &quot;allow&quot;, &quot;deny&quot;, and &quot;ignore&quot;; defaults to &quot;ignore&quot;.</li>
 <li><code>etag</code> enable or disable etag generation, defaults to <code>true</code>.</li>
 <li><code>extensions</code> sets file extension fallbacks, defaults to <code>false</code>.</li>
 <li><code>index</code> sends directory index file, defaults to &quot;index.html&quot;. Set <code>false</code> to disable directory indexing.</li>

--- a/guide/using-middleware.md
+++ b/guide/using-middleware.md
@@ -11,7 +11,7 @@ Middleware is a function with access to the request object (`req`), the response
 If the current middleware does not end the request-response cycle, it must call `next()` to pass control to the next middleware, otherwise the request will be left hanging.
 
 With an optional mount path, middleware can be loaded at the application level or at the router level.
-Also, a series of middleware functions can be loaded together, creating a sub-stack of middleware system at a mount point.
+Also, a series of middleware functions can be loaded together, creating a sub-stack of the middleware system at a mount point.
 
 An Express application can use the following kinds of middleware:
  - [Application-level middleware](#middleware.application)
@@ -157,7 +157,7 @@ The `root` argument refers to the root directory from which the static assets ar
 
 The optional `options` object can have the following properties.
 
-* `dotfiles` option for serving dotfiles. Possible values are "allow", "deny", "ignore"; defaults to "ignore".
+* `dotfiles` option for serving dotfiles. Possible values are "allow", "deny", and "ignore"; defaults to "ignore".
 * `etag` enable or disable etag generation, defaults to `true`.
 * `extensions` sets file extension fallbacks, defaults to `false`.
 * `index` sends directory index file, defaults to "index.html". Set `false` to disable directory indexing.


### PR DESCRIPTION
Hopefully this will improve the readability of the doc :)

Change on line 12; added a "the" to reference "middleware system".
Change on line 137; added an "and" after the penultimate value in the list.
