### PR TITLE
Fix GitHub repository URL when JavaScript disabled

### DIFF
--- a/_includes/footer/footer-en.html
+++ b/_includes/footer/footer-en.html
@@ -25,7 +25,7 @@
             <iframe src="http://ghbtns.com/github-btn.html?user=strongloop&amp;repo=express&amp;type=watch&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe>
         </div>
         <div id="sponsor">The Express project is sponsored by <a href="http://strongloop.com/">StrongLoop</a>. </div>
-        <div id="fork"><a href="https://github.com/strongloop/express?_ga=1.39756451.1408343404.1407943788">Fork the website on GitHub</a>.
+        <div id="fork"><a href="https://github.com/strongloop/expressjs.com">Fork the website on GitHub</a>.
         </div>
         <div>Copyright &copy; StrongLoop, Inc., and other expressjs.com contributors.</div>
     </div>

--- a/_includes/footer/footer-es.html
+++ b/_includes/footer/footer-es.html
@@ -25,7 +25,7 @@
             <iframe src="http://ghbtns.com/github-btn.html?user=strongloop&amp;repo=express&amp;type=watch&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe>
         </div>
         <div id="sponsor">Express es patrocinado por <a href="http://strongloop.com/">StrongLoop</a>.</div>
-        <div id="fork"><a href="https://github.com/strongloop/express?_ga=1.39756451.1408343404.1407943788">Fork del sitio web en GitHub</a></div>
+        <div id="fork"><a href="https://github.com/strongloop/expressjs.com">Fork del sitio web en GitHub</a></div>
         <div id="traductor">Traducido por <a href="https://twitter.com/john1988triana">John F Triana</a></div>
     </div>
 </footer>

--- a/_includes/footer/footer-ja.html
+++ b/_includes/footer/footer-ja.html
@@ -25,7 +25,7 @@
             <iframe src="http://ghbtns.com/github-btn.html?user=strongloop&amp;repo=express&amp;type=watch&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe>
         </div>
         <div id="sponsor">Expressプロジェクトは<a href="http://strongloop.com/">StrongLoop</a>が後援しています。</div>
-        <div id="fork"><a href="https://github.com/strongloop/express?_ga=1.39756451.1408343404.1407943788">GitHubの上のウェブサイトをforkする</a>
+        <div id="fork"><a href="https://github.com/strongloop/expressjs.com">GitHubの上のウェブサイトをforkする</a>
         </div>
     </div>
 </footer>

--- a/_includes/footer/footer-ko.html
+++ b/_includes/footer/footer-ko.html
@@ -25,7 +25,7 @@
             <iframe src="http://ghbtns.com/github-btn.html?user=strongloop&amp;repo=express&amp;type=watch&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe>
         </div>
         <div id="sponsor">Express 프로젝트는 <a href="http://strongloop.com/">StrongLoop</a>의 후원을 받습니다.</div>
-        <div id="fork"><a href="https://github.com/strongloop/express?_ga=1.39756451.1408343404.1407943788">GitHub에서 이 사이트를 Fork하기</a>
+        <div id="fork"><a href="https://github.com/strongloop/expressjs.com">GitHub에서 이 사이트를 Fork하기</a>
         </div>
     </div>
 </footer>

--- a/_includes/footer/footer-pt-br.html
+++ b/_includes/footer/footer-pt-br.html
@@ -25,7 +25,7 @@
             <iframe src="http://ghbtns.com/github-btn.html?user=strongloop&amp;repo=express&amp;type=watch&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe>
         </div>
         <div id="sponsor">O projeto Express é patrocinado pela <a href="http://strongloop.com/">StrongLoop</a>. </div>
-        <div id="fork"><a href="https://github.com/strongloop/express?_ga=1.39756451.1408343404.1407943788">Fork o website em GitHub</a>.
+        <div id="fork"><a href="https://github.com/strongloop/expressjs.com">Fork o website em GitHub</a>.
         </div>
         <div>Copyright &copy; StrongLoop, Inc., e outros expressjs.com contribuidores.</div>
     </div>

--- a/_includes/footer/footer-ru.html
+++ b/_includes/footer/footer-ru.html
@@ -25,7 +25,7 @@
             <iframe src="http://ghbtns.com/github-btn.html?user=strongloop&amp;repo=express&amp;type=watch&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe>
         </div>
         <div id="sponsor">Проект Express спонсируется <a href="http://strongloop.com/">StrongLoop</a>.</div>
-        <div id="fork"><a href="https://github.com/strongloop/express?_ga=1.39756451.1408343404.1407943788">Fork the website on GitHub</a>
+        <div id="fork"><a href="https://github.com/strongloop/expressjs.com">Fork the website on GitHub</a>
         </div>
     </div>
 </footer>

--- a/_includes/footer/footer-zh.html
+++ b/_includes/footer/footer-zh.html
@@ -25,7 +25,7 @@
             <iframe src="http://ghbtns.com/github-btn.html?user=strongloop&amp;repo=express&amp;type=watch&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe>
         </div>
         <div id="sponsor">The Express project is sponsored by <a href="http://strongloop.com/">StrongLoop</a>.</div>
-        <div id="fork"><a href="https://github.com/strongloop/express?_ga=1.39756451.1408343404.1407943788">Fork the website on GitHub</a>
+        <div id="fork"><a href="https://github.com/strongloop/expressjs.com">Fork the website on GitHub</a>
         </div>
     </div>
 </footer>


### PR DESCRIPTION
that is when `./js/app.js` is not run on the client-side and `$('#fork').html(editLink);` is thus not run.
