### PR TITLE
fixed typo

### DIFF
--- a/_includes/api/en/4x/res-download.md
+++ b/_includes/api/en/4x/res-download.md
@@ -1,7 +1,7 @@
 <h3 id='res.download'>res.download(path [, filename] [, fn])</h3>
 
 Transfers the file at `path` as an "attachment". Typically, browsers will prompt the user for download.
-By default, the `Content-Disposition` header "filename=" parameter is `path` (this typically appears in the brower dialog).
+By default, the `Content-Disposition` header "filename=" parameter is `path` (this typically appears in the browser dialog).
 Override this default with the `filename` parameter.
 
 When an error ocurrs or transfer is complete, the method calls the optional callback function `fn`.


### PR DESCRIPTION
Typo fixed in line 4: "browser" instead of "brower"
