### PR TITLE
npm 5.0 --save and --no-save changes

### DIFF
--- a/en/starter/installing.md
+++ b/en/starter/installing.md
@@ -34,12 +34,17 @@ Enter `app.js`, or whatever you want the name of the main file to be. If you wan
 Now install Express in the `myapp` directory and save it in the dependencies list. For example:
 
 ```sh
-$ npm install express 
+$ npm install express --save
 ```
 
-To install Express temporarily and not add it to the dependencies list, add the `--no-save` option:
+To install Express temporarily and not add it to the dependencies list:
 
-```sh
+1. omit the `--save` option for older version for npm.
+  ```sh
+$ npm install express
+```
+2. add the `--no-save` option for npm 5.0.0 and above.
+  ```sh
 $ npm install express --no-save
 ```
 

--- a/en/starter/installing.md
+++ b/en/starter/installing.md
@@ -39,13 +39,8 @@ $ npm install express --save
 
 To install Express temporarily and not add it to the dependencies list:
 
-If using npm 5.0.0 or later, use the --no-save option:
-  ```sh
+```sh
 $ npm install express --no-save
-```
-If using npm version prior to 5.0.0, omit the --save option:
-  ```sh
-$ npm install express
 ```
 
 <div class="doc-box doc-info" markdown="1">

--- a/en/starter/installing.md
+++ b/en/starter/installing.md
@@ -39,17 +39,16 @@ $ npm install express --save
 
 To install Express temporarily and not add it to the dependencies list:
 
-1. omit the `--save` option for older version for npm.
-  ```sh
-$ npm install express
-```
-2. add the `--no-save` option for npm 5.0.0 and above.
+If using npm 5.0.0 or later, use the --no-save option:
   ```sh
 $ npm install express --no-save
 ```
+If using npm version prior to 5.0.0, omit the --save option:
+  ```sh
+$ npm install express
+```
 
 <div class="doc-box doc-info" markdown="1">
-Node modules installed with the `--save` option are added to the `dependencies` list in the `package.json` file.
-Afterwards, running `npm install` in the `app` directory will automatically install modules in the dependencies list.
+By default with version npm 5.0+ npm install adds the module to the `dependencies` list in the `package.json` file; with earlier versions of npm, you must specify the `--save` option explicitly. Then, afterwards, running `npm install` in the app directory will automatically install modules in the dependencies list.
 </div>
 </div>

--- a/en/starter/installing.md
+++ b/en/starter/installing.md
@@ -34,13 +34,13 @@ Enter `app.js`, or whatever you want the name of the main file to be. If you wan
 Now install Express in the `myapp` directory and save it in the dependencies list. For example:
 
 ```sh
-$ npm install express --save
+$ npm install express 
 ```
 
-To install Express temporarily and not add it to the dependencies list, omit the `--save` option:
+To install Express temporarily and not add it to the dependencies list, add the `--no-save` option:
 
 ```sh
-$ npm install express
+$ npm install express --no-save
 ```
 
 <div class="doc-box doc-info" markdown="1">


### PR DESCRIPTION
npm now saves dependencies by default without needing to place --save flag. 

It requires --no-save flag to install temporarily without adding to dependencies.