### PR TITLE
Clarifying template documentation

### DIFF
--- a/advanced/developing-template-engines.md
+++ b/advanced/developing-template-engines.md
@@ -15,7 +15,7 @@ The following is an example of implementing a very simple template engine for re
 var fs = require('fs'); // this engine requires the fs module
 app.engine('ntl', function (filePath, options, callback) { // define the template engine
   fs.readFile(filePath, function (err, content) {
-    if (err) throw new Error(err);
+    if (err) return callback(new Error(err));
     // this is an extremely simple template engine
     var rendered = content.toString().replace('#title#', '<title>'+ options.title +'</title>')
     .replace('#message#', '<h1>'+ options.message +'</h1>');


### PR DESCRIPTION
In the "developing template engines" example, adjusting code to return template errors to the callback. This clarifies the first argument is used for errors (which is standard notation, but non-obvious in the example).
