### PR TITLE
Mention that req.params are being URI-decoded

### DIFF
--- a/_includes/api/en/4x/req-params.md
+++ b/_includes/api/en/4x/req-params.md
@@ -19,3 +19,7 @@ req.params[0]
 If you need to make changes to a key in `req.params`, use the [app.param](/{{ page.lang }}/4x/api.html#app.param) handler. Changes are applicable only to [parameters](/{{ page.lang }}/guide/routing.html#route-parameters) already defined in the route path.
 
 Any changes made to the `req.params` object in a middleware or route handler will be reset.
+
+<div class="doc-box doc-info" markdown="1">
+NOTE: Express automatically decodes the values in `req.params` (using `decodeURIComponent`).
+</div>


### PR DESCRIPTION
From looking at the [source code](https://github.com/expressjs/express/blob/9722202df964bfbfc0f579e4baeb5a4e1b43b344/lib/router/layer.js#L110) and doing some testing I saw that req.params values are being URI-decoded via `decodeURIComponent`.
I've tested for paths with regular parameters, paths containing wild card and regular expression paths.
As far as I can tell there is no case where they aren't being decoded. Am I correct?
I think this should be mentioned in the documentation since it is not necessarily obvious.
In [Play framework for example](https://www.playframework.com/documentation/2.6.x/ScalaRouting#The-URI-pattern) they are decoded in some cases but not in others and in either case it is explicitly stated.