### PR TITLE
Update faq.md

### DIFF
--- a/starter/faq.md
+++ b/starter/faq.md
@@ -60,7 +60,7 @@ to handle a 404:
 
 ~~~js
 app.use(function(req, res, next) {
-  res.send(404, 'Sorry cant find that!');
+  res.status(404).send('Sorry cant find that!');
 });
 ~~~
 
@@ -72,7 +72,7 @@ except with four arguments instead of three; specifically with the signature `(e
 ~~~js
 app.use(function(err, req, res, next) {
   console.error(err.stack);
-  res.send(500, 'Something broke!');
+  res.status(500).send('Something broke!');
 });
 ~~~
 


### PR DESCRIPTION
Use `request.status(status).send(msg)` instead of `request.send(status, msg)` in FAQ.

I copied the code from the FAQ and got the warning:

> express deprecated res.send(status, body): Use res.status(status).send(body) instead
