### PR TITLE
Change req.accepts() examples using csv-string into string arrays

### DIFF
--- a/_includes/api/en/4x/req-accepts.md
+++ b/_includes/api/en/4x/req-accepts.md
@@ -18,7 +18,7 @@ req.accepts('html');
 // => "html"
 req.accepts('text/html');
 // => "text/html"
-req.accepts('json, text');
+req.accepts(['json', 'text']);
 // => "json"
 req.accepts('application/json');
 // => "application/json"
@@ -30,7 +30,6 @@ req.accepts('png');
 
 // Accept: text/*;q=.5, application/json
 req.accepts(['html', 'json']);
-req.accepts('html, json');
 // => "json"
 ~~~
 


### PR DESCRIPTION
See [4.x req.accepts() docs wrong - csv-string unsupported after switch to accepts module](https://github.com/strongloop/express/issues/2673).
