### PR TITLE
Add Express 4.15 documentation

### DIFF
--- a/_includes/announcement/announcement-en.md
+++ b/_includes/announcement/announcement-en.md
@@ -1,8 +1,8 @@
 <ul>
   <li>
-    <p class="announcement-title">Express 4.14.0 is the current release.</p>
+    <p class="announcement-title">Express 4.15.0 is the current release.</p>
     <p markdown="1">
-     For more information on what was added in this release, see the [4.14.0 changelog](/{{ page.lang }}/changelog/4x.html#4.14.0).
+     For more information on what was added in this release, see the [4.15.0 changelog](/{{ page.lang }}/changelog/4x.html#4.15.0).
     </p>
   </li>
 </ul>

--- a/_includes/announcement/announcement-uz.md
+++ b/_includes/announcement/announcement-uz.md
@@ -1,8 +1,8 @@
 <ul>
   <li>
-    <p class="announcement-title"><time datetime="2016-06-16 19:00">16-iyun, 2016</time> Express 4.14.0 reliz qilindi</p>
+    <p class="announcement-title">Express 4.15.0 reliz qilindi</p>
     <p markdown="1">
-    Express 4.14.0 da ko'plab xatolar to'g'irlandi, xavfsizlikni ta'minlash uchun o'zgarishlar kiritildi, ishlash unumdorligi oshirildi va boshqa yangi imkoniyatlar qo'shildi. To'liq ma'lumot uchun [4.14.0 changelog](/{{ page.lang }}/changelog/4x.html#4.14.0).
+    Express 4.15.0 da ko'plab xatolar to'g'irlandi, xavfsizlikni ta'minlash uchun o'zgarishlar kiritildi, ishlash unumdorligi oshirildi va boshqa yangi imkoniyatlar qo'shildi. To'liq ma'lumot uchun [4.15.0 changelog](/en/changelog/4x.html#4.15.0).
     </p>
   </li>
 </ul>

--- a/en/changelog/4x.md
+++ b/en/changelog/4x.md
@@ -7,6 +7,31 @@ lang: en
 <div id="page-doc" markdown="1">
 # Release Change Log
 
+## 4.15.0 - Release date: 2017-03-01
+{: id="4.15.0"}
+
+The 4.15.0 minor release includes bug fixes, performance improvements, and other minor feature additions, including:
+
+<ul>
+  <li markdown="1" class="changelog-item">
+  Starting with this version, Express supports Node.js 7.x.
+  </li>
+
+  <li markdown="1" class="changelog-item">
+  The [`express.static()` middleware](/{{ page.lang }}/4x/api.html#express.static) and [`res.sendFile()` method](/{{ page.lang }}/4x/api.html#res.sendFile) now support the `If-Match` and `If-Unmodified-Since` request headers.
+  </li>
+
+  <li markdown="1" class="changelog-item">
+  Update to [jshttp/etag module](https://www.npmjs.com/package/etag) to generate the default ETags for responses which work when Node.js has [FIPS-compliant crypto enabled](https://nodejs.org/dist/latest/docs/api/cli.html#cli_enable_fips).
+  </li>
+
+  <li markdown="1" class="changelog-item">
+  Various auto-generated HTML responses like the default not found and error handlers will respond with complete HTML 5 documents and additional security headers.
+  </li>
+</ul>
+
+For a complete list of changes in this release, see [History.md](https://github.com/expressjs/express/blob/master/History.md#4150--2017-03-01).
+
 ## 4.14.1 - Release date: 2017-01-28
 {: id="4.14.1"}
 

--- a/en/guide/using-middleware.md
+++ b/en/guide/using-middleware.md
@@ -169,6 +169,31 @@ router.get('/user/:id', function (req, res, next) {
 app.use('/', router)
 ```
 
+To skip the rest of the router's middleware functions, call `next('router')`
+to pass control back out of the router instance.
+
+This example shows a middleware sub-stack that handles GET requests to the `/user/:id` path.
+
+```js
+var app = express()
+var router = express.Router()
+
+// predicate the router with a check and bail out when needed
+router.use(function (req, res, next) {
+  if (!req.headers['x-auth']) return next('router')
+  next()
+})
+
+router.get('/', function (req, res) {
+  res.send('hello, user!')
+})
+
+// use the router and 401 anything falling through
+app.use('/admin', router, function (req, res) {
+  res.sendStatus(401)
+})
+```
+
 <h2 id='middleware.error-handling'>Error-handling middleware</h2>
 
 <div class="doc-box doc-notice" markdown="1">

--- a/index.md
+++ b/index.md
@@ -42,8 +42,6 @@ redirect_from: "/en/index.html"
 
 </section>
 
-<!--
 <section id="announcements">
   {% include announcement/announcement-{{ page.lang }}.md %}
 </section>
--->


### PR DESCRIPTION
This is my initial stab at adding the Express 4.15 information for #791 . The `next('router')` documentation can use some more beefing up, but at the very least it's mentioned somewhere and we can probably land as we get it better updated.