### PR TITLE
Fork link in footer (en) now points to the correct GitHub repo

### DIFF
--- a/_includes/footer/footer-en.html
+++ b/_includes/footer/footer-en.html
@@ -26,7 +26,7 @@
         </div>
         <div id="sponsor"><a href="https://github.com/expressjs/express/">Express</a>
             is a project of the <a href="http://nodejs.org/foundation"></a>Node.js Foundation</a>.</div>
-        <div id="fork"><a href="https://github.com/expressjs/expressjs.com">Fork the website on GitHub</a>.
+        <div id="fork"><a href="https://github.com/strongloop/expressjs.com">Fork the website on GitHub</a>.
         </div>
         <div>Copyright &copy; 2016 StrongLoop, IBM, and other expressjs.com contributors.</div>
     </div>


### PR DESCRIPTION
This fixes #598 
