### PR TITLE
Update app.param example

### DIFF
--- a/_includes/api/en/4x/app-param.md
+++ b/_includes/api/en/4x/app-param.md
@@ -101,7 +101,7 @@ app.param(function(param, option) {
       next();
     }
     else {
-      res.sendStatus(403);
+      next('route');
     }
   }
 });
@@ -128,7 +128,7 @@ app.param(function(param, validator) {
       next();
     }
     else {
-      res.sendStatus(403);
+      next('route');
     }
   }
 });


### PR DESCRIPTION
Update example to continue route lookup on param validation failure to line up with default router paths behavior. Consider `route.get('/users/:id(\d+)', ...)` which when called as `/users/abc` wouldn't result in 403.

The reason for this edit is simple: I wasn't sure how to pass control to default 404 handler when param does not pass validation. 

I think it will help others to get started with params validation with less confusion.