### PR TITLE
(cleanup) Update error-handling.md

### DIFF
--- a/guide/error-handling.md
+++ b/guide/error-handling.md
@@ -18,7 +18,7 @@ app.use(function(err, req, res, next) {
 });
 ~~~
 
-You define error-handling middleware last, after other `app.use()` and routes calls;
+You define error-handling middleware last, after other `app.use()` and routes calls.
 For example:
 
 ~~~js

--- a/guide/error-handling.md
+++ b/guide/error-handling.md
@@ -18,8 +18,7 @@ app.use(function(err, req, res, next) {
 });
 ~~~
 
-You define error-handling middleware last, after other `app.use()` and routes calls.
-For example:
+You define error-handling middleware last, after other `app.use()` and routes calls; for example:
 
 ~~~js
 var bodyParser = require('body-parser');


### PR DESCRIPTION
Minor grammar change from a semi-colon to a period (after the word 'calls').
Now = 'You define error-handling middleware last, after other `app.use()` and routes calls. For example:'
Was = 'You define error-handling middleware last, after other `app.use()` and routes calls; For example:'
