### PR TITLE
Add 3.x deprecated notice to security page

### DIFF
--- a/advanced/security-updates.md
+++ b/advanced/security-updates.md
@@ -29,6 +29,12 @@ The list below enumerates the Express vulnerabilities that were fixed in the spe
 
 ## 3.x
 
+  <div class="doc-box doc-warn" markdown="1">
+  **Express 3.x IS NO LONGER MAINTAINED**
+
+  Known and unknown security issues in 3.x have not been addressed since the last update (1 August, 2015). Using the 3.x line should not be considered secure.
+  </div>
+
   * 3.19.1
     * Fixed root path disclosure vulnerability in express.static, res.sendfile, and res.sendFile
   * 3.19.0


### PR DESCRIPTION
So when looking at the security page, it's not exactly clear that even using the most recent version of the 3.x line may be secure. This is basically just adding the deprecation notice from the 3.x API page to the 3.x section on the security page. Let me know if there are any desired style changes :)
