### PR TITLE
Remove incorrect argument information for res.json

### DIFF
--- a/_includes/api/en/4x/res-json.md
+++ b/_includes/api/en/4x/res-json.md
@@ -1,6 +1,6 @@
 <h3 id='res.json'>res.json([body])</h3>
 
-Sends a JSON response. This method is identical to `res.send()` with an object or array as the parameter.
+Sends a JSON response. This method is identical to `res.send()` with any JSON type as the parameter (object, array, string, boolean number).
 However, you can use it to convert other values to JSON, such as `null`, and `undefined`.
 (although these are technically not valid JSON).
 

--- a/_includes/api/en/4x/res-json.md
+++ b/_includes/api/en/4x/res-json.md
@@ -1,6 +1,7 @@
 <h3 id='res.json'>res.json([body])</h3>
 
-Sends a JSON response. This method is identical to `res.send()` with any JSON type as the parameter (object, array, string, boolean number).
+Sends a JSON response. This method sends a response with the provided argument stringified as json with the correct content-type.
+This method accepts any JSON type as the parameter (object, array, string, boolean number).
 However, you can use it to convert other values to JSON, such as `null`, and `undefined`.
 (although these are technically not valid JSON).
 


### PR DESCRIPTION
The res.json documentation incorrectly stated that it only took an object or array as an argument, which isn't true as internally JSON.stringify is used, and being able to send primitive types as a json response is a very desirable feature.

Also it incorrectly stated that it was almost identical to `res.send`, which is incorrect in the case of numbers and strings and has been reworded.
