### PR TITLE
Fix req.is() return value

### DIFF
--- a/_includes/api/en/4x/req-is.md
+++ b/_includes/api/en/4x/req-is.md
@@ -6,16 +6,14 @@ Returns `false` otherwise.
 
 ```js
 // With Content-Type: text/html; charset=utf-8
-req.is('html');
-req.is('text/html');
-req.is('text/*');
-// => 'html'
+req.is('html');       // => 'html'
+req.is('text/html');  // => 'text/html'
+req.is('text/*');     // => 'text/*'
 
 // When Content-Type is application/json
-req.is('json');
-req.is('application/json');
-req.is('application/*');
-// => 'html'
+req.is('json');              // => 'json'
+req.is('application/json');  // => 'application/json'
+req.is('application/*');     // => 'application/*'
 
 req.is('html');
 // => false

--- a/_includes/api/en/4x/req-is.md
+++ b/_includes/api/en/4x/req-is.md
@@ -1,6 +1,6 @@
 <h3 id='req.is'>req.is(type)</h3>
 
-Returns `true` if the incoming request's "Content-Type" HTTP header field
+Returns the matching content type if the incoming request's "Content-Type" HTTP header field
 matches the MIME type specified by the `type` parameter.
 Returns `false` otherwise.
 
@@ -9,13 +9,13 @@ Returns `false` otherwise.
 req.is('html');
 req.is('text/html');
 req.is('text/*');
-// => true
+// => 'html'
 
 // When Content-Type is application/json
 req.is('json');
 req.is('application/json');
 req.is('application/*');
-// => true
+// => 'html'
 
 req.is('html');
 // => false


### PR DESCRIPTION
The type-is docs say the return value is `string | false`. When a matching content type is found, that is the value returned, not a Boolean `true`