### PR TITLE
proper spacing for footer contents 

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1029,6 +1029,11 @@ h2 a {
     color: #666 !important;
   }
 
+  footer {
+    margin: 60px 0px 30px 0px;
+    padding: 0 5%;
+  }
+
   #footer-content {
     display: flex;
     flex-wrap: wrap;
@@ -1048,7 +1053,7 @@ h2 a {
   }
 
   #doc-langs {
-    `font-size: 11px;
+    font-size: 11px;
   }
 
 }
@@ -1073,7 +1078,7 @@ h2 a {
   }
 
   footer {
-    margin-top: 14px 0 0 0;
+    margin-top: 14px;
   }
 
   #footer-content {


### PR DESCRIPTION
Added proper spacing for footer, for mobile and tablet views.

old mobile view: 
![selection_017](https://cloud.githubusercontent.com/assets/12847937/23577522/6cad3f94-00e7-11e7-8ef2-c6b8167b9ad4.png)

new mobile view:
![selection_018](https://cloud.githubusercontent.com/assets/12847937/23577523/72c5a0e2-00e7-11e7-8927-a40df185b7cc.png)
