### PR TITLE
Remove English string from non-en pages footer

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -47,10 +47,17 @@ $(function(){
 
   var editLink;
 
-  if (pathName == '/') editLink = '<a href="' + branchPath + '">Fork the website on GitHub</a>.';
-  else editLink = '<a href="' + editPath + '">Edit this page on GitHub</a>.';
+  console.log("pagePath is " + pagePath);
 
-  $('#fork').html(editLink);
+// Edit/Fork link in footer
+  if (pagePath.startsWith('/en')) {
+    if (pathName == '/') 
+      editLink = '<a href="' + branchPath + '">Fork the website on GitHub</a>.';
+    else 
+      editLink = '<a href="' + editPath + '">Edit this page on GitHub</a>.';
+
+    $('#fork').html(editLink);
+  }
 
   // code highlight
 


### PR DESCRIPTION
This addresses #523.  Note that the IBM translations will include the footer.
@hacksparrow PTAL.
