### PR TITLE
Fix the list of TC members

### DIFF
--- a/en/resources/contributing.md
+++ b/en/resources/contributing.md
@@ -28,10 +28,8 @@ Members of the Express technical committee are:
 - [@dougwilson](https://github.com/dougwilson) - Douglas Wilson
 - [@Fishrock123](https://github.com/Fishrock123) - Jeremiah Senkpiel
 - [@hacksparrow](https://github.com/hacksparrow) - Hage Yaapa
-- [@jasnell](https://github.com/jasnell) - James M Snell
 - [@jonathanong](https://github.com/jonathanong) jongleberry
 - [@LinusU](https://github.com/LinusU) - Linus Unnebäck
-- [@mikeal](https://github.com/mikeal) - Mikeal Rogers
 - [@niftylettuce](https://github.com/niftylettuce) - niftylettuce
 - [@troygoode](https://github.com/troygoode) - Troy Goode
 


### PR DESCRIPTION
I removed the two Node.js mentors from the TC list, as they are not actually part of the TC (which is why they generally do not show up to any TC meetings, etc.). Rather James & Mikeal are our mentors :)
