### PR TITLE
Remove incorrect argument information for res.json

### DIFF
--- a/_includes/api/en/4x/res-json.md
+++ b/_includes/api/en/4x/res-json.md
@@ -1,6 +1,6 @@
 <h3 id='res.json'>res.json([body])</h3>
 
-Sends a JSON response. This method is identical to `res.send()` with an object or array as the parameter.
+Sends a JSON response. This method is identical to `res.send()` with any JSON type as the parameter (object, array, string, boolean number).
 However, you can use it to convert other values to JSON, such as `null`, and `undefined`.
 (although these are technically not valid JSON).
 


### PR DESCRIPTION
The res.json documentation incorrectly stated that it only took an object or array as an argument, which isn't true as internally JSON.stringify is used, and being able to send primitive types as a json response is a very desirable feature.
