### PR TITLE
Feat improve trust proxy doc

### DIFF
--- a/_includes/api/en/4x/app-settings.md
+++ b/_includes/api/en/4x/app-settings.md
@@ -147,6 +147,11 @@ If `name` is one of the application settings, it affects the behavior of the app
 
   <h5 id="trust.proxy.options.table">Options for `trust proxy` setting</h5>
 
+  <p markdown="1">
+  Read [Express behind proxies](/guide/behind-proxies.html) for more
+  information.
+  </p>
+
   <table class="doctable" border="1">
     <thead><tr><th>Type</th><th>Value</th></tr></thead>
     <tbody>

--- a/_includes/api/en/4x/req-hostname.md
+++ b/_includes/api/en/4x/req-hostname.md
@@ -1,6 +1,10 @@
 <h3 id='req.hostname'>req.hostname</h3>
 
-Contains the hostname from the "Host" HTTP header.
+Contains the hostname from the `Host` HTTP header.
+
+When the [`trust proxy` setting](/4x/api.html#trust.proxy.options.table) trusts
+the socket address, the value of the `X-Forwarded-Host` header field will be
+trusted and used if present.
 
 ~~~js
 // Host: "example.com:3000"

--- a/_includes/api/en/4x/req-ip.md
+++ b/_includes/api/en/4x/req-ip.md
@@ -2,8 +2,8 @@
 
 The remote IP address of the request.
 
-If the `trust proxy` is setting enabled, it is the upstream address;
-see [Express behind proxies](/guide/behind-proxies.html) for more information.
+When the [`trust proxy` setting](/4x/api.html#trust.proxy.options.table) trusts
+the socket address, it is the upstream address.
 
 ~~~js
 req.ip

--- a/_includes/api/en/4x/req-ips.md
+++ b/_includes/api/en/4x/req-ips.md
@@ -1,9 +1,8 @@
 <h3 id='req.ips'>req.ips</h3>
 
-When the `trust proxy` setting is `true`, this property contains an array of
-IP addresses specified in the "X-Forwarded-For" request header.  Otherwise, it contains an empty array.
+When the [`trust proxy` setting](/4x/api.html#trust.proxy.options.table) trusts
+the socket address, this property contains an array of IP addresses specified in
+the `X-Forwarded-For` request header. Otherwise, it contains an empty array.
 
-For example, if "X-Forwarded-For" is "client, proxy1, proxy2", `req.ips` would be 
-`["client", "proxy1", "proxy2"]`, where "proxy2" is the furthest downstream.
-
-For more information on the `trust proxy` setting, see [app.set](#app.set).
+For example, if `X-Forwarded-For` is `client, proxy1, proxy2`, `req.ips` would be 
+`["client", "proxy1", "proxy2"]`, where `proxy2` is the furthest downstream.

--- a/_includes/api/en/4x/req-protocol.md
+++ b/_includes/api/en/4x/req-protocol.md
@@ -1,6 +1,9 @@
 <h3 id='req.protocol'>req.protocol</h3>
 
-The request protocol string, "http" or "https" when requested with TLS. When the "trust proxy" [setting](/4x/api.html#trust.proxy.options.table) trusts the socket address, the value of the "X-Forwarded-Proto" header ("http" or "https") field will be trusted and used if present.
+The request protocol string, `http` or `https` when requested with TLS. When the
+[`trust proxy` setting](/4x/api.html#trust.proxy.options.table) trusts the
+socket address, the value of the `X-Forwarded-Proto` header (`http` or `https`)
+field will be trusted and used if present.
 
 ~~~js
 req.protocol

--- a/_includes/api/es/4x/app-settings.md
+++ b/_includes/api/es/4x/app-settings.md
@@ -147,6 +147,11 @@ If `name` is one of the application settings, it affects the behavior of the app
 
   <h5 id="trust.proxy.options.table">Options for `trust proxy` setting</h5>
 
+  <p markdown="1">
+  Read [Express behind proxies](/guide/behind-proxies.html) for more
+  information.
+  </p>
+
   <table class="doctable" border="1">
     <thead><tr><th>Type</th><th>Value</th></tr></thead>
     <tbody>

--- a/_includes/api/es/4x/req-hostname.md
+++ b/_includes/api/es/4x/req-hostname.md
@@ -1,6 +1,10 @@
 <h3 id='req.hostname'>req.hostname</h3>
 
-Contains the hostname from the "Host" HTTP header.
+Contains the hostname from the `Host` HTTP header.
+
+When the [`trust proxy` setting](/4x/api.html#trust.proxy.options.table) trusts
+the socket address, the value of the `X-Forwarded-Host` header field will be
+trusted and used if present.
 
 ~~~js
 // Host: "example.com:3000"

--- a/_includes/api/es/4x/req-ip.md
+++ b/_includes/api/es/4x/req-ip.md
@@ -2,8 +2,8 @@
 
 The remote IP address of the request.
 
-If the `trust proxy` is setting enabled, it is the upstream address;
-see [Express behind proxies](/guide/behind-proxies.html) for more information.
+When the [`trust proxy` setting](/4x/api.html#trust.proxy.options.table) trusts
+the socket address, it is the upstream address.
 
 ~~~js
 req.ip

--- a/_includes/api/es/4x/req-ips.md
+++ b/_includes/api/es/4x/req-ips.md
@@ -1,9 +1,8 @@
 <h3 id='req.ips'>req.ips</h3>
 
-When the `trust proxy` setting is `true`, this property contains an array of
-IP addresses specified in the "X-Forwarded-For" request header.  Otherwise, it contains an empty array.
+When the [`trust proxy` setting](/4x/api.html#trust.proxy.options.table) trusts
+the socket address, this property contains an array of IP addresses specified in
+the `X-Forwarded-For` request header. Otherwise, it contains an empty array.
 
-For example, if "X-Forwarded-For" is "client, proxy1, proxy2", `req.ips` would be 
-`["client", "proxy1", "proxy2"]`, where "proxy2" is the furthest downstream.
-
-For more information on the `trust proxy` setting, see [app.set](#app.set).
+For example, if `X-Forwarded-For` is `client, proxy1, proxy2`, `req.ips` would be 
+`["client", "proxy1", "proxy2"]`, where `proxy2` is the furthest downstream.

--- a/_includes/api/es/4x/req-protocol.md
+++ b/_includes/api/es/4x/req-protocol.md
@@ -1,6 +1,9 @@
 <h3 id='req.protocol'>req.protocol</h3>
 
-The request protocol string, "http" or "https" when requested with TLS. When the "trust proxy" [setting](/4x/api.html#trust.proxy.options.table) trusts the socket address, the value of the "X-Forwarded-Proto" header ("http" or "https") field will be trusted and used if present.
+The request protocol string, `http` or `https` when requested with TLS. When the
+[`trust proxy` setting](/4x/api.html#trust.proxy.options.table) trusts the
+socket address, the value of the `X-Forwarded-Proto` header (`http` or `https`)
+field will be trusted and used if present.
 
 ~~~js
 req.protocol

--- a/_includes/api/ja/4x/app-settings.md
+++ b/_includes/api/ja/4x/app-settings.md
@@ -147,6 +147,11 @@ If `name` is one of the application settings, it affects the behavior of the app
 
   <h5 id="trust.proxy.options.table">Options for `trust proxy` setting</h5>
 
+  <p markdown="1">
+  Read [Express behind proxies](/guide/behind-proxies.html) for more
+  information.
+  </p>
+
   <table class="doctable" border="1">
     <thead><tr><th>Type</th><th>Value</th></tr></thead>
     <tbody>

--- a/_includes/api/ja/4x/req-hostname.md
+++ b/_includes/api/ja/4x/req-hostname.md
@@ -1,6 +1,10 @@
 <h3 id='req.hostname'>req.hostname</h3>
 
-Contains the hostname from the "Host" HTTP header.
+Contains the hostname from the `Host` HTTP header.
+
+When the [`trust proxy` setting](/4x/api.html#trust.proxy.options.table) trusts
+the socket address, the value of the `X-Forwarded-Host` header field will be
+trusted and used if present.
 
 ~~~js
 // Host: "example.com:3000"

--- a/_includes/api/ja/4x/req-ip.md
+++ b/_includes/api/ja/4x/req-ip.md
@@ -2,8 +2,8 @@
 
 The remote IP address of the request.
 
-If the `trust proxy` is setting enabled, it is the upstream address;
-see [Express behind proxies](/guide/behind-proxies.html) for more information.
+When the [`trust proxy` setting](/4x/api.html#trust.proxy.options.table) trusts
+the socket address, it is the upstream address.
 
 ~~~js
 req.ip

--- a/_includes/api/ja/4x/req-ips.md
+++ b/_includes/api/ja/4x/req-ips.md
@@ -1,9 +1,8 @@
 <h3 id='req.ips'>req.ips</h3>
 
-When the `trust proxy` setting is `true`, this property contains an array of
-IP addresses specified in the "X-Forwarded-For" request header.  Otherwise, it contains an empty array.
+When the [`trust proxy` setting](/4x/api.html#trust.proxy.options.table) trusts
+the socket address, this property contains an array of IP addresses specified in
+the `X-Forwarded-For` request header. Otherwise, it contains an empty array.
 
-For example, if "X-Forwarded-For" is "client, proxy1, proxy2", `req.ips` would be 
-`["client", "proxy1", "proxy2"]`, where "proxy2" is the furthest downstream.
-
-For more information on the `trust proxy` setting, see [app.set](#app.set).
+For example, if `X-Forwarded-For` is `client, proxy1, proxy2`, `req.ips` would be 
+`["client", "proxy1", "proxy2"]`, where `proxy2` is the furthest downstream.

--- a/_includes/api/ja/4x/req-protocol.md
+++ b/_includes/api/ja/4x/req-protocol.md
@@ -1,6 +1,9 @@
 <h3 id='req.protocol'>req.protocol</h3>
 
-The request protocol string, "http" or "https" when requested with TLS. When the "trust proxy" [setting](/4x/api.html#trust.proxy.options.table) trusts the socket address, the value of the "X-Forwarded-Proto" header ("http" or "https") field will be trusted and used if present.
+The request protocol string, `http` or `https` when requested with TLS. When the
+[`trust proxy` setting](/4x/api.html#trust.proxy.options.table) trusts the
+socket address, the value of the `X-Forwarded-Proto` header (`http` or `https`)
+field will be trusted and used if present.
 
 ~~~js
 req.protocol

--- a/_includes/api/ko/4x/app-settings.md
+++ b/_includes/api/ko/4x/app-settings.md
@@ -147,6 +147,11 @@ If `name` is one of the application settings, it affects the behavior of the app
 
   <h5 id="trust.proxy.options.table">Options for `trust proxy` setting</h5>
 
+  <p markdown="1">
+  Read [Express behind proxies](/guide/behind-proxies.html) for more
+  information.
+  </p>
+
   <table class="doctable" border="1">
     <thead><tr><th>Type</th><th>Value</th></tr></thead>
     <tbody>

--- a/_includes/api/ko/4x/req-hostname.md
+++ b/_includes/api/ko/4x/req-hostname.md
@@ -1,6 +1,10 @@
 <h3 id='req.hostname'>req.hostname</h3>
 
-Contains the hostname from the "Host" HTTP header.
+Contains the hostname from the `Host` HTTP header.
+
+When the [`trust proxy` setting](/4x/api.html#trust.proxy.options.table) trusts
+the socket address, the value of the `X-Forwarded-Host` header field will be
+trusted and used if present.
 
 ~~~js
 // Host: "example.com:3000"

--- a/_includes/api/ko/4x/req-ip.md
+++ b/_includes/api/ko/4x/req-ip.md
@@ -2,8 +2,8 @@
 
 The remote IP address of the request.
 
-If the `trust proxy` is setting enabled, it is the upstream address;
-see [Express behind proxies](/guide/behind-proxies.html) for more information.
+When the [`trust proxy` setting](/4x/api.html#trust.proxy.options.table) trusts
+the socket address, it is the upstream address.
 
 ~~~js
 req.ip

--- a/_includes/api/ko/4x/req-ips.md
+++ b/_includes/api/ko/4x/req-ips.md
@@ -1,9 +1,8 @@
 <h3 id='req.ips'>req.ips</h3>
 
-When the `trust proxy` setting is `true`, this property contains an array of
-IP addresses specified in the "X-Forwarded-For" request header.  Otherwise, it contains an empty array.
+When the [`trust proxy` setting](/4x/api.html#trust.proxy.options.table) trusts
+the socket address, this property contains an array of IP addresses specified in
+the `X-Forwarded-For` request header. Otherwise, it contains an empty array.
 
-For example, if "X-Forwarded-For" is "client, proxy1, proxy2", `req.ips` would be 
-`["client", "proxy1", "proxy2"]`, where "proxy2" is the furthest downstream.
-
-For more information on the `trust proxy` setting, see [app.set](#app.set).
+For example, if `X-Forwarded-For` is `client, proxy1, proxy2`, `req.ips` would be 
+`["client", "proxy1", "proxy2"]`, where `proxy2` is the furthest downstream.

--- a/_includes/api/ko/4x/req-protocol.md
+++ b/_includes/api/ko/4x/req-protocol.md
@@ -1,6 +1,9 @@
 <h3 id='req.protocol'>req.protocol</h3>
 
-The request protocol string, "http" or "https" when requested with TLS. When the "trust proxy" [setting](/4x/api.html#trust.proxy.options.table) trusts the socket address, the value of the "X-Forwarded-Proto" header ("http" or "https") field will be trusted and used if present.
+The request protocol string, `http` or `https` when requested with TLS. When the
+[`trust proxy` setting](/4x/api.html#trust.proxy.options.table) trusts the
+socket address, the value of the `X-Forwarded-Proto` header (`http` or `https`)
+field will be trusted and used if present.
 
 ~~~js
 req.protocol

--- a/_includes/api/pt-br/4x/app-settings.md
+++ b/_includes/api/pt-br/4x/app-settings.md
@@ -147,6 +147,11 @@ If `name` is one of the application settings, it affects the behavior of the app
 
   <h5 id="trust.proxy.options.table">Options for `trust proxy` setting</h5>
 
+  <p markdown="1">
+  Read [Express behind proxies](/guide/behind-proxies.html) for more
+  information.
+  </p>
+
   <table class="doctable" border="1">
     <thead><tr><th>Type</th><th>Value</th></tr></thead>
     <tbody>

--- a/_includes/api/pt-br/4x/req-hostname.md
+++ b/_includes/api/pt-br/4x/req-hostname.md
@@ -1,6 +1,10 @@
 <h3 id='req.hostname'>req.hostname</h3>
 
-Contains the hostname from the "Host" HTTP header.
+Contains the hostname from the `Host` HTTP header.
+
+When the [`trust proxy` setting](/4x/api.html#trust.proxy.options.table) trusts
+the socket address, the value of the `X-Forwarded-Host` header field will be
+trusted and used if present.
 
 ~~~js
 // Host: "example.com:3000"

--- a/_includes/api/pt-br/4x/req-ip.md
+++ b/_includes/api/pt-br/4x/req-ip.md
@@ -2,8 +2,8 @@
 
 The remote IP address of the request.
 
-If the `trust proxy` is setting enabled, it is the upstream address;
-see [Express behind proxies](/guide/behind-proxies.html) for more information.
+When the [`trust proxy` setting](/4x/api.html#trust.proxy.options.table) trusts
+the socket address, it is the upstream address.
 
 ~~~js
 req.ip

--- a/_includes/api/pt-br/4x/req-ips.md
+++ b/_includes/api/pt-br/4x/req-ips.md
@@ -1,9 +1,8 @@
 <h3 id='req.ips'>req.ips</h3>
 
-When the `trust proxy` setting is `true`, this property contains an array of
-IP addresses specified in the "X-Forwarded-For" request header.  Otherwise, it contains an empty array.
+When the [`trust proxy` setting](/4x/api.html#trust.proxy.options.table) trusts
+the socket address, this property contains an array of IP addresses specified in
+the `X-Forwarded-For` request header. Otherwise, it contains an empty array.
 
-For example, if "X-Forwarded-For" is "client, proxy1, proxy2", `req.ips` would be 
-`["client", "proxy1", "proxy2"]`, where "proxy2" is the furthest downstream.
-
-For more information on the `trust proxy` setting, see [app.set](#app.set).
+For example, if `X-Forwarded-For` is `client, proxy1, proxy2`, `req.ips` would be 
+`["client", "proxy1", "proxy2"]`, where `proxy2` is the furthest downstream.

--- a/_includes/api/pt-br/4x/req-protocol.md
+++ b/_includes/api/pt-br/4x/req-protocol.md
@@ -1,6 +1,9 @@
 <h3 id='req.protocol'>req.protocol</h3>
 
-The request protocol string, "http" or "https" when requested with TLS. When the "trust proxy" [setting](/4x/api.html#trust.proxy.options.table) trusts the socket address, the value of the "X-Forwarded-Proto" header ("http" or "https") field will be trusted and used if present.
+The request protocol string, `http` or `https` when requested with TLS. When the
+[`trust proxy` setting](/4x/api.html#trust.proxy.options.table) trusts the
+socket address, the value of the `X-Forwarded-Proto` header (`http` or `https`)
+field will be trusted and used if present.
 
 ~~~js
 req.protocol

--- a/_includes/api/ru/4x/app-settings.md
+++ b/_includes/api/ru/4x/app-settings.md
@@ -147,6 +147,11 @@ If `name` is one of the application settings, it affects the behavior of the app
 
   <h5 id="trust.proxy.options.table">Options for `trust proxy` setting</h5>
 
+  <p markdown="1">
+  Read [Express behind proxies](/guide/behind-proxies.html) for more
+  information.
+  </p>
+
   <table class="doctable" border="1">
     <thead><tr><th>Type</th><th>Value</th></tr></thead>
     <tbody>

--- a/_includes/api/ru/4x/req-hostname.md
+++ b/_includes/api/ru/4x/req-hostname.md
@@ -1,6 +1,10 @@
 <h3 id='req.hostname'>req.hostname</h3>
 
-Contains the hostname from the "Host" HTTP header.
+Contains the hostname from the `Host` HTTP header.
+
+When the [`trust proxy` setting](/4x/api.html#trust.proxy.options.table) trusts
+the socket address, the value of the `X-Forwarded-Host` header field will be
+trusted and used if present.
 
 ~~~js
 // Host: "example.com:3000"

--- a/_includes/api/ru/4x/req-ip.md
+++ b/_includes/api/ru/4x/req-ip.md
@@ -2,8 +2,8 @@
 
 The remote IP address of the request.
 
-If the `trust proxy` is setting enabled, it is the upstream address;
-see [Express behind proxies](/guide/behind-proxies.html) for more information.
+When the [`trust proxy` setting](/4x/api.html#trust.proxy.options.table) trusts
+the socket address, it is the upstream address.
 
 ~~~js
 req.ip

--- a/_includes/api/ru/4x/req-ips.md
+++ b/_includes/api/ru/4x/req-ips.md
@@ -1,9 +1,8 @@
 <h3 id='req.ips'>req.ips</h3>
 
-When the `trust proxy` setting is `true`, this property contains an array of
-IP addresses specified in the "X-Forwarded-For" request header.  Otherwise, it contains an empty array.
+When the [`trust proxy` setting](/4x/api.html#trust.proxy.options.table) trusts
+the socket address, this property contains an array of IP addresses specified in
+the `X-Forwarded-For` request header. Otherwise, it contains an empty array.
 
-For example, if "X-Forwarded-For" is "client, proxy1, proxy2", `req.ips` would be 
-`["client", "proxy1", "proxy2"]`, where "proxy2" is the furthest downstream.
-
-For more information on the `trust proxy` setting, see [app.set](#app.set).
+For example, if `X-Forwarded-For` is `client, proxy1, proxy2`, `req.ips` would be 
+`["client", "proxy1", "proxy2"]`, where `proxy2` is the furthest downstream.

--- a/_includes/api/ru/4x/req-protocol.md
+++ b/_includes/api/ru/4x/req-protocol.md
@@ -1,6 +1,9 @@
 <h3 id='req.protocol'>req.protocol</h3>
 
-The request protocol string, "http" or "https" when requested with TLS. When the "trust proxy" [setting](/4x/api.html#trust.proxy.options.table) trusts the socket address, the value of the "X-Forwarded-Proto" header ("http" or "https") field will be trusted and used if present.
+The request protocol string, `http` or `https` when requested with TLS. When the
+[`trust proxy` setting](/4x/api.html#trust.proxy.options.table) trusts the
+socket address, the value of the `X-Forwarded-Proto` header (`http` or `https`)
+field will be trusted and used if present.
 
 ~~~js
 req.protocol

--- a/_includes/api/zh/4x/app-settings.md
+++ b/_includes/api/zh/4x/app-settings.md
@@ -147,6 +147,11 @@ If `name` is one of the application settings, it affects the behavior of the app
 
   <h5 id="trust.proxy.options.table">Options for `trust proxy` setting</h5>
 
+  <p markdown="1">
+  Read [Express behind proxies](/guide/behind-proxies.html) for more
+  information.
+  </p>
+
   <table class="doctable" border="1">
     <thead><tr><th>Type</th><th>Value</th></tr></thead>
     <tbody>

--- a/_includes/api/zh/4x/req-hostname.md
+++ b/_includes/api/zh/4x/req-hostname.md
@@ -1,6 +1,10 @@
 <h3 id='req.hostname'>req.hostname</h3>
 
-Contains the hostname from the "Host" HTTP header.
+Contains the hostname from the `Host` HTTP header.
+
+When the [`trust proxy` setting](/4x/api.html#trust.proxy.options.table) trusts
+the socket address, the value of the `X-Forwarded-Host` header field will be
+trusted and used if present.
 
 ~~~js
 // Host: "example.com:3000"

--- a/_includes/api/zh/4x/req-ip.md
+++ b/_includes/api/zh/4x/req-ip.md
@@ -2,8 +2,8 @@
 
 The remote IP address of the request.
 
-If the `trust proxy` is setting enabled, it is the upstream address;
-see [Express behind proxies](/guide/behind-proxies.html) for more information.
+When the [`trust proxy` setting](/4x/api.html#trust.proxy.options.table) trusts
+the socket address, it is the upstream address.
 
 ~~~js
 req.ip

--- a/_includes/api/zh/4x/req-ips.md
+++ b/_includes/api/zh/4x/req-ips.md
@@ -1,9 +1,8 @@
 <h3 id='req.ips'>req.ips</h3>
 
-When the `trust proxy` setting is `true`, this property contains an array of
-IP addresses specified in the "X-Forwarded-For" request header.  Otherwise, it contains an empty array.
+When the [`trust proxy` setting](/4x/api.html#trust.proxy.options.table) trusts
+the socket address, this property contains an array of IP addresses specified in
+the `X-Forwarded-For` request header. Otherwise, it contains an empty array.
 
-For example, if "X-Forwarded-For" is "client, proxy1, proxy2", `req.ips` would be 
-`["client", "proxy1", "proxy2"]`, where "proxy2" is the furthest downstream.
-
-For more information on the `trust proxy` setting, see [app.set](#app.set).
+For example, if `X-Forwarded-For` is `client, proxy1, proxy2`, `req.ips` would be 
+`["client", "proxy1", "proxy2"]`, where `proxy2` is the furthest downstream.

--- a/_includes/api/zh/4x/req-protocol.md
+++ b/_includes/api/zh/4x/req-protocol.md
@@ -1,6 +1,9 @@
 <h3 id='req.protocol'>req.protocol</h3>
 
-The request protocol string, "http" or "https" when requested with TLS. When the "trust proxy" [setting](/4x/api.html#trust.proxy.options.table) trusts the socket address, the value of the "X-Forwarded-Proto" header ("http" or "https") field will be trusted and used if present.
+The request protocol string, `http` or `https` when requested with TLS. When the
+[`trust proxy` setting](/4x/api.html#trust.proxy.options.table) trusts the
+socket address, the value of the `X-Forwarded-Proto` header (`http` or `https`)
+field will be trusted and used if present.
 
 ~~~js
 req.protocol


### PR DESCRIPTION
This PR contains global improvements to all the doc related to the `trust proxy` setting.

The only true change in the doc is that the addition that `req.hostname` is modified by trust proxy cf. [code of `request.js`](https://github.com/strongloop/express/blob/master/lib/request.js#L400)

The other changes are just systematizing links and formulations.
