### PR TITLE
Adding sass to -css commandline option

### DIFF
--- a/starter/generator.md
+++ b/starter/generator.md
@@ -29,7 +29,7 @@ $ express -h
     -e, --ejs           add ejs engine support (defaults to jade)
         --hbs           add handlebars engine support
     -H, --hogan         add hogan.js engine support
-    -c, --css <engine>  add stylesheet <engine> support (less|stylus|compass) (defaults to plain css)
+    -c, --css <engine>  add stylesheet <engine> support (less|stylus|compass|sass) (defaults to plain css)
     -f, --force         force on non-empty directory
 ~~~
 


### PR DESCRIPTION
I noticed that the `sass` command-line option was missing from the express-generator homepage: http://expressjs.com/starter/generator.html
