### PR TITLE
Fix minor typo in `Starting` for the Changelog for 4.14.0

### DIFF
--- a/en/changelog/4x.md
+++ b/en/changelog/4x.md
@@ -14,7 +14,7 @@ The 4.14.0 minor release includes bug fixes, security update, performance improv
 
 <ul>
   <li markdown="1" class="changelog-item">
-  Starging with this version, Express supports Node.js 6.x.
+  Starting with this version, Express supports Node.js 6.x.
   </li>
 
   <li markdown="1" class="changelog-item">


### PR DESCRIPTION
Fixes a minor typo for `Starting` being `Starging`
