### PR TITLE
Change router.param first arg to string not array

### DIFF
--- a/_includes/api/en/4x/router-param.md
+++ b/_includes/api/en/4x/router-param.md
@@ -1,8 +1,6 @@
 <h3 id='router.param'>router.param([name,] callback)</h3>
 
-Add callback triggers to route parameters, where `name` is the name of the parameter or an array of them, and `function` is the callback function. The parameters of the callback function are the request object, the response object, the next middleware, and the value of the parameter, in that order.
-
-If `name` is an array, the `callback` trigger is registered for each parameter declared in it, in the order in which they are declared. Furthermore, for each declared parameter except the last one, a call to `next` inside the callback will call the callback for the next declared parameter. For the last parameter, a call to `next` will call the next middleware in place for the route currently being processed, just like it would if `name` were just a string.
+Add callback triggers to route parameters, where `name` is the name of the parameter and `callback` is the callback function. The parameters of the callback function are the request object, the response object, the next middleware, and the value of the parameter, in that order.  Although `name` is technically optional, using this method without it is deprecated starting with Express v4.11.0 (see below).
 
 For example, when `:user` is present in a route path, you may map user loading logic to automatically provide `req.user` to the route, or perform validations on the parameter input.
 
@@ -53,11 +51,6 @@ and this matches too
 ~~~
 
 ~~~js
-router.param(['id', 'page'], function (req, res, next, value) {
-  console.log('CALLED ONLY ONCE with', value);
-  next();
-})
-
 app.get('/user/:id/:page', function (req, res, next) {
   console.log('although this matches');
   next();
@@ -72,8 +65,6 @@ app.get('/user/:id/:page', function (req, res) {
 On `GET /user/42/3`, the following is printed:
 
 ~~~
-CALLED ONLY ONCE with 42
-CALLED ONLY ONCE with 3
 although this matches
 and this matches too
 ~~~


### PR DESCRIPTION
Per #425.  In https://github.com/strongloop/express/issues/2742#issuecomment-134736492 Doug clearly states that router.param never accepted an array as the first arg.  I don't doubt him, but it seems a bit odd that the docs had as much detail as they did on that and an example...

@hacksparrow  PTAL.
