### PR TITLE
Update router-param.md

### DIFF
--- a/_includes/api/en/4x/router-param.md
+++ b/_includes/api/en/4x/router-param.md
@@ -35,12 +35,12 @@ router.param('id', function (req, res, next, id) {
   next();
 })
 
-app.get('/user/:id', function (req, res, next) {
+router.get('/user/:id', function (req, res, next) {
   console.log('although this matches');
   next();
 });
 
-app.get('/user/:id', function (req, res) {
+router.get('/user/:id', function (req, res) {
   console.log('and this matches too');
   res.end();
 });
@@ -50,25 +50,6 @@ On `GET /user/42`, the following is printed:
 
 ~~~
 CALLED ONLY ONCE
-although this matches
-and this matches too
-~~~
-
-~~~js
-app.get('/user/:id/:page', function (req, res, next) {
-  console.log('although this matches');
-  next();
-});
-
-app.get('/user/:id/:page', function (req, res) {
-  console.log('and this matches too');
-  res.end();
-});
-~~~
-
-On `GET /user/42/3`, the following is printed:
-
-~~~
 although this matches
 and this matches too
 ~~~


### PR DESCRIPTION
This seems to be a Copy&Paste error from the standard app.param() documentation. As documented "Param callback functions are local to the router on which they are defined.", the router param callback would't be triggered when requesting a route in "app".
The following section (which was the param section with an array from app.param()), can be ignored, since "Unlike app.param(), router.param() does not accept an array of route parameters."
