### PR TITLE
Fix HTML entities in generator options

### DIFF
--- a/en/starter/generator.md
+++ b/en/starter/generator.md
@@ -30,7 +30,7 @@ $ express -h
     -e, --ejs           add ejs engine support (defaults to jade)
         --hbs           add handlebars engine support
     -H, --hogan         add hogan.js engine support
-    -c, --css &lt;engine&gt;  add stylesheet &lt;engine&gt; support (less|stylus|compass|sass) (defaults to plain css)
+    -c, --css <engine>  add stylesheet <engine> support (less|stylus|compass|sass) (defaults to plain css)
         --git           add .gitignore
     -f, --force         force on non-empty directory
 ```


### PR DESCRIPTION
Possibly a byproduct of the change to backticks (#628)

<img width="976" alt="screen shot 2016-05-03 at 10 14 12" src="https://cloud.githubusercontent.com/assets/871743/14979047/d5be0812-1117-11e6-814e-cc2c4e418422.png">
