### PR TITLE
Document req/res "inheritance"

### DIFF
--- a/_includes/api/en/3x/req.md
+++ b/_includes/api/en/3x/req.md
@@ -1,5 +1,8 @@
 <h2>Request</h2>
 
+The `req` object is an enhanced version of Node's own request object
+and supports all [built-in fields and methods](https://nodejs.org/api/http.html#http_class_http_incomingmessage).
+
 <section markdown="1">
   {% include api/en/3x/req-params.md %}
 </section>

--- a/_includes/api/en/3x/res.md
+++ b/_includes/api/en/3x/res.md
@@ -1,5 +1,8 @@
 <h2>Response</h2>
 
+The `res` object is an enhanced version of Node's own response object
+and supports all [built-in fields and methods](https://nodejs.org/api/http.html#http_class_http_serverresponse).
+
 <section markdown="1">
   {% include api/en/3x/res-status.md %}
 </section>

--- a/_includes/api/en/4x/req.md
+++ b/_includes/api/en/4x/req.md
@@ -21,6 +21,9 @@ app.get('/user/:id', function(request, response) {
 });
 {% endhighlight %}
 
+The `req` object is an enhanced version of Node's own request object
+and supports all [built-in fields and methods](https://nodejs.org/api/http.html#http_class_http_incomingmessage).
+
 <h3 id='req.properties'>Properties</h3>
 
 <div class="doc-box doc-notice" markdown="1">

--- a/_includes/api/en/4x/res.md
+++ b/_includes/api/en/4x/res.md
@@ -22,6 +22,9 @@ app.get('/user/:id', function(request, response){
 });
 {% endhighlight %}
 
+The `res` object is an enhanced version of Node's own response object
+and supports all [built-in fields and methods](https://nodejs.org/api/http.html#http_class_http_serverresponse).
+
 <h3 id='res.properties'>Properties</h3>
 
 <section markdown="1">


### PR DESCRIPTION
I'm assuming this fact was always part of the official API of express, just never spelled out in the docs.
