### PR TITLE
Update error-handling.md

### DIFF
--- a/en/guide/error-handling.md
+++ b/en/guide/error-handling.md
@@ -139,3 +139,6 @@ function errorHandler(err, req, res, next) {
   res.render('error', { error: err });
 }
 ```
+
+Note that the default error handler can get triggered if you call `next()` with an error 
+in your code more than once, even if custom error handling middleware is in place.


### PR DESCRIPTION
Added note regarding the default error handler triggering by multiple `next(err)` calls, as this feature is not very clear and can come as a surprise.
Ref: https://github.com/expressjs/express/issues/3024
