### PR TITLE
Update generator documentation to 4.14.0

### DIFF
--- a/de/starter/generator.md
+++ b/de/starter/generator.md
@@ -28,10 +28,12 @@ $ express -h
   Options:
 
     -h, --help          output usage information
-    -V, --version       output the version number
-    -e, --ejs           add ejs engine support (defaults to jade)
+        --version       output the version number
+    -e, --ejs           add ejs engine support
         --hbs           add handlebars engine support
+        --pug           add pug engine support
     -H, --hogan         add hogan.js engine support
+    -v, --view &lt;engine&gt; add view &lt;engine&gt; support (ejs|hbs|hjs|jade|pug|twig|vash) (defaults to jade)
     -c, --css &lt;engine&gt;  add stylesheet &lt;engine&gt; support (less|stylus|compass|sass) (defaults to plain css)
         --git           add .gitignore
     -f, --force         force on non-empty directory
@@ -42,7 +44,7 @@ Im folgenden Beispiel wird eine Express-Anwendung mit dem Namen _myapp_ im aktue
 
 <pre>
 <code class="language-sh" translate="no">
-$ express myapp
+$ express --view=jade myapp
 
    create : myapp
    create : myapp/package.json

--- a/en/starter/generator.md
+++ b/en/starter/generator.md
@@ -26,10 +26,12 @@ $ express -h
   Options:
 
     -h, --help          output usage information
-    -V, --version       output the version number
-    -e, --ejs           add ejs engine support (defaults to jade)
+        --version       output the version number
+    -e, --ejs           add ejs engine support
         --hbs           add handlebars engine support
+        --pug           add pug engine support
     -H, --hogan         add hogan.js engine support
+    -v, --view <engine> add view <engine> support (ejs|hbs|hjs|jade|pug|twig|vash) (defaults to jade)
     -c, --css <engine>  add stylesheet <engine> support (less|stylus|compass|sass) (defaults to plain css)
         --git           add .gitignore
     -f, --force         force on non-empty directory
@@ -38,7 +40,7 @@ $ express -h
 For example, the following creates an Express app named _myapp_ in the current working directory:
 
 ```sh
-$ express myapp
+$ express --view=jade myapp
 
    create : myapp
    create : myapp/package.json

--- a/es/starter/generator.md
+++ b/es/starter/generator.md
@@ -28,10 +28,12 @@ $ express -h
   Options:
 
     -h, --help          output usage information
-    -V, --version       output the version number
-    -e, --ejs           add ejs engine support (defaults to jade)
+        --version       output the version number
+    -e, --ejs           add ejs engine support
         --hbs           add handlebars engine support
+        --pug           add pug engine support
     -H, --hogan         add hogan.js engine support
+    -v, --view &lt;engine&gt; add view &lt;engine&gt; support (ejs|hbs|hjs|jade|pug|twig|vash) (defaults to jade)
     -c, --css &lt;engine&gt;  add stylesheet &lt;engine&gt; support (less|stylus|compass|sass) (defaults to plain css)
         --git           add .gitignore
     -f, --force         force on non-empty directory
@@ -42,7 +44,7 @@ Por ejemplo, el código siguiente crea una aplicación Express denominada _myapp
 
 <pre>
 <code class="language-sh" translate="no">
-$ express myapp
+$ express --view=jade myapp
 
    create : myapp
    create : myapp/package.json

--- a/fr/starter/generator.md
+++ b/fr/starter/generator.md
@@ -28,10 +28,12 @@ $ express -h
   Options:
 
     -h, --help          output usage information
-    -V, --version       output the version number
-    -e, --ejs           add ejs engine support (defaults to jade)
+        --version       output the version number
+    -e, --ejs           add ejs engine support
         --hbs           add handlebars engine support
+        --pug           add pug engine support
     -H, --hogan         add hogan.js engine support
+    -v, --view &lt;engine&gt; add view &lt;engine&gt; support (ejs|hbs|hjs|jade|pug|twig|vash) (defaults to jade)
     -c, --css &lt;engine&gt;  add stylesheet &lt;engine&gt; support (less|stylus|compass|sass) (defaults to plain css)
         --git           add .gitignore
     -f, --force         force on non-empty directory
@@ -42,7 +44,7 @@ Par exemple, ce qui suit crée une application Express nommée _myapp_ dans le r
 
 <pre>
 <code class="language-sh" translate="no">
-$ express myapp
+$ express --view=jade myapp
 
    create : myapp
    create : myapp/package.json

--- a/it/starter/generator.md
+++ b/it/starter/generator.md
@@ -28,10 +28,12 @@ $ express -h
   Options:
 
     -h, --help          output usage information
-    -V, --version       output the version number
-    -e, --ejs           add ejs engine support (defaults to jade)
+        --version       output the version number
+    -e, --ejs           add ejs engine support
         --hbs           add handlebars engine support
+        --pug           add pug engine support
     -H, --hogan         add hogan.js engine support
+    -v, --view &lt;engine&gt; add view &lt;engine&gt; support (ejs|hbs|hjs|jade|pug|twig|vash) (defaults to jade)
     -c, --css &lt;engine&gt;  add stylesheet &lt;engine&gt; support (less|stylus|compass|sass) (defaults to plain css)
         --git           add .gitignore
     -f, --force         force on non-empty directory
@@ -42,7 +44,7 @@ Ad esempio, quanto segue crea un'applicazione Express denominata _myapp_ nella d
 
 <pre>
 <code class="language-sh" translate="no">
-$ express myapp
+$ express --view=jade myapp
 
    create : myapp
    create : myapp/package.json

--- a/ja/starter/generator.md
+++ b/ja/starter/generator.md
@@ -28,10 +28,12 @@ $ express -h
   Options:
 
     -h, --help          output usage information
-    -V, --version       output the version number
-    -e, --ejs           add ejs engine support (defaults to jade)
+        --version       output the version number
+    -e, --ejs           add ejs engine support
         --hbs           add handlebars engine support
+        --pug           add pug engine support
     -H, --hogan         add hogan.js engine support
+    -v, --view &lt;engine&gt; add view &lt;engine&gt; support (ejs|hbs|hjs|jade|pug|twig|vash) (defaults to jade)
     -c, --css &lt;engine&gt;  add stylesheet &lt;engine&gt; support (less|stylus|compass|sass) (defaults to plain css)
         --git           add .gitignore
     -f, --force         force on non-empty directory
@@ -42,7 +44,7 @@ $ express -h
 
 <pre>
 <code class="language-sh" translate="no">
-$ express myapp
+$ express --view=jade myapp
 
    create : myapp
    create : myapp/package.json

--- a/ko/starter/generator.md
+++ b/ko/starter/generator.md
@@ -28,10 +28,12 @@ $ express -h
   Options:
 
     -h, --help          output usage information
-    -V, --version       output the version number
-    -e, --ejs           add ejs engine support (defaults to jade)
+        --version       output the version number
+    -e, --ejs           add ejs engine support
         --hbs           add handlebars engine support
+        --pug           add pug engine support
     -H, --hogan         add hogan.js engine support
+    -v, --view &lt;engine&gt; add view &lt;engine&gt; support (ejs|hbs|hjs|jade|pug|twig|vash) (defaults to jade)
     -c, --css &lt;engine&gt;  add stylesheet &lt;engine&gt; support (less|stylus|compass|sass) (defaults to plain css)
         --git           add .gitignore
     -f, --force         force on non-empty directory
@@ -42,7 +44,7 @@ $ express -h
 
 <pre>
 <code class="language-sh" translate="no">
-$ express myapp
+$ express --view=jade myapp
 
    create : myapp
    create : myapp/package.json

--- a/pt-br/starter/generator.md
+++ b/pt-br/starter/generator.md
@@ -29,10 +29,12 @@ $ express -h
   Options:
 
     -h, --help          output usage information
-    -V, --version       output the version number
-    -e, --ejs           add ejs engine support (defaults to jade)
+        --version       output the version number
+    -e, --ejs           add ejs engine support
         --hbs           add handlebars engine support
+        --pug           add pug engine support
     -H, --hogan         add hogan.js engine support
+    -v, --view &lt;engine&gt; add view &lt;engine&gt; support (ejs|hbs|hjs|jade|pug|twig|vash) (defaults to jade)
     -c, --css &lt;engine&gt;  add stylesheet &lt;engine&gt; support (less|stylus|compass|sass) (defaults to plain css)
         --git           add .gitignore
     -f, --force         force on non-empty directory
@@ -44,7 +46,7 @@ no diretório atualmente em funcionamento:
 
 <pre>
 <code class="language-sh" translate="no">
-$ express myapp
+$ express --view=jade myapp
 
    create : myapp
    create : myapp/package.json

--- a/ru/starter/generator.md
+++ b/ru/starter/generator.md
@@ -28,10 +28,12 @@ $ express -h
   Options:
 
     -h, --help          output usage information
-    -V, --version       output the version number
-    -e, --ejs           add ejs engine support (defaults to jade)
+        --version       output the version number
+    -e, --ejs           add ejs engine support
         --hbs           add handlebars engine support
+        --pug           add pug engine support
     -H, --hogan         add hogan.js engine support
+    -v, --view &lt;engine&gt; add view &lt;engine&gt; support (ejs|hbs|hjs|jade|pug|twig|vash) (defaults to jade)
     -c, --css &lt;engine&gt;  add stylesheet &lt;engine&gt; support (less|stylus|compass|sass) (defaults to plain css)
         --git           add .gitignore
     -f, --force         force on non-empty directory
@@ -42,7 +44,7 @@ $ express -h
 
 <pre>
 <code class="language-sh" translate="no">
-$ express myapp
+$ express --view=jade myapp
 
    create : myapp
    create : myapp/package.json

--- a/sk/starter/generator.md
+++ b/sk/starter/generator.md
@@ -32,10 +32,12 @@ $ express -h
   Options:
 
     -h, --help          output usage information
-    -V, --version       output the version number
-    -e, --ejs           add ejs engine support (defaults to jade)
+        --version       output the version number
+    -e, --ejs           add ejs engine support
         --hbs           add handlebars engine support
+        --pug           add pug engine support
     -H, --hogan         add hogan.js engine support
+    -v, --view &lt;engine&gt; add view &lt;engine&gt; support (ejs|hbs|hjs|jade|pug|twig|vash) (defaults to jade)
     -c, --css &lt;engine&gt;  add stylesheet &lt;engine&gt; support (less|stylus|compass|sass) (defaults to plain css)
         --git           add .gitignore
     -f, --force         force on non-empty directory
@@ -46,7 +48,7 @@ Nasledujúci príkaz vytvorí v aktuálnom priečinku Express aplikáciu s názv
 
 <pre>
 <code class="language-sh" translate="no">
-$ express myapp
+$ express --view=jade myapp
 
    create : myapp
    create : myapp/package.json

--- a/uk/starter/generator.md
+++ b/uk/starter/generator.md
@@ -25,10 +25,12 @@ $ express -h
   Options:
 
     -h, --help          output usage information
-    -V, --version       output the version number
-    -e, --ejs           add ejs engine support (defaults to jade)
+        --version       output the version number
+    -e, --ejs           add ejs engine support
         --hbs           add handlebars engine support
+        --pug           add pug engine support
     -H, --hogan         add hogan.js engine support
+    -v, --view &lt;engine&gt; add view &lt;engine&gt; support (ejs|hbs|hjs|jade|pug|twig|vash) (defaults to jade)
     -c, --css &lt;engine&gt;  add stylesheet &lt;engine&gt; support (less|stylus|compass|sass) (defaults to plain css)
         --git           add .gitignore
     -f, --force         force on non-empty directory
@@ -37,7 +39,7 @@ $ express -h
 В наступному прикладі створюється каркас застосунку Express з іменем _myapp_ в поточній директорії:
 
 <pre><code class="language-sh" translate="no">
-$ express myapp
+$ express --view=jade myapp
 
    create : myapp
    create : myapp/package.json

--- a/uz/starter/generator.md
+++ b/uz/starter/generator.md
@@ -25,18 +25,21 @@ $ express -h
   Options:
 
     -h, --help          output usage information
-    -V, --version       output the version number
-    -e, --ejs           add ejs engine support (defaults to jade)
+        --version       output the version number
+    -e, --ejs           add ejs engine support
         --hbs           add handlebars engine support
+        --pug           add pug engine support
     -H, --hogan         add hogan.js engine support
-    -c, --css &lt;engine>  add stylesheet &lt;engine> support (less|stylus|compass) (defaults to plain css)
+    -v, --view &lt;engine&gt; add view &lt;engine&gt; support (ejs|hbs|hjs|jade|pug|twig|vash) (defaults to jade)
+    -c, --css &lt;engine&gt;  add stylesheet &lt;engine&gt; support (less|stylus|compass|sass) (defaults to plain css)
+        --git           add .gitignore
     -f, --force         force on non-empty directory
 </code></pre>
 
 Masalan, quyidagi buyruq _myapp_ nomi dasturni yaratadi.
 
 <pre><code class="language-sh" translate="no">
-$ express myapp
+$ express --view=jade myapp
 
    create : myapp
    create : myapp/package.json

--- a/zh-cn/starter/generator.md
+++ b/zh-cn/starter/generator.md
@@ -28,10 +28,12 @@ $ express -h
   Options:
 
     -h, --help          output usage information
-    -V, --version       output the version number
-    -e, --ejs           add ejs engine support (defaults to jade)
+        --version       output the version number
+    -e, --ejs           add ejs engine support
         --hbs           add handlebars engine support
+        --pug           add pug engine support
     -H, --hogan         add hogan.js engine support
+    -v, --view &lt;engine&gt; add view &lt;engine&gt; support (ejs|hbs|hjs|jade|pug|twig|vash) (defaults to jade)
     -c, --css &lt;engine&gt;  add stylesheet &lt;engine&gt; support (less|stylus|compass|sass) (defaults to plain css)
         --git           add .gitignore
     -f, --force         force on non-empty directory
@@ -42,7 +44,7 @@ $ express -h
 
 <pre>
 <code class="language-sh" translate="no">
-$ express myapp
+$ express --view=jade myapp
 
    create : myapp
    create : myapp/package.json

--- a/zh-tw/starter/generator.md
+++ b/zh-tw/starter/generator.md
@@ -28,10 +28,12 @@ $ express -h
   Options:
 
     -h, --help          output usage information
-    -V, --version       output the version number
-    -e, --ejs           add ejs engine support (defaults to jade)
+        --version       output the version number
+    -e, --ejs           add ejs engine support
         --hbs           add handlebars engine support
+        --pug           add pug engine support
     -H, --hogan         add hogan.js engine support
+    -v, --view &lt;engine&gt; add view &lt;engine&gt; support (ejs|hbs|hjs|jade|pug|twig|vash) (defaults to jade)
     -c, --css &lt;engine&gt;  add stylesheet &lt;engine&gt; support (less|stylus|compass|sass) (defaults to plain css)
         --git           add .gitignore
     -f, --force         force on non-empty directory
@@ -42,7 +44,7 @@ $ express -h
 
 <pre>
 <code class="language-sh" translate="no">
-$ express myapp
+$ express --view=jade myapp
 
    create : myapp
    create : myapp/package.json


### PR DESCRIPTION
This pull request simply updates all the generator documentation to reflect the changes in express-generator version 4.14.0. It does _not_ change the view engine away from jade, simply updates the commands to work the same way it does today. There is a much more comprehensive PR #717 that is changing the views from jade to pug. If that PR is rebased on top of these changes, the generator command can simply be updated from `--view=jade` to `--view=pug`.