### PR TITLE
Add `database` field to mysql connection section.

### DIFF
--- a/en/guide/database-integration.md
+++ b/en/guide/database-integration.md
@@ -170,10 +170,11 @@ $ npm install mysql
 ```js
 var mysql = require('mysql')
 var connection = mysql.createConnection({
-  host: 'localhost',
-  user: 'dbuser',
-  password: 's3kreee7'
-})
+  host     : 'localhost',
+  user     : 'dbuser',
+  password : 's3kreee7',
+  database : 'my_db'
+});
 
 connection.connect()
 


### PR DESCRIPTION
The `mysql.createConnection()` snippet only had connection information for `host`, `user`, and `password`, but should have a `database` field as well for comprehensiveness. This way the user knows the property name without having to do an additional Google search on the mysql module.