### PR TITLE
Embed a working example server on the "Hello World" tutorial

### DIFF
--- a/en/starter/hello-world.md
+++ b/en/starter/hello-world.md
@@ -9,14 +9,11 @@ redirect_from: "/starter/hello-world.html"
 # Hello world example
 
 <div class="doc-box doc-info" markdown="1">
-This is essentially going to be the simplest Express app you can create. It is a single file app &mdash; _not_ what you'd get if you use the [Express generator](/{{ page.lang }}/starter/generator.html), which creates the scaffolding for a full app with numerous JavaScript files, Jade templates, and sub-directories for various purposes.
+Embedded below is essentially the simplest Express app you can create. It is a single file app &mdash; _not_ what you'd get if you use the [Express generator](/{{ page.lang }}/starter/generator.html), which creates the scaffolding for a full app with numerous JavaScript files, Jade templates, and sub-directories for various purposes.
 </div>
 
-First create a directory named `myapp`, change to it and run `npm init`. Then install `express` as a dependency, as per the [installation guide](/{{ page.lang }}/starter/installing.html).
-
-In the `myapp` directory, create a file named `app.js` and add the following code:
-
-```js
+<script src="https://embed.runkit.com" data-element-id="hello-example" data-mode="endpoint" async defer></script>
+<div id="hello-example"><pre><code class="language-js">
 const express = require('express')
 const app = express()
 
@@ -27,10 +24,18 @@ app.get('/', function (req, res) {
 app.listen(3000, function () {
   console.log('Example app listening on port 3000!')
 })
-```
+</code></pre></div>
+
+The example above is actually a working server, go ahead and click on the URL. You'll get a response, with real time logs right here on the page, and any changes you make will be reflected in real time. Below, you'll find instructions for running the same app on your local machine.
 
 The app starts a server and listens on port 3000 for connections. The app responds with "Hello World!" for requests
 to the root URL (`/`) or _route_. For every other path, it will respond with a **404 Not Found**.
+
+### Running Locally
+
+First create a directory named `myapp`, change to it and run `npm init`. Then install `express` as a dependency, as per the [installation guide](/{{ page.lang }}/starter/installing.html).
+
+In the `myapp` directory, create a file named `app.js` and copy in the code from the example above.
 
 <div class="doc-box doc-notice" markdown="1">
 The `req` (request) and `res` (response) are the exact same objects that Node provides, so you can invoke

--- a/en/starter/hello-world.md
+++ b/en/starter/hello-world.md
@@ -26,10 +26,10 @@ app.listen(3000, function () {
 })
 </code></pre></div>
 
-The example above is actually a working server, go ahead and click on the URL. You'll get a response, with real time logs right here on the page, and any changes you make will be reflected in real time. Below, you'll find instructions for running the same app on your local machine.
-
-The app starts a server and listens on port 3000 for connections. The app responds with "Hello World!" for requests
+This app starts a server and listens on port 3000 for connections. The app responds with "Hello World!" for requests
 to the root URL (`/`) or _route_. For every other path, it will respond with a **404 Not Found**.
+
+The example above is actually a working server, go ahead and click on the URL. You'll get a response, with real time logs right here on the page, and any changes you make will be reflected in real time. This is powered by RunKit, which provides an interactive JavaScript playground connected to a complete Node environment that runs in your web browser. RunKit is a third-party service not affiliated with the Express project. Below, you'll find instructions for running the same app on your local machine.
 
 ### Running Locally
 

--- a/en/starter/hello-world.md
+++ b/en/starter/hello-world.md
@@ -29,7 +29,7 @@ app.listen(3000, function () {
 This app starts a server and listens on port 3000 for connections. The app responds with "Hello World!" for requests
 to the root URL (`/`) or _route_. For every other path, it will respond with a **404 Not Found**.
 
-The example above is actually a working server, go ahead and click on the URL. You'll get a response, with real time logs right here on the page, and any changes you make will be reflected in real time. This is powered by RunKit, which provides an interactive JavaScript playground connected to a complete Node environment that runs in your web browser. RunKit is a third-party service not affiliated with the Express project. Below, you'll find instructions for running the same app on your local machine.
+The example above is actually a working server, go ahead and click on the URL. You'll get a response, with real time logs right here on the page, and any changes you make will be reflected in real time. This is powered by [RunKit](https://runkit.com), which provides an interactive JavaScript playground connected to a complete Node environment that runs in your web browser. RunKit is a third-party service not affiliated with the Express project. Below, you'll find instructions for running the same app on your local machine.
 
 ### Running Locally
 


### PR DESCRIPTION
I'd like to propose adding a runnable embedded Express server into the documentation, to make it easy for people to play around with Express and see how it works. I've implemented a fairly small set of changes to the existing "Hello World" tutorial to make this possible, which ends up looking like this:

![screenshot 2017-06-20 11 44 29](https://user-images.githubusercontent.com/22065/27342474-4ea12c10-55ae-11e7-8010-f06329629aab.png)

Of course, I know that given this document needs to be translated, there are perhaps reasons to change the wording less, or perhaps people would prefer another approach or to discuss including on a different page.

This is powered by [RunKit](https://runkit.com) (which I helped create), which is creating a virtual server on demand behind the scenes. And if for whatever reason RunKit goes down, the example will fall back to just looking as it does now.