### PR TITLE
Resolve ambiguity in app.set documentation

### DIFF
--- a/_includes/api/en/4x/app-set.md
+++ b/_includes/api/en/4x/app-set.md
@@ -1,7 +1,8 @@
 <h3 id='app.set'>app.set(name, value)</h3>
 
-Assigns setting `name` to `value`, where `name` is one of the properties from
-the [app settings table](#app.settings.table).
+Assigns setting `name` to `value`. You may store any value that you want,
+but certain names can be used to configure the behavior of the server. These
+special names are listed in the [app settings table](#app.settings.table).
 
 Calling `app.set('foo', true)` for a Boolean property is the same as calling
 `app.enable('foo')`. Similarly, calling `app.set('foo', false)` for a Boolean


### PR DESCRIPTION
Resolves #839

---

I often use this to access these values in my middleware, via `req.app.get('hello')`. I think it could be worthwhile to mention that somewhere, but I didn't put it here. Does anyone agree that that's worth adding somewhere? If so, let me know where and I can update this PR or do a follow up PR.