### PR TITLE
correct return value of accepts()

### DIFF
--- a/_includes/api/en/4x/req-accepts.md
+++ b/_includes/api/en/4x/req-accepts.md
@@ -2,7 +2,7 @@
 
 Checks if the specified content types are acceptable, based on the request's `Accept` HTTP header field.
 The method returns the best match, or if none of the specified content types is acceptable, returns 
-`undefined` (in which case, the application should respond with `406 "Not Acceptable"`).
+`false` (in which case, the application should respond with `406 "Not Acceptable"`).
 
 The `type` value may be a single MIME type string (such as "application/json"),
 an extension name such as "json", a comma-delimited list, or an array. For a


### PR DESCRIPTION
Return value of accepts is false, not undefined, when no match is found in the content types. See https://github.com/jshttp/accepts/blob/master/index.js#L102
