### PR TITLE
Added documentation of 'encode' cookie option.

### DIFF
--- a/_includes/api/en/4x/res-cookie.md
+++ b/_includes/api/en/4x/res-cookie.md
@@ -13,6 +13,7 @@ The `options` parameter is an object that can have the following properties.
 | `path`      | String | Path for the cookie. Defaults to "/".
 | `secure`    | Boolean | Marks the cookie to be used with HTTPS only.
 | `signed`    | Boolean | Indicates if the cookie should be signed.
+| `encode`    | Function | A synchronous function used for cookie value encoding.
 
 <div class="doc-box doc-notice" markdown="1">
 All `res.cookie()` does is set the HTTP `Set-Cookie` header with the options provided.
@@ -49,3 +50,19 @@ res.cookie('name', 'tobi', { signed: true });
 ~~~
 
 Later you may access this value through the [req.signedCookie](#req.signedCookies) object.
+
+The `encode` option allows you to choose the function used for cookie value encoding.
+The default setting is `encodeURIComponent` (URI encoding). Does not support asynchronous functions.
+
+~~~js
+//Default encoding
+res.cookie('some_cross_domain_cookie', 'http://mydomain.example.com',{domain:'example.com'});  
+// Result: 'some_cross_domain_cookie=http%3A%2F%2Fmydomain.example.com; Domain=example.com; Path=/'
+
+//Custom encoding
+res.cookie('some_cross_domain_cookie', 'http://mydomain.example.com',{domain:'example.com', encode: String});  
+// Result: 'some_cross_domain_cookie=http://mydomain.example.com; Domain=example.com; Path=/;'
+~~~
+
+Example use case: You need to set a domain wide cookie for another site in your organization to use. 
+This other site (not under your administrative control) does not use URI encoded cookie values.

--- a/_includes/api/en/4x/res-cookie.md
+++ b/_includes/api/en/4x/res-cookie.md
@@ -7,13 +7,13 @@ The `options` parameter is an object that can have the following properties.
 | Property    | Type |  Description                                                             |
 |-------------|-------------------------------------------------------------------------|
 | `domain`    | String | Domain name for the cookie. Defaults to the domain name of the app.
+| `encode`    | Function | A synchronous function used for cookie value encoding. Defaults to `encodeURIComponent`.
 | `expires`   | Date | Expiry date of the cookie in GMT. If not specified or set to 0, creates a session cookie.
 | `httpOnly`  | Boolean | Flags the cookie to be accessible only by the web server.
 | `maxAge`    | String | Convenient option for setting the expiry time relative to the current time in milliseconds.
 | `path`      | String | Path for the cookie. Defaults to "/".
 | `secure`    | Boolean | Marks the cookie to be used with HTTPS only.
 | `signed`    | Boolean | Indicates if the cookie should be signed.
-| `encode`    | Function | A synchronous function used for cookie value encoding.
 
 <div class="doc-box doc-notice" markdown="1">
 All `res.cookie()` does is set the HTTP `Set-Cookie` header with the options provided.
@@ -25,6 +25,22 @@ For example:
 ~~~js
 res.cookie('name', 'tobi', { domain: '.example.com', path: '/admin', secure: true });
 res.cookie('rememberme', '1', { expires: new Date(Date.now() + 900000), httpOnly: true });
+~~~
+
+The `encode` option allows you to choose the function used for cookie value encoding.
+Does not support asynchronous functions.
+
+Example use case: You need to set a domain wide cookie for another site in your organization to use. 
+This other site (not under your administrative control) does not use URI encoded cookie values.
+
+~~~js
+//Default encoding
+res.cookie('some_cross_domain_cookie', 'http://mysubdomain.example.com',{domain:'example.com'});  
+// Result: 'some_cross_domain_cookie=http%3A%2F%2Fmysubdomain.example.com; Domain=example.com; Path=/'
+
+//Custom encoding
+res.cookie('some_cross_domain_cookie', 'http://mysubdomain.example.com',{domain:'example.com', encode: String});  
+// Result: 'some_cross_domain_cookie=http://mysubdomain.example.com; Domain=example.com; Path=/;'
 ~~~
 
 The `maxAge` option is a convenience option for setting "expires" relative to the current time in milliseconds.
@@ -50,19 +66,3 @@ res.cookie('name', 'tobi', { signed: true });
 ~~~
 
 Later you may access this value through the [req.signedCookie](#req.signedCookies) object.
-
-The `encode` option allows you to choose the function used for cookie value encoding.
-The default setting is `encodeURIComponent` (URI encoding). Does not support asynchronous functions.
-
-~~~js
-//Default encoding
-res.cookie('some_cross_domain_cookie', 'http://mydomain.example.com',{domain:'example.com'});  
-// Result: 'some_cross_domain_cookie=http%3A%2F%2Fmydomain.example.com; Domain=example.com; Path=/'
-
-//Custom encoding
-res.cookie('some_cross_domain_cookie', 'http://mydomain.example.com',{domain:'example.com', encode: String});  
-// Result: 'some_cross_domain_cookie=http://mydomain.example.com; Domain=example.com; Path=/;'
-~~~
-
-Example use case: You need to set a domain wide cookie for another site in your organization to use. 
-This other site (not under your administrative control) does not use URI encoded cookie values.


### PR DESCRIPTION
Added documentation of 'encode' cookie option available from 'cookie' module, function 'serialize' line:100 & line:106. Default option of 'encodeURIComponent' at line:22.

URL to 'cookie' module function 'serialize' -
https://github.com/jshttp/cookie/blob/master/index.js#L98
