### PR TITLE
correct docs when `trust proxy` is set to a number of hops

### DIFF
--- a/en/guide/behind-proxies.md
+++ b/en/guide/behind-proxies.md
@@ -48,7 +48,7 @@ When specified, the IP addresses or the subnets are excluded from the address de
     <tr>
       <td>Number</td>
 <td markdown="1">
-Trust the `n`th hop from the front-facing proxy server as the client.
+Trust the `n`th hop from the express application server.
 </td>
     </tr>
     <tr>


### PR DESCRIPTION
Express uses proxy-addr to parse the `X-Forwarded-For` header. It parses from the socket address out towards the client which isn't reflected in the express docs.

```js
> const proxyaddr = require('proxy-addr');
undefined
> const req = { connection: { remoteAddress: '1.1.1.1' }, headers: { 'x-forwarded-for': '2.2.2.2, 3.3.3.3, 4.4.4.4' } };
undefined
> proxyaddr(req, (addr, i) => i < 0);
'1.1.1.1'
> proxyaddr(req, (addr, i) => i < 1);
'4.4.4.4'
> proxyaddr(req, (addr, i) => i < 2);
'3.3.3.3'
> proxyaddr(req, (addr, i) => i < 3);
'2.2.2.2'
> proxyaddr(req, (addr, i) => i < 4);
'2.2.2.2'
```