### PR TITLE
Add basic print media adjustments

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1018,6 +1018,17 @@ h2 a {
   }
 }
 
+@media print {
+
+  header {
+    position: absolute;
+  }
+
+  #mobile-menu {
+    display:none;
+  }
+}
+
 /* For image callouts in writing-middleware.md  */
 
 .callout {position: relative;}


### PR DESCRIPTION
This adds the most basic print media CSS needed to keep web browsers that understand fixed position from positioning the header at the top of every page, covering content.
