### PR TITLE
Do not use req.params for setting state

### DIFF
--- a/_includes/api/en/4x/req-params.md
+++ b/_includes/api/en/4x/req-params.md
@@ -15,3 +15,7 @@ When you use a regular expression for the route definition, capture groups are p
 req.params[0]
 // => "javascripts/jquery.js"
 ```
+
+If you need to make changes to a key in `req.params`, use the [app.param](/{{ page.lang }}/4x/api.html#app.param) handler. Changes are applicable only to [parameters](/{{ page.lang }}/guide/routing.html#route-parameters) already defined in the route path.
+
+Any changes made to the `req.params` object in a middleware or route handler will be reset.


### PR DESCRIPTION
Ref:
- https://github.com/expressjs/express/issues/3341
- https://github.com/expressjs/expressjs.com/pull/820

@sehrope based on your feedback, I have updated the `req.params` doc to include a warning:

_"Any changes made to the `req.params` object and its keys may be overwritten by subsequent middleware in the stack. Do not use them for setting any state from your application code."_

@dougwilson @crandmck 