### PR TITLE
node foundation proposed express WG governance

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,5 @@
+### Express Documentation WG Code of Conduct
+
+The [Node.js Code of Conduct][] applies to this WG.
+
+[Node.js Code of Conduct]: https://github.com/nodejs/node/blob/master/CODE_OF_CONDUCT.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,15 @@ This repository is only for issues related to the website [http://expressjs.com]
 
 Feel free to make changes to the template files or the document files. The supporting docs are located in their respective directories, and the API docs are located under the `_includes` directory.
 
+## Code of Conduct
+
+The [Code of Conduct][] explains the bare minimum behavior expectations for all contributors to Express documentation. Please read it before participating.
+
+## Developer's Certificate of Origin
+
+All code contributions to Express documentation fall under the Express documentation [Developer's Certificate of Origin][].
+
+
 ## Help translate the docs to other languages
 
 We are looking for volunteers to help translate the Express docs to other languages.
@@ -38,3 +47,6 @@ Then, load [http://localhost:4000/](http://localhost:4000/) on your browser.
 Jekyll uses a variant of Markdown known as [Kramdown](http://kramdown.gettalong.org/quickref.html), read up the docs if you need to go beyond basic Markdown in the doc files.
 
 To understand the template system used by Jekyll, read up the [Liquid template engine docs](http://liquidmarkup.org/).
+
+[Code of Conduct]: CODE_OF_CONDUCT.md
+[Developer's Certificate of Origin]: DCO.md

--- a/DCO.md
+++ b/DCO.md
@@ -1,0 +1,15 @@
+## Developer's Certificate of Origin 1.0
+
+By making a contribution to this project, I certify that:
+
+* (a) The contribution was created in whole or in part by me and I
+  have the right to submit it under the open source license indicated
+  in the file; or
+* (b) The contribution is based upon previous work that, to the best
+  of my knowledge, is covered under an appropriate open source license
+  and I have the right under that license to submit that work with
+  modifications, whether created in whole or in part by me, under the
+  same open source license (unless I am permitted to submit under a
+  different license), as indicated in the file; or
+* (c) The contribution was provided directly to me by some other
+  person who certified (a), (b) or (c) and I have not modified it.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,137 @@
+## Express Documentation Working Group Governance
+
+### Collaborators
+
+The strongloop/expressjs.com GitHub repository is maintained by the WG and
+additional Collaborators who are added by the WG on an ongoing basis.
+
+Individuals making significant and valuable contributions are made
+Collaborators and given commit-access to the project. These individuals are
+identified by the WG and their addition as Collaborators is discussed during
+the weekly WG meeting.
+
+Individuals who have made significant contributions and who wish to be
+considered for commit-access may create an issue or contact a WG member
+directly. It is not necessary to wait for a WG member to nominate the
+individual.
+
+Modifications of the contents of the strongloop/expressjs.com repository
+are made on a collaborative basis. Anybody with a GitHub account may propose
+a modification via pull request and it will be considered by the project
+Collaborators. All pull requests must be reviewed and accepted by a
+Collaborator with sufficient expertise who is able to take full
+responsibility for the change. In the case of pull requests proposed
+by an existing Collaborator, an additional Collaborator is required
+for sign-off. Consensus should be sought if additional Collaborators
+participate and there is disagreement around a particular
+modification. See _Consensus Seeking Process_ below for further detail
+on the consensus model used for governance.
+
+Collaborators may opt to esacalate discussion about significant or
+controversial modifications to the WG as a whole by assigning the
+`express-docs-agenda` tag to a pull request or issue. The WG should serve as the
+final arbiter where required.
+
+### WG Membership
+
+WG seats are not time-limited.  There is no fixed size of the WG.
+However, the expected target is between 6 and 12, to ensure adequate
+coverage of important areas of expertise, balanced with the ability to
+make decisions efficiently.
+
+There is no specific set of requirements or qualifications for WG
+membership beyond these rules.
+
+The WG may add additional members to the WG by consensus. If there are
+any objections to adding any individual member, an attempt should be
+made to resolve those objections following the WG's Consensus Seeking
+Process.
+
+A WG member may be removed from the WG by voluntary resignation, or by
+consensus of all other WG members.
+
+Changes to WG membership should be posted in the agenda, and may be
+suggested as any other agenda item (see "WG Meetings" below).
+
+If an addition or removal is proposed during a meeting, and the full
+WG is not in attendance to participate, then the addition or removal
+is added to the agenda for the subsequent meeting.  This is to ensure
+that all members are given the opportunity to participate in all
+membership decisions.  If a WG member is unable to attend a meeting
+where a planned membership decision is being made, then their consent
+is assumed.
+
+If the WG membership consists of more than 3 active participants, no more than
+1/3 of the WG members may be affiliated with the same employer.  If removal or
+resignation of a WG member, or a change of employment by a WG member, creates a
+situation where more than 1/3 of the WG membership shares an employer, then the
+situation must be immediately remedied by the resignation or removal of one or
+more WG members affiliated with the over-represented employer(s).
+
+### WG Meetings
+
+The WG meets bi-weekly using Google Hangouts on Air or similar tool that allows
+public viewing or participation. A designated moderator approved by the WG runs
+the meeting. A recording of each meeting should be published to either YouTube
+or similar service and all meeting minutes should be posted to the
+strongloop/expressjs.com GitHub repository.
+
+Items are added to the WG agenda that are considered contentious or
+are modifications of governance, contribution policy, WG membership,
+or release process.
+
+The intention of the agenda is not to approve or review all patches;
+that should happen continuously on GitHub and be handled by the larger
+group of Collaborators.
+
+Any community member or contributor can ask that something be added to
+the next meeting's agenda by logging a GitHub Issue. Any Collaborator,
+WG member or the moderator can add the item to the agenda by adding
+the `express-docs-agenda` tag to the issue.
+
+Prior to each WG meeting the moderator will share the Agenda with
+members of the WG. WG members can add any items they like to the
+agenda at the beginning of each meeting. The moderator and the WG
+cannot veto or remove items.
+
+The WG may invite persons or representatives from certain projects to
+participate in a non-voting capacity.
+
+The moderator is responsible for summarizing the discussion of each
+agenda item and sends it as a pull request after the meeting.
+
+### Consensus Seeking Process
+
+The WG follows a [Consensus Seeking][] decision-making model.
+
+When an agenda item has appeared to reach a consensus the moderator
+will ask "Does anyone object?" as a final call for dissent from the
+consensus.
+
+If an agenda item cannot reach a consensus a WG member can call for
+either a closing vote or a vote to table the issue to the next
+meeting. The call for a vote must be seconded by a majority of the WG
+or else the discussion will continue. Simple majority wins.
+
+Note that changes to WG membership require consensus. If there are any
+objections to adding or removing individual members, an effort must be
+made to resolve those objections. If consensus cannot be reached, a
+vote may be called following the process above.
+
+### Developer's Certificate of Origin 1.0
+
+By making a contribution to this project, I certify that:
+
+* (a) The contribution was created in whole or in part by me and I
+  have the right to submit it under the open source license indicated
+  in the file; or
+* (b) The contribution is based upon previous work that, to the best
+  of my knowledge, is covered under an appropriate open source license
+  and I have the right under that license to submit that work with
+  modifications, whether created in whole or in part by me, under the
+  same open source license (unless I am permitted to submit under a
+  different license), as indicated in the file; or
+* (c) The contribution was provided directly to me by some other
+  person who certified (a), (b) or (c) and I have not modified it.
+
+[Consensus Seeking]: http://en.wikipedia.org/wiki/Consensus-seeking_decision-making

--- a/MODERATION_POLICY.md
+++ b/MODERATION_POLICY.md
@@ -1,0 +1,5 @@
+### Express Documentation WG Moderation Policy
+
+The [Node.js Moderation Policy] applies to this WG.
+
+[Node.js Moderation Policy]: https://github.com/nodejs/TSC/blob/master/Moderation-Policy.md


### PR DESCRIPTION
Per the proposal to add express to the Node.js Foundation incubator (nodejs/TSC#39) an Express Documentation WG under the Node.js TSC would be chartered to oversee the nodejs/expressjs.com github repository. Per the TSC guidelines, every WG needs a minimum set of governance policies in place that describe how the WG will operate. This adds an initial draft that is based directly on the base policy templates provided by the TSC.
