### PR TITLE
Remove clickjacking

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -194,12 +194,6 @@ $(function(){
 
   })
 
-  // sub menu navigation
-  $('.dropit-submenu li').click(function () {
-    var path = $(this).find('a').attr('href')
-    document.location = path
-  })
-
   // i18n notice
   if (readCookie('i18nClose')) {
     $('#i18n-notice-box').hide()


### PR DESCRIPTION
Has anyone tried middle-clicking (or ctrl/cmd-clicking) on the links in the navigation dropdowns? The clicked link opens in a new tab as requested... and also in the current tab, which is very frustrating! This patch removes the offending code.

It's a particularly puzzling bit of code because the `<a>` elements in question are already styled with enough padding that they'll be easily clickable on mobile without this javascript shim.
