### PR TITLE
Remove rogue semicolons from app.route book example

### DIFF
--- a/guide/migrating-4.md
+++ b/guide/migrating-4.md
@@ -134,10 +134,10 @@ Here is an example of chained route handlers defined using `app.route()`.
 app.route('/book')
   .get(function(req, res) {
     res.send('Get a random book');
-  });
+  })
   .post(function(req, res) {
     res.send('Add a book');
-  });
+  })
   .put(function(req, res) {
     res.send('Update the book');
   });

--- a/guide/routing.md
+++ b/guide/routing.md
@@ -228,10 +228,10 @@ Here is an example of chained route handlers defined using `app.route()`.
 app.route('/book')
   .get(function(req, res) {
     res.send('Get a random book');
-  });
+  })
   .post(function(req, res) {
     res.send('Add a book');
-  });
+  })
   .put(function(req, res) {
     res.send('Update the book');
   });


### PR DESCRIPTION
Fixed syntax error in chained routing book example caused by additional semicolons added in change #362. Thanks to @dougwilson for spotting it.
