### PR TITLE
"node app.js" doesn't do anything by default

### DIFF
--- a/starter/hello-world.md
+++ b/starter/hello-world.md
@@ -37,7 +37,7 @@ The app starts a server and listens on port 3000 for connection. It will respond
 Save the code in a file named `app.js` and run it with the following command.
 
 ~~~ sh
-$ node bin/www  
+$ npm start
 ~~~
 
 Then, load [http://localhost:3000/](http://localhost:3000/) in a browser to see the output.

--- a/starter/hello-world.md
+++ b/starter/hello-world.md
@@ -37,7 +37,7 @@ The app starts a server and listens on port 3000 for connection. It will respond
 Save the code in a file named `app.js` and run it with the following command.
 
 ~~~ sh
-$ node app.js
+$ node start  
 ~~~
 
 Then, load [http://localhost:3000/](http://localhost:3000/) in a browser to see the output.

--- a/starter/hello-world.md
+++ b/starter/hello-world.md
@@ -37,7 +37,7 @@ The app starts a server and listens on port 3000 for connection. It will respond
 Save the code in a file named `app.js` and run it with the following command.
 
 ~~~ sh
-$ node start  
+$ node bin/www  
 ~~~
 
 Then, load [http://localhost:3000/](http://localhost:3000/) in a browser to see the output.


### PR DESCRIPTION
It seems it needs to be `node start` or `node bin/www` as suggested [here](http://stackoverflow.com/questions/23178363/unable-to-run-node-app-js-file).

Way to reproduce it:

```
> express demo
> cd demo
> npm install
> node app.js
```
