### PR TITLE
Fix error handing in a res.sendFile example

### DIFF
--- a/_includes/api/en/4x/res-sendFile.md
+++ b/_includes/api/en/4x/res-sendFile.md
@@ -46,10 +46,8 @@ app.get('/file/:name', function (req, res, next) {
   var fileName = req.params.name;
   res.sendFile(fileName, options, function (err) {
     if (err) {
-      console.log(err);
-      res.status(err.status).end();
-    }
-    else {
+      next(err);
+    } else {
       console.log('Sent:', fileName);
     }
   });


### PR DESCRIPTION
This is a possible way to fix #774 . The issue is that `err.status` may be `undefined`, and in newer versions of Node.js that will cause an error to be thrown. Since the example wasn't really trying to demonstrate doing anything of value with the error, I think it's better to show it being handed to `next()` to participate in the error handling pipeline of the app.