### PR TITLE
Added missing semicolon

### DIFF
--- a/_includes/api/en/4x/app-all.md
+++ b/_includes/api/en/4x/app-all.md
@@ -18,7 +18,7 @@ app.all('*', requireAuthentication, loadUser);
 Or the equivalent:
 
 ```js
-app.all('*', requireAuthentication)
+app.all('*', requireAuthentication);
 app.all('*', loadUser);
 ```
 


### PR DESCRIPTION
I know semicolons are not strictly necessary, but the rest of the page contains semicolon-terminated lines. This edit just maintains a consistent code style.
