### PR TITLE
Note that app[method] names are lowercase

### DIFF
--- a/en/starter/basic-routing.md
+++ b/en/starter/basic-routing.md
@@ -21,7 +21,7 @@ app.METHOD(PATH, HANDLER)
 Where:
 
 - `app` is an instance of `express`.
-- `METHOD` is an [HTTP request method](http://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol).
+- `METHOD` is an [HTTP request method](https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Request_methods), in lowercase.
 - `PATH` is a path on the server.
 - `HANDLER` is the function executed when the route is matched.
 


### PR DESCRIPTION
It's mentioned in the [API docs](http://expressjs.com/en/4x/api.html#app.METHOD), but not here. It lacks clarity because the HTTP method names are uppercase, and these docs use a convention of representing placeholder values in uppercase (e.g. `app.METHOD`) .

And link to fragment about request methods.
