### PR TITLE
Recommend using absolute path for `express.static`. Fix #443.

### DIFF
--- a/starter/static-files.md
+++ b/starter/static-files.md
@@ -53,3 +53,9 @@ http://localhost:3000/static/js/app.js
 http://localhost:3000/static/images/bg.png
 http://localhost:3000/static/hello.html
 ~~~
+
+However, the path you provide to `express.static` is relative to the directory where you launch your node process. If you run the express app from another directory, it's safer to use the absolute path of the directory you want to serve:
+
+~~~js
+app.use('/static', express.static(__dirname + '/public'));
+~~~


### PR DESCRIPTION
Somehow the code has a badly-styled line-number, but I don't know how to fix it:

<img width="995" alt="screen shot 2015-09-11 at 9 23 11 pm" src="https://cloud.githubusercontent.com/assets/4033249/9829268/57a971e6-58cb-11e5-9fde-b3e179b2d558.png">
