### PR TITLE
Adding KeystoneJS to Frameworks

### DIFF
--- a/en/resources/frameworks.md
+++ b/en/resources/frameworks.md
@@ -9,9 +9,11 @@ lang: en
 
 Several popular Node.js frameworks are built on Express:
 
+- **[Feathers](http://feathersjs.com)**: Build prototypes in minutes and production ready real-time apps in days.
+- **[KeystoneJS](http://keystonejs.com/)**: Website and API Application Framework / CMS with an auto-generated React.js Admin UI
+- **[Kraken](http://krakenjs.com/)**: Secure and scalable layer that extends Express by providing structure and convention.
 - **[LEAN-STACK](http://lean-stack.io)**: The Pure JavaScript Stack.
 - **[LoopBack](http://loopback.io)**: Highly-extensible, open-source Node.js framework for quickly creating dynamic end-to-end REST APIs.
-- **[Sails](http://sailsjs.org/)**: MVC framework for Node.js for building practical, production-ready apps.
-- **[Kraken](http://krakenjs.com/)**: Secure and scalable layer that extends Express by providing structure and convention.
 - **[MEAN](http://mean.io/)**: Opinionated fullstack JavaScript framework that simplifies and accelerates web application development.
-- **[Feathers](http://feathersjs.com)**: Build prototypes in minutes and production ready real-time apps in days.
+- **[Sails](http://sailsjs.org/)**: MVC framework for Node.js for building practical, production-ready apps.
+


### PR DESCRIPTION
I've also ordered the frameworks alphabetically, this seems to make sense and avoids favouritism in the ordering.
