### PR TITLE
Updating routing guide for route tester

### DIFF
--- a/guide/routing.md
+++ b/guide/routing.md
@@ -65,7 +65,7 @@ app.all('/secret', function (req, res, next) {
 Route paths, in combination with a request method, define the endpoints at which requests can be made to. They can be strings, string patterns, or regular expressions.
 
 <div class="doc-box doc-info" markdown="1">
-  Express uses [path-to-regexp](https://www.npmjs.com/package/path-to-regexp) for matching the route paths; see its documentation for all the possibilities in defining route paths. [Express Route Tester](http://forbeslindesay.github.io/express-route-tester/) is a handy tool for testing Express routes.
+  Express uses [path-to-regexp](https://www.npmjs.com/package/path-to-regexp) for matching the route paths; see its documentation for all the possibilities in defining route paths. [Express Route Tester](http://forbeslindesay.github.io/express-route-tester/) is a handy tool for testing basic Express routes, although it does not support pattern matching.
 </div>
 
 <div class="doc-box doc-warn" markdown="1">


### PR DESCRIPTION
In the linked route testing tool, routes like `/content/*` do not correctly translate to `(.*)` style regular expressions. Instead the wildcard character is escaped and it performs a literal match.
