### PR TITLE
Fix typo in app get function description

### DIFF
--- a/_includes/api/en/4x/app-get.md
+++ b/_includes/api/en/4x/app-get.md
@@ -1,6 +1,6 @@
 <h3 id='app.get'>app.get(name)</h3>
 
-Returns the value of `name` app setting, where `name` is one of strings in the
+Returns the value of `name` app setting, where `name` is one of the strings in the
 [app settings table](#app.settings.table). For example:
 
 ```js


### PR DESCRIPTION
Before, the description of the app.get() function read:
> Returns the value of name app setting, where name is one of strings in the app settings table.

Sentence was missing *the* to instead read:
> Returns the value of name app setting, where name is one of *the* strings in the app settings table.
