### PR TITLE
Add missing path argument types

### DIFF
--- a/_includes/api/en/4x/app-METHOD.md
+++ b/_includes/api/en/4x/app-METHOD.md
@@ -4,6 +4,8 @@ Routes an HTTP request, where METHOD is the HTTP method of the request, such as 
 PUT, POST, and so on, in lowercase. Thus, the actual methods are `app.get()`,
 `app.post()`, `app.put()`, and so on.  See below for the complete list.
 
+The `path` argument can be a string representing a path, a path pattern, a regular expression to match paths, or an array of combinations thereof.
+
 For more information, see the [routing guide](/guide/routing.html).
 
 Express supports the following routing methods corresponding to the HTTP methods of the same names:

--- a/_includes/api/en/4x/app-all.md
+++ b/_includes/api/en/4x/app-all.md
@@ -11,6 +11,8 @@ that these callbacks do not have to act as end-points: `loadUser`
 can perform a task, then call `next()` to continue matching subsequent
 routes.
 
+The `path` argument can be a string representing a path, a path pattern, a regular expression to match paths, or an array of combinations thereof.
+
 ```js
 app.all('*', requireAuthentication, loadUser);
 ```

--- a/_includes/api/en/4x/app-get-method.md
+++ b/_includes/api/en/4x/app-get-method.md
@@ -12,4 +12,19 @@ subsequent routes if there's no reason to proceed with the current route.
 app.get('/', function (req, res) {
   res.send('GET request to homepage');
 });
+
+// path could be array of strings
+app.get(['/foo/bar', '/other/bar'], function (req, res) {
+  res.send('GET request to any of above path');
+});
+
+// path could be regex
+app.get(/^\/yellboom(er|s)?$/, function (req, res) {
+  res.send('GET request to page that starts with startswithboom');
+});
+
+// path could be array of regex
+app.get([/^\/yellboom(er|s)?$/, /^\/ab(cd)?e$/], function (req, res) {
+  res.send('GET request to page that matches any of above regex path');
+});
 ```

--- a/_includes/api/en/4x/app-post-method.md
+++ b/_includes/api/en/4x/app-post-method.md
@@ -13,4 +13,19 @@ the current route.
 app.post('/', function (req, res) {
   res.send('POST request to homepage');
 });
+
+// path could be array of strings
+app.post(['/foo/bar', '/other/bar'], function (req, res) {
+  res.send('POST request to any of above path');
+});
+
+// path could be regex
+app.post(/^\/yellboom(er|s)?$/, function (req, res) {
+  res.send('POST request to page that starts with startswithboom');
+});
+
+// path could be array of regex
+app.post([/^\/yellboom(er|s)?$/, /^\/ab(cd)?e$/], function (req, res) {
+  res.send('POST request to page that matches any of above regex path');
+});
 ```

--- a/_includes/api/en/4x/app-put-method.md
+++ b/_includes/api/en/4x/app-put-method.md
@@ -13,4 +13,19 @@ the current route.
 app.put('/', function (req, res) {
   res.send('PUT request to homepage');
 });
+
+// path could be array of strings
+app.put(['/foo/bar', '/other/bar'], function (req, res) {
+  res.send('PUT request to any of above path');
+});
+
+// path could be regex
+app.put(/^\/yellboom(er|s)?$/, function (req, res) {
+  res.send('PUT request to page that starts with startswithboom');
+});
+
+// path could be array of regex
+app.put([/^\/yellboom(er|s)?$/, /^\/ab(cd)?e$/], function (req, res) {
+  res.send('PUT request to page that matches any of above regex path');
+});
 ```


### PR DESCRIPTION
- Adds missing path arguments type for app.put, app.post, app.get.
- documents path type for app.METHOD and app.all
- addresses issue https://github.com/expressjs/expressjs.com/issues/630
