### PR TITLE
res.locals edit

### DIFF
--- a/_includes/api/en/4x/res-locals.md
+++ b/_includes/api/en/4x/res-locals.md
@@ -7,6 +7,8 @@ this property is identical to [app.locals](#app.locals).
 This property is useful for exposing request-level information such as the request path name,
 authenticated user, user settings, and so on.
 
+Keep in mind that this property takes immediate precedent over [app.locals](#app.locals) during the request/response cycle.
+
 ```js
 app.use(function(req, res, next){
   res.locals.user = req.user;

--- a/_includes/api/en/4x/res-locals.md
+++ b/_includes/api/en/4x/res-locals.md
@@ -7,7 +7,7 @@ this property is identical to [app.locals](#app.locals).
 This property is useful for exposing request-level information such as the request path name,
 authenticated user, user settings, and so on.
 
-Keep in mind that this property takes immediate precedent over `app.locals` during the request/response cycle.
+Note: a `res.locals` object takes immediate precedent over `app.locals` during the request/response cycle.
 
 ```js
 app.use(function(req, res, next){

--- a/_includes/api/en/4x/res-locals.md
+++ b/_includes/api/en/4x/res-locals.md
@@ -7,7 +7,7 @@ this property is identical to [app.locals](#app.locals).
 This property is useful for exposing request-level information such as the request path name,
 authenticated user, user settings, and so on.
 
-Keep in mind that this property takes immediate precedent over [app.locals](#app.locals) during the request/response cycle.
+Keep in mind that this property takes immediate precedent over `app.locals` during the request/response cycle.
 
 ```js
 app.use(function(req, res, next){


### PR DESCRIPTION
- I wasn't sure if this is entirely necessary for most, but I wanted to add a note explicitly noting that res.locals takes precedent over app.locals. 
- This might be too much detail, but I thought it might help understanding the use of both app.locals and res.locals. 