### PR TITLE
Fix logo anchor such that it is clickable again

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -81,7 +81,7 @@ strong, th {
 
 #homepage-rightpane {
   min-width: 500px;
-  padding: 25px 30px 0px 0px; 
+  padding: 25px 30px 0px 0px;
 }
 
 #homepage-rightpane iframe {
@@ -227,6 +227,7 @@ a {
   padding: 10px 25px;
   width: auto;
   border-left: none;
+  z-index: 1;
 }
 
 #logo .express {
@@ -812,7 +813,7 @@ h2 a {
   #homepage-leftpane {
     padding-top: 0px;
   }
-  
+
   #homepage-rightpane {
     padding-top: 0;
     padding-right: 0;


### PR DESCRIPTION
In this patch, the logo is assigned a z-index such that it can be used again to navigate to the homepage. Prior to this patch, the `div#navbar` was overlapping the logo, only allowing to the top border of the logo to be clickable.

Note that I am no expert in CSS and therefore I am not sure if this the _best_ solution. Let me know what you think 😬 