### PR TITLE
Fix typo (`console.err()` => `console.error()`)

### DIFF
--- a/en/advanced/best-practice-performance.md
+++ b/en/advanced/best-practice-performance.md
@@ -49,7 +49,7 @@ If you are using Node.js 4.0+ or io.js 2.1.0+, you can use the `--trace-sync-io`
 
 ### Do logging correctly
 
-In general, there are two reasons for logging from your app: For debugging and for logging app activity (essentially, everything else). Using `console.log()` or `console.err()` to print log messages to the terminal is common practice in development. But [these functions are synchronous](https://nodejs.org/api/console.html#console_console_1) when the destination is a terminal or a file, so they are not suitable for production, unless you pipe the output to another program.
+In general, there are two reasons for logging from your app: For debugging and for logging app activity (essentially, everything else). Using `console.log()` or `console.error()` to print log messages to the terminal is common practice in development. But [these functions are synchronous](https://nodejs.org/api/console.html#console_console_1) when the destination is a terminal or a file, so they are not suitable for production, unless you pipe the output to another program.
 
 #### For debugging
 


### PR DESCRIPTION
Hey y'all, this is just a minor typo fix for the **Production best practices: performance and reliability** page (https://expressjs.com/en/advanced/best-practice-performance.html).