### PR TITLE
Add tracing documentation

### DIFF
--- a/_includes/api/en/4x/app-instrument.md
+++ b/_includes/api/en/4x/app-instrument.md
@@ -1,0 +1,22 @@
+<h3 id='app.instrument'>app.instrument(tracer)</h3>
+
+Add a tracer to the application object. This tracer will be activated each time
+the `trace` method of a response is called.
+
+A tracer is a function which takes an options object as argument. It has the
+following field:
+
+* `res`: Response that fired the tracing.
+* `req`: Request related to the response that fired the tracing.
+* `app`: Application object.
+* `event`: String sent by the response to name the event.
+* `date`: Date when the tracing occured.
+* `args`: Additional arguments provided by the tracing call.
+
+For example:
+
+```js
+app.instrument(function(options){
+  debug(options.event + ' ' + options.date + ' ' + options.argv[0]);
+});
+```

--- a/_includes/api/en/4x/app.md
+++ b/_includes/api/en/4x/app.md
@@ -83,6 +83,10 @@ The Express application object can be referred from the [request object](#req) a
 </section>
 
 <section markdown="1">
+  {% include api/en/4x/app-instrument.md %}
+</section>
+
+<section markdown="1">
   {% include api/en/4x/app-listen.md %}
 </section>
 

--- a/_includes/api/en/4x/res-trace.md
+++ b/_includes/api/en/4x/res-trace.md
@@ -1,0 +1,15 @@
+<h3 id='res.trace'>res.trace(event [, parameters])</h3>
+
+Fire all tracers instrumented at the application level.
+
+Optional parameters:
+
+- `event`, name of the event to send to tracers.
+- `parameters`, additional parameters to send to tracers.
+
+```js
+app.get('/', function(req, res){
+  res.trace('index:visited', 'my-parameter');
+  res.render('index');
+});
+```

--- a/_includes/api/en/4x/res.md
+++ b/_includes/api/en/4x/res.md
@@ -122,5 +122,9 @@ and supports all [built-in fields and methods](https://nodejs.org/api/http.html#
 </section>
 
 <section markdown="1">
+  {% include api/en/4x/res-trace.md %}
+</section>
+
+<section markdown="1">
   {% include api/en/4x/res-vary.md %}
 </section>


### PR DESCRIPTION
*Warning: before being merged, all changes included in the related PR should be validated  (expressjs/express#2437).*

This PR includes the following additions:

* `res.trace` documentation.
* `app.instrument` documentation.
* Tracing guide and examples.

Related to:  #729