### PR TITLE
Fix for clicking section header in API shows correct sub-sections

### DIFF
--- a/4x/api.md
+++ b/4x/api.md
@@ -11,13 +11,13 @@ lang: en
   <a id='express' class='h2'></a>
   {% include api/{{ page.lang }}/4x/express.md %}
 
-  <a id='application' class='h2'></a>
+  <a id='app' class='h2'></a>
   {% include api/{{ page.lang }}/4x/app.md %}
 
-  <a id='request' class='h2'></a>
+  <a id='req' class='h2'></a>
   {% include api/{{ page.lang }}/4x/req.md %}
 
-  <a id='response' class='h2'></a>
+  <a id='res' class='h2'></a>
   {% include api/{{ page.lang }}/4x/res.md %}
 
   <a id='router' class='h2'></a>

--- a/_includes/api/en/4x/menu.md
+++ b/_includes/api/en/4x/menu.md
@@ -1,6 +1,6 @@
 <ul id="menu">
     <li><a href="#express">express()</a></li>
-    <li id="app-api"><a href="#application">Application</a>
+    <li id="app-api"><a href="#app">Application</a>
         <ul id="app-menu">
             <li><em>Properties</em>
             </li>
@@ -54,7 +54,7 @@
             </li>
         </ul>
     </li>
-    <li id="req-api"><a href="#request">Request</a>
+    <li id="req-api"><a href="#req">Request</a>
         <ul id="req-menu">
             <li><em>Properties</em>
             </li>
@@ -114,7 +114,7 @@
             </li>
         </ul>
     </li>
-    <li id="res-api"><a href="#response">Response</a>
+    <li id="res-api"><a href="#res">Response</a>
         <ul id="res-menu">
             <li><em>Properties</em>
             </li>

--- a/css/style.css
+++ b/css/style.css
@@ -654,7 +654,7 @@ footer {
 #menu {
   position: fixed;
   margin: 0;
-  padding: 0;
+  padding: 0 10px 0 0;
   top: 90px;
   right: 30px;
   height: 500px;
@@ -674,7 +674,6 @@ footer {
 
 #menu ul {
   height: 0;
-  overflow-y: hidden;
   overflow: hidden;
 }
 
@@ -965,4 +964,3 @@ footer {
   }
 
 }
-

--- a/css/style.css
+++ b/css/style.css
@@ -660,6 +660,7 @@ footer {
   height: 500px;
   text-align: right;
   font-size: 13px;
+  overflow-y: auto;
 }
 
 #menu em {
@@ -674,6 +675,7 @@ footer {
 #menu ul {
   height: 0;
   overflow-y: hidden;
+  overflow: hidden;
 }
 
 #menu ul.active {

--- a/js/app.js
+++ b/js/app.js
@@ -66,7 +66,7 @@ $(function(){
   var prev;
   var n = 0;
 
-  var headings = $('h3').map(function(i, el){
+  var headings = $('.h2, h3').map(function(i, el){
     return {
       top: $(el).offset().top - 100,
       id: el.id

--- a/js/app.js
+++ b/js/app.js
@@ -5,7 +5,7 @@ $(function(){
 
   // top link
   $('#top').click(function(e){
-    $('html, body').animate({scrollTop : 0}, 200);
+    $('html, body').animate({scrollTop : 0}, 500);
     return false;
   });
 

--- a/js/app.js
+++ b/js/app.js
@@ -87,6 +87,12 @@ $(function(){
   var parentMenuSelector;
   var lastApiPrefix;
 
+  $(window).bind('load resize', function() {
+
+    $('#menu').css('height', ($(this).height() - 150) + 'px');
+
+  });
+
   $(document).scroll(function() {
 
     var h = closest();


### PR DESCRIPTION
Currently if you visit http://expressjs.com/4x/api.html and click the "Request" menu item it expands the "Application" section since the last item in "Application" is `closest()` to the one you clicked. Same goes for other sections as well.

I unified all the IDs and included the `.h2` anchors in the list of headings so it can find the correct closest one.
