### PR TITLE
Add :target style to all elements in the API doc

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -185,8 +185,10 @@ a {
   padding-top: 40px;
 }
 
-#api-doc h3:target, #api-doc h4:target {
-  padding-top: 80px;
+#api-doc *:target{
+ margin-top: -80px;
+ padding-top: 80px;
+ z-index: -1;
 }
 
 .outlined-img {


### PR DESCRIPTION
This adds the target padding to all the elements in the API doc area, as well as repositioning it back up to remove the created whitespace gap.

Proposed fix for #699 

/cc @crandmck @hacksparrow 
