### PR TITLE
Add links to the API documentation for items in changelog

### DIFF
--- a/en/changelog/4x.md
+++ b/en/changelog/4x.md
@@ -35,7 +35,7 @@ The 4.14.0 minor release includes bug fixes, security update, performance improv
   </li>
 
   <li markdown="1" class="changelog-item">
-  `res.sendFile` now accepts two new options, `acceptRanges` and `cacheControl`.
+  The [`res.sendFile()` method](/{{ page.lang }}/4x/api.html#res.sendFile) now accepts two new options: `acceptRanges` and `cacheControl`.
 
   - `acceptRanges` (defaut is `true`), enables or disables accepting ranged requests. When disabled, the response does not send the `Accept-Ranges` header and ignores the contents of the `Range` request header.
 
@@ -45,15 +45,15 @@ The 4.14.0 minor release includes bug fixes, security update, performance improv
   </li>
 
   <li markdown="1" class="changelog-item">
-  `res.location` and `res.redirect` will now URL-encode the URL string, if it is not already encoded.
+  The [`res.location()` method](/{{ page.lang }}/4x/api.html#res.location) and [`res.redirect()` method](/{{ page.lang }}/4x/api.html#res.redirect) will now URL-encode the URL string, if it is not already encoded.
   </li>
 
   <li markdown="1" class="changelog-item">
-  The performance of `res.json` and `res.jsonp` methods has been improved in most cases.
+  The performance of the [`res.json()` method](/{{ page.lang }}/4x/api.html#res.json) and [`res.jsonp()` method](/{{ page.lang }}/4x/api.html#res.jsonp) have been improved in the common cases.
   </li>
 
   <li markdown="1" class="changelog-item">
-  The [jshttp/cookie module](https://www.npmjs.com/package/cookie) (in addition to a number of other improvements) now supports the `sameSite` option to let you specify the [SameSite cookie attribute](https://tools.ietf.org/html/draft-west-first-party-cookies-07).  NOTE: This attribute has not yet been fully standardized, may change in the future, and many clients may ignore it.
+  The [jshttp/cookie module](https://www.npmjs.com/package/cookie) (in addition to a number of other improvements) has been updated and now the [`res.cookie()` method](/{{ page.lang }}/4x/api.html#res.cookie) supports the `sameSite` option to let you specify the [SameSite cookie attribute](https://tools.ietf.org/html/draft-west-first-party-cookies-07).  NOTE: This attribute has not yet been fully standardized, may change in the future, and many clients may ignore it.
 
   The possible value for the `sameSite` option are:
 
@@ -72,7 +72,7 @@ The 4.14.0 minor release includes bug fixes, security update, performance improv
   </li>
 
   <li markdown="1" class="changelog-item">
-  The `req.range` options object now includes a `combine` option (`false` by default), which when `true`, combines overlapping and adjacent ranges and returns them as if they were specified that way in the header.
+  The [`req.range()` method](/{{ page.lang }}/4x/api.html#req.range) options object now supports a `combine` option (`false` by default), which when `true`, combines overlapping and adjacent ranges and returns them as if they were specified that way in the header.
   </li>
 </ul>
 


### PR DESCRIPTION
I went through the 4.x changelog and added links for the referenced API elements directly to the documentation for them.