### PR TITLE
Mention signedCookies when reading about cookies

### DIFF
--- a/_includes/api/en/4x/req-cookies.md
+++ b/_includes/api/en/4x/req-cookies.md
@@ -9,4 +9,6 @@ req.cookies.name
 // => "tj"
 ```
 
+If the cookie has been signed, you have to use [req.signedCookies](#req.signedCookies).
+
 For more information, issues, or concerns, see [cookie-parser](https://github.com/expressjs/cookie-parser).


### PR DESCRIPTION
I could not figure out why my cookies was not in the req.cookies, but it was because I had signed it. I went to cookie-parser, but it was not mention either in that README. I created a Pull request, but I think the info could also be needed here to avoid confusion. https://github.com/expressjs/cookie-parser/pull/29 
