### PR TITLE
Fix code error in routing.md

### DIFF
--- a/guide/routing.md
+++ b/guide/routing.md
@@ -228,10 +228,10 @@ Here is an example of chained route handlers defined using `app.route()`.
 app.route('/book')
   .get(function(req, res) {
     res.send('Get a random book');
-  });
+  })
   .post(function(req, res) {
     res.send('Add a book');
-  });
+  })
   .put(function(req, res) {
     res.send('Update the book');
   });


### PR DESCRIPTION
Handlers should be chained, so semicolons are removed.
