### PR TITLE
Clarify arguments to routing methods

### DIFF
--- a/_includes/api/en/4x/app-METHOD.md
+++ b/_includes/api/en/4x/app-METHOD.md
@@ -2,9 +2,11 @@
 
 Routes an HTTP request, where METHOD is the HTTP method of the request, such as GET,
 PUT, POST, and so on, in lowercase. Thus, the actual methods are `app.get()`,
-`app.post()`, `app.put()`, and so on.  See below for the complete list.
+`app.post()`, `app.put()`, and so on.  See [Routing methods](#routing-methods) below for the complete list.
 
-For more information, see the [routing guide](/guide/routing.html).
+{% include api/en/4x/routing-args.html %}
+
+#### Routing methods
 
 Express supports the following routing methods corresponding to the HTTP methods of the same names:
 
@@ -42,31 +44,17 @@ Express supports the following routing methods corresponding to the HTTP methods
 </tr>
 </table>
 
+The API documentation has explicit entries only for the most popular HTTP methods `app.get()`,
+`app.post()`, `app.put()`, and `app.delete()`.
+However, the other methods listed above work in exactly the same way.
+
 <div class="doc-box doc-info" markdown="1">
-  To route methods which translate to invalid JavaScript variable names, use the bracket notation. For example,
+  To route methods that translate to invalid JavaScript variable names, use the bracket notation. For example,
   `app['m-search']('/', function ...`.
 </div>
 
-You can provide multiple callback functions that behave just like middleware, except
-that these callbacks can invoke `next('route')` to bypass
-the remaining route callback(s). You can use this mechanism to impose pre-conditions
-on a route, then pass control to subsequent routes if there is no reason to proceed with the current route.
+The method, `app.all()`, is not derived from any HTTP method and loads middleware at
+the specified path for _all_ HTTP request methods.
+For more information, see [app.all](#app.all).
 
-<div class="doc-box doc-info" markdown="1">
-  The API documentation has explicit entries only for the most popular HTTP methods `app.get()`,
-  `app.post()`, `app.put()`, and `app.delete()`.
-  However, the other methods listed above work in exactly the same way.
-</div>
-
-There is a special routing method, `app.all()`, that is not derived from any HTTP method.
-It loads middleware at a path for all request methods.
-
-In the following example, the handler is executed for requests to "/secret" whether using
-GET, POST, PUT, DELETE, or any other HTTP request method.
-
-```js
-app.all('/secret', function (req, res, next) {
-  console.log('Accessing the secret section ...')
-  next() // pass control to the next handler
-});
-```
+For more information on routing, see the [routing guide](/guide/routing.html).

--- a/_includes/api/en/4x/app-all.md
+++ b/_includes/api/en/4x/app-all.md
@@ -3,8 +3,21 @@
 This method is like the standard [app.METHOD()](#app.METHOD) methods,
 except it matches all HTTP verbs.
 
-It's useful for mapping "global" logic for specific path prefixes or arbitrary matches.
-For example, if you put the following at the top of all other
+{% include api/en/4x/routing-args.html %}
+
+#### Examples
+
+The following callback is executed for requests to `/secret` whether using
+GET, POST, PUT, DELETE, or any other HTTP request method:
+
+```js
+app.all('/secret', function (req, res, next) {
+  console.log('Accessing the secret section ...')
+  next() // pass control to the next handler
+});
+```
+
+The `app.all()` method is useful for mapping "global" logic for specific path prefixes or arbitrary matches.  For example, if you put the following at the top of all other
 route definitions, it requires that all routes from that point on
 require authentication, and automatically load a user. Keep in mind
 that these callbacks do not have to act as end-points: `loadUser`

--- a/_includes/api/en/4x/app-delete-method.md
+++ b/_includes/api/en/4x/app-delete-method.md
@@ -3,10 +3,9 @@
 Routes HTTP DELETE requests to the specified path with the specified callback functions.
 For more information, see the [routing guide](/guide/routing.html).
 
-You can provide multiple callback functions that behave just like middleware, except
-these callbacks can invoke `next('route')` to bypass the remaining route
-callback(s). You can use this mechanism to impose pre-conditions on a route, then pass control
-to subsequent routes if there's no reason to proceed with the current route.
+{% include api/en/4x/routing-args.html %}
+
+#### Example
 
 ```js
 app.delete('/', function (req, res) {

--- a/_includes/api/en/4x/app-get-method.md
+++ b/_includes/api/en/4x/app-get-method.md
@@ -1,12 +1,12 @@
 <h3 id='app.get.method'>app.get(path, callback [, callback ...])</h3>
 
 Routes HTTP GET requests to the specified path with the specified callback functions.
+
+{% include api/en/4x/routing-args.html %}
+
 For more information, see the [routing guide](/guide/routing.html).
 
-You can provide multiple callback functions that behave just like middleware, except
-these callbacks can invoke `next('route')` to bypass the remaining route callback(s).
-You can use this mechanism to impose pre-conditions on a route, then pass control to
-subsequent routes if there's no reason to proceed with the current route.
+#### Example
 
 ```js
 app.get('/', function (req, res) {

--- a/_includes/api/en/4x/app-post-method.md
+++ b/_includes/api/en/4x/app-post-method.md
@@ -3,11 +3,9 @@
 Routes HTTP POST requests to the specified path with the specified callback functions.
 For more information, see the [routing guide](/guide/routing.html).
 
-You can provide multiple callback functions that behave just like middleware,
-except that these callbacks can invoke `next('route')` to bypass the
-remaining route callback(s). You can use this mechanism to impose pre-conditions on
-a route, then pass control to subsequent routes if there's no reason to proceed with
-the current route.
+{% include api/en/4x/routing-args.html %}
+
+#### Example
 
 ```js
 app.post('/', function (req, res) {

--- a/_includes/api/en/4x/app-put-method.md
+++ b/_includes/api/en/4x/app-put-method.md
@@ -1,13 +1,10 @@
 <h3 id='app.put.method'>app.put(path, callback [, callback ...])</h3>
 
 Routes HTTP PUT requests to the specified path with the specified callback functions.
-For more information, see the [routing guide](/guide/routing.html).
 
-You can provide multiple callback functions that behave just like middleware,
-except that these callbacks can invoke `next('route')` to bypass the
-remaining route callback(s). You can use this mechanism to impose pre-conditions on
-a route, then pass control to subsequent routes if there's no reason to proceed with
-the current route.
+{% include api/en/4x/routing-args.html %}
+
+#### Example
 
 ```js
 app.put('/', function (req, res) {

--- a/_includes/api/en/4x/app-use.md
+++ b/_includes/api/en/4x/app-use.md
@@ -1,32 +1,21 @@
-<h3 id='app.use'>app.use([path,] function [, function...])</h3>
+<h3 id='app.use'>app.use([path,] callback [, callback...])</h3>
 
-Mounts the specified [middleware](/guide/using-middleware.html) function or functions at the specified path.
-If `path` is not specified, it defaults to "/".
+Mounts the specified [middleware](/guide/using-middleware.html) function or functions
+at the specified path:
+the middleware function is executed when the base of the requested path matches `path`.
 
-<div class="doc-box doc-info" markdown="1">
-  A route will match any path that follows its path immediately with a "<code>/</code>".
-  For example: <code>app.use('/apple', ...)</code> will match "/apple", "/apple/images",
-  "/apple/images/news", and so on.
-</div>
+{% include api/en/4x/routing-args.html %}
 
-Note that `req.originalUrl` in a middleware function is a combination of `req.baseUrl` and `req.path`, as shown in the following example.
+#### Description
 
-```js
-app.use('/admin', function(req, res, next) {
-  // GET 'http://www.example.com/admin/new'
-  console.log(req.originalUrl); // '/admin/new'
-  console.log(req.baseUrl); // '/admin'
-  console.log(req.path); // '/new'
-  next();
-});
-```
+A route will match any path that follows its path immediately with a "`/`".
+For example: `app.use('/apple', ...)` will match "/apple", "/apple/images",
+"/apple/images/news", and so on.
 
-Mounting a middleware function at a `path` will cause the middleware function to be executed whenever the base of the requested path matches the `path`.
-
-Since `path` defaults to "/", middleware mounted without a path will be executed for every request to the app.
+Since `path` defaults to "/", middleware mounted without a path will be executed for every request to the app.  
+For example, this middleware function will be executed for _every_ request to the app:
 
 ```js
-// this middleware will be executed for every request to the app
 app.use(function (req, res, next) {
   console.log('Time: %d', Date.now());
   next();
@@ -58,11 +47,23 @@ app.get('/', function (req, res) {
 });
 ```
 
-`path` can be a string representing a path, a path pattern, a regular expression to match paths,
-or an array of combinations thereof.
+**Error-handling middleware**
 
+Error-handling middleware always takes _four_ arguments.  You must provide four arguments to identify it as an error-handling middleware function. Even if you don't need to use the `next` object, you must specify it to maintain the signature. Otherwise, the `next` object will be interpreted as regular middleware and will fail to handle errors. For details about error-handling middleware, see: [Error handling](/{{ page.lang }}/guide/error-handling.html).
 
-The following table provides some simple examples of mounting middleware.
+Define error-handling middleware functions in the same way as other middleware functions, except with four arguments instead of three, specifically with the signature `(err, req, res, next)`):
+
+```js
+app.use(function(err, req, res, next) {
+  console.error(err.stack);
+  res.status(500).send('Something broke!');
+});
+```
+
+#### Path examples
+
+The following table provides some simple examples of valid `path` values for
+mounting middleware.
 
 <div class="table-scroller">
 <table class="doctable" border="1">
@@ -96,20 +97,17 @@ The following table provides some simple examples of mounting middleware.
 </code></pre>
 
 This will match paths starting with `/abcd`, `/abbcd`, `/abbbbbcd`, and so on:
-<pre><code class="language-js">
-app.use('/ab+cd', function (req, res, next) {
+<pre><code class="language-js">app.use('/ab+cd', function (req, res, next) {
   next();
 });</code></pre>
 
 This will match paths starting with `/abcd`, `/abxcd`, `/abFOOcd`, `/abbArcd`, and so on:
-<pre><code class="language-js">
-app.use('/ab\*cd', function (req, res, next) {
+<pre><code class="language-js">app.use('/ab\*cd', function (req, res, next) {
   next();
 });</code></pre>
 
 This will match paths starting with `/ad` and `/abcd`:
-<pre><code class="language-js">
-app.use('/a(bc)?d', function (req, res, next) {
+<pre><code class="language-js">app.use('/a(bc)?d', function (req, res, next) {
   next();
 });</code></pre>
       </td>
@@ -140,10 +138,11 @@ app.use('/a(bc)?d', function (req, res, next) {
 </table>
 </div>
 
-`function` can be a middleware function, a series of middleware functions,
-an array of middleware functions, or a combination of all of them.
-Since [router](#router) and [app](#application) implement the middleware interface, you can use them
-as you would any other middleware function.
+#### Middleware callback function examples
+
+The following table provides some simple examples of middleware functions that
+can be used as the `callback` argument to `app.use()`, `app.METHOD()`, and `app.all()`.
+Even though the examples are for `app.use()`, they are also valid for `app.use()`, `app.METHOD()`, and `app.all()`.
 
 <table class="doctable" border="1">
 
@@ -245,17 +244,6 @@ app.use(mw1, [mw2, r1, r2], subApp);
   </tbody>
 
 </table>
-
-Error-handling middleware always takes _four_ arguments.  You must provide four arguments to identify it as an error-handling middleware function. Even if you don't need to use the `next` object, you must specify it to maintain the signature. Otherwise, the `next` object will be interpreted as regular middleware and will fail to handle errors. For details about error-handling middleware, see: [Error handling](/{{ page.lang }}/guide/error-handling.html).
-
-Define error-handling middleware functions in the same way as other middleware functions, except with four arguments instead of three, specifically with the signature `(err, req, res, next)`):
-
-```js
-app.use(function(err, req, res, next) {
-  console.error(err.stack);
-  res.status(500).send('Something broke!');
-});
-```
 
 Following are some examples of using the [express.static](/guide/using-middleware.html#middleware.built-in)
 middleware in an Express app.

--- a/_includes/api/en/4x/req-originalUrl.md
+++ b/_includes/api/en/4x/req-originalUrl.md
@@ -13,3 +13,14 @@ the "mounting" feature of [app.use()](#app.use) will rewrite `req.url` to strip 
 req.originalUrl
 // => "/search?q=something"
 ```
+
+In a middleware function, `req.originalUrl` is a combination of `req.baseUrl` and `req.path`, as shown in the following example.
+
+```js
+app.use('/admin', function(req, res, next) {  // GET 'http://www.example.com/admin/new'
+  console.log(req.originalUrl); // '/admin/new'
+  console.log(req.baseUrl); // '/admin'
+  console.log(req.path); // '/new'
+  next();
+});
+```

--- a/_includes/api/en/4x/router-route.md
+++ b/_includes/api/en/4x/router-route.md
@@ -2,7 +2,7 @@
 
 Returns an instance of a single route which you can then use to handle HTTP verbs
 with optional middleware. Use `router.route()` to avoid duplicate route naming and
-thus typo errors.
+thus typing errors.
 
 Building on the `router.param()` example above, the following code shows how to use
 `router.route()` to specify various HTTP method handlers.

--- a/_includes/api/en/4x/routing-args.html
+++ b/_includes/api/en/4x/routing-args.html
@@ -1,0 +1,49 @@
+<h4> Arguments</h4>
+
+<table class="doctable" border="1" style="padding-left: 20px;">
+<tr>
+<th>Argument </th>
+<th> Description </th>
+<th style="width: 100px;"> Default </th>
+</tr>
+
+<tr>
+<td><code>path</code></td>
+<td>
+The path for which the middleware function is invoked; can be any of:
+<ul>
+<li>A string representing a path.</li>
+<li>A path pattern.</li>
+<li></li>A regular expression pattern to match paths.</li>
+<li>An array of combinations of any of the above.</li>
+</ul>
+
+For examples, see <a href="#path-examples">Path examples</a>.
+</td>
+<td>'/' (root path)</td>
+</tr>
+
+<tr>
+<td> <code>callback</code></td>
+<td>
+Callback functions; can be:
+<ul>
+<li>A middleware function.</li>
+<li>A series of middleware functions (separated by commas).</li>
+<li>An array of middleware functions.</li>
+<li>A combination of all of the above.</li>
+</ul>
+<p>
+You can provide multiple callback functions that behave just like middleware, except
+that these callbacks can invoke <code>next('route')</code> to bypass
+the remaining route callback(s). You can use this mechanism to impose pre-conditions
+on a route, then pass control to subsequent routes if there is no reason to proceed with the current route.
+</p><p>
+Since <a href="#router">router</a> and <a href="#application">app</a> implement the middleware interface,
+you can use them as you would any other middleware function.
+</p><p>
+For examples, see <a href="#middleware-callback-function-examples">Middleware callback function examples</a>.
+</p>
+</td>
+<td> None </td>
+</tr></table>


### PR DESCRIPTION
This addresses #630, related issues, and some other minor issues.

First, I have to apologize for leaving #630 unaddressed for so long.  Especially when the resolution was pretty straightforward and the necessary info was in the issue.  I guess it just fell off my radar.

Second, I want to thank @aks- for putting it back on my radar by opening #697.  Unfortunately, I think this PR will obviate that one, although if you still want to add some more examples of (realistic) regexes, you could probably do that.

Anyway, here's what's in this PR:
- Consolidate description of path and callback arguments into an "include" and then duplicate it everywhere appropriate (app.METHOD, app.get, app.put, app.post, and app.all) via `{% include api/en/4x/routing-args.html %}`  I also included a paragraph about providing multiple callback functions that was duplicated in a number of places.
- Added subsection headers for the examples in app.use for "Path examples" and "Middleware callback function examples" and linked to these from all the applicable sections 
- (essentially unrelated) Move note about `req.orignalUrl` from "app.use" section (where it was a bit out of place) to "req.orginalUrl" section.

One minor question: Since the method signatures (in the headings) have `callback [, callback ...])
`, I wonder if we need to specify "A series of middleware functions (separated by commas)." since that's implied by the signature? Maybe it's clear either way? Or perhaps we should just have `callback(s)` in the signature?  

Finally, I _think_ the description of the `path` & `callback` arguments is also applicable to `router.all`, `router.METHOD`, and `router.use`, but I wasn't 100% sure.  If so, I can land that in a separate PR, as this one has enough in it already.  Having the pertinent info in an include will make it very simple.
