### PR TITLE
update about (not) removing uncaughtException event

### DIFF
--- a/en/advanced/best-practice-performance.md
+++ b/en/advanced/best-practice-performance.md
@@ -92,7 +92,7 @@ For more on the fundamentals of error handling, see:
 
 One thing you should _not_ do is to listen for the `uncaughtException` event, emitted when an exception bubbles all the way back to the event loop. Adding an event listener for `uncaughtException` will change the default behavior of the process that is encountering an exception; the process will continue to run despite the exception. This might sound like a good way of preventing your app from crashing, but continuing to run the app after an uncaught exception is a dangerous practice and is not recommended, because the state of the process becomes unreliable and unpredictable.
 
-Additionally, using `uncaughtException` is officially recognized as [crude](https://nodejs.org/api/process.html#process_event_uncaughtexception) and there is a [proposal](https://github.com/nodejs/node-v0.x-archive/issues/2582) to remove it from the core. So listening for `uncaughtException` is just a bad idea. This is why we recommend things like multiple processes and supervisors: crashing and restarting is often the most reliable way to recover from an error.
+Additionally, using `uncaughtException` is officially recognized as [crude](https://nodejs.org/api/process.html#process_event_uncaughtexception). So listening for `uncaughtException` is just a bad idea. This is why we recommend things like multiple processes and supervisors: crashing and restarting is often the most reliable way to recover from an error.
 
 We also don't recommend using [domains](https://nodejs.org/api/domain.html). It generally doesn't solve the problem and is a deprecated module.
 


### PR DESCRIPTION
I think the documentation is a little bit outdated about removing uncaughtException from Node.js core.

They decided to keep it as is and closed the proposal about removing it.
https://github.com/nodejs/node-v0.x-archive/issues/2582#issuecomment-9971225

The documentation was updated as well.
https://github.com/nodejs/node-v0.x-archive/commit/a2fd657b10c7609e1776004156a8cd3016e2c6c8

So we should too :)
