### PR TITLE
static: Fixed typo in API.

### DIFF
--- a/_includes/api/en/4x/express.static.md
+++ b/_includes/api/en/4x/express.static.md
@@ -14,7 +14,7 @@ The following table describes the properties of the `options` object.
 |---------------|-----------------------------------------------------------------------|-------------|-----------------|
 | `dotfiles`    | Determines how dotfiles (files or directories that begin with a dot ".") are treated.  <br/><br/>See [dotfiles](#dotfiles) below. | String | "ignore"|
 | `etag`        | Enable or disable etag generation <br/><br/>NOTE: `express.static` always sends weak ETags. | Boolean | `true` |
-| `extensions`  | Sets file extension fallbacks: If a file is not found, search for files with the specified extensions and serve the first one found. Example: `['html', 'htm']`.| Boolean | `false` |
+| `extensions`  | Sets file extension fallbacks: If a file is not found, search for files with the specified extensions and serve the first one found. Example: `['html', 'htm']`.| Mixed | `false` |
 | `fallthrough`  | Let client errors fall-through as unhandled requests, otherwise forward a client error. <br/><br/>See [fallthrough](#fallthrough) below.| Boolean | `true` |
 | `index`       | Sends the specified directory index file. Set to `false` to disable directory indexing. | Mixed | "index.html" |
 | `lastModified` | Set the `Last-Modified` header to the last modified date of the file on the OS. | Boolean | `true` |


### PR DESCRIPTION
options.extension is currently listed as type "Boolean", but "true" is not a valid value.
options.extension is only able to accept an array of strings or a false.
I have changed to "Mixed" to match options.index type.

I had thought to also add the extra information of valid options below, but I wanted communities instructions to if this is necessary or not.