### PR TITLE
Update error-handling.md for v4

### DIFF
--- a/guide/error-handling.md
+++ b/guide/error-handling.md
@@ -11,7 +11,7 @@ app.use(function(err, req, res, next){
 });
 ```
 
-Though not strictly required, by convention you define error-handling middleware last, after other `app.use()` calls;
+You define error-handling middleware last, after other `app.use()` and routes calls;
 For example:
 
 ```js


### PR DESCRIPTION
Error-handling middleware for v4 should be placed after all app.use and routes calls.

Should we make this part of the doc more explicit ?
