### PR TITLE
fix load mixed content when https

### DIFF
--- a/_includes/footer/footer-de.html
+++ b/_includes/footer/footer-de.html
@@ -23,13 +23,13 @@
 <footer>
     <div id="footer-content">
         <div id="github">
-            <iframe src="http://ghbtns.com/github-btn.html?user=expressjs&amp;repo=express&amp;type=watch&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe>
+            <iframe src="//ghbtns.com/github-btn.html?user=expressjs&amp;repo=express&amp;type=watch&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe>
         </div>
         <div id="sponsor"><a href="https://github.com/expressjs/express">Express</a> ist ein Projekt der Stiftung Node.js.</div>
         <div id="fork"><a href="https://github.com/expressjs/expressjs.com">Verzweigung der Website auf GitHub</a>. </div>
         <div>Copyright &copy; StrongLoop, Inc. und andere Mitwirkende an expressjs.com.</div>
     </div>
     <div id="license">
-        <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/"><img alt="Creative Commons Lizenzvertrag" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/3.0/us/80x15.png" /></a> Dieses Werk ist lizenziert unter einer <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/">Creative Commons Namensnennung - Weitergabe unter gleichen Bedingungen 3.0 Vereinigte Staaten von Amerika Lizenz</a>.        
-    </div>     
+        <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/"><img alt="Creative Commons Lizenzvertrag" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/3.0/us/80x15.png" /></a> Dieses Werk ist lizenziert unter einer <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/">Creative Commons Namensnennung - Weitergabe unter gleichen Bedingungen 3.0 Vereinigte Staaten von Amerika Lizenz</a>.
+    </div>
 </footer>

--- a/_includes/footer/footer-es.html
+++ b/_includes/footer/footer-es.html
@@ -23,7 +23,7 @@
 <footer>
     <div id="footer-content">
         <div id="github">
-            <iframe src="http://ghbtns.com/github-btn.html?user=expressjs&amp;repo=express&amp;type=watch&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe>
+            <iframe src="//ghbtns.com/github-btn.html?user=expressjs&amp;repo=express&amp;type=watch&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe>
         </div>
         <div id="sponsor"><a href="https://github.com/expressjs/express">Express</a> es un proyecto de la Fundación Node.js.</div>
 
@@ -32,6 +32,6 @@
         <div>Copyright &copy; StrongLoop, Inc. y otros colaboradores de expressjs.com.</div>
     </div>
     <div id="license">
-        <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/"><img alt="Licencia Creative Commons" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/3.0/us/80x15.png" /></a> Esta obra está bajo una <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/">Licencia Creative Commons Atribución-CompartirIgual 3.0 Estados Unidos de América</a>.   
-    </div>      
+        <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/"><img alt="Licencia Creative Commons" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/3.0/us/80x15.png" /></a> Esta obra está bajo una <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/">Licencia Creative Commons Atribución-CompartirIgual 3.0 Estados Unidos de América</a>.
+    </div>
 </footer>

--- a/_includes/footer/footer-fr.html
+++ b/_includes/footer/footer-fr.html
@@ -23,7 +23,7 @@
 <footer>
     <div id="footer-content">
         <div id="github">
-            <iframe src="http://ghbtns.com/github-btn.html?user=expressjs&amp;repo=express&amp;type=watch&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe>
+            <iframe src="//ghbtns.com/github-btn.html?user=expressjs&amp;repo=express&amp;type=watch&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe>
         </div>
         <div id="sponsor"><a href="https://github.com/expressjs/express">Express</a> est un projet de la Fondation Node.js. </div>
         <div id="fork"><a href="https://github.com/expressjs/expressjs.com">Consultez le site Web GitHub</a>.
@@ -32,5 +32,5 @@
     </div>
     <div id="license">
         <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/"><img alt="Licence Creative Commons" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/3.0/us/80x15.png" /></a> Ce(tte) œuvre est mise à disposition selon les termes de la <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/">Licence Creative Commons Attribution -  Partage dans les Mêmes Conditions 3.0 États-Unis</a>.
-    </div> 
+    </div>
 </footer>

--- a/_includes/footer/footer-it.html
+++ b/_includes/footer/footer-it.html
@@ -23,7 +23,7 @@
 <footer>
     <div id="footer-content">
         <div id="github">
-            <iframe src="http://ghbtns.com/github-btn.html?user=expressjs&amp;repo=express&amp;type=watch&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe>
+            <iframe src="//ghbtns.com/github-btn.html?user=expressjs&amp;repo=express&amp;type=watch&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe>
         </div>
         <div id="sponsor"><a href="https://github.com/expressjs/express">Express</a> è un progetto della Fondazione Node.js.</div>
         <div id="fork"><a href="https://github.com/expressjs/expressjs.com">Avviare il sito web su GitHub</a>.
@@ -32,5 +32,5 @@
     </div>
     <div id="license">
         <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/"><img alt="Licenza Creative Commons" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/3.0/us/80x15.png" /></a> Quest'opera è distribuita con Licenza <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/">Creative Commons Attribuzione - Condividi allo stesso modo 3.0 Stati Uniti</a>.
-    </div>      
+    </div>
 </footer>

--- a/_includes/footer/footer-ja.html
+++ b/_includes/footer/footer-ja.html
@@ -23,7 +23,7 @@
 <footer>
     <div id="footer-content">
         <div id="github">
-            <iframe src="http://ghbtns.com/github-btn.html?user=expressjs&amp;repo=express&amp;type=watch&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe>
+            <iframe src="//ghbtns.com/github-btn.html?user=expressjs&amp;repo=express&amp;type=watch&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe>
         </div>
         <div id="sponsor"><a href="https://github.com/expressjs/express">Express</a>は、Node.jsの財団のプロジェクトです</div>
         <div id="fork"><a href="https://github.com/expressjs/expressjs.com">GitHub で Web サイトを fork します</a>。</div>
@@ -31,5 +31,5 @@
     </div>
     <div id="license">
         <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/"><img alt="クリエイティブ・コモンズ・ライセンス" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/3.0/us/80x15.png" /></a> この 作品 は <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/">クリエイティブ・コモンズ 表示 - 継承 3.0 アメリカ合衆国 ライセンスの下に提供されています。</a>
-    </div>     
+    </div>
 </footer>

--- a/_includes/footer/footer-ko.html
+++ b/_includes/footer/footer-ko.html
@@ -23,7 +23,7 @@
 <footer>
     <div id="footer-content">
         <div id="github">
-            <iframe src="http://ghbtns.com/github-btn.html?user=expressjs&amp;repo=express&amp;type=watch&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe>
+            <iframe src="//ghbtns.com/github-btn.html?user=expressjs&amp;repo=express&amp;type=watch&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe>
         </div>
         <div id="sponsor"><a href="https://github.com/expressjs/express">Express</a>는 Node.js 기반의 프로젝트입니다.</div>
         <div id="fork"><a href="https://github.com/expressjs/expressjs.com">GitHub에서 웹사이트의 포크를 작성하십시오</a>.
@@ -32,5 +32,5 @@
     </div>
     <div id="license">
 <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/"><img alt="크리에이티브 커먼즈 라이선스" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/3.0/us/80x15.png" /></a> 이 저작물은 <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/">크리에이티브 커먼즈 저작자표시-동일조건변경허락 3.0 미국 라이선스</a>에 따라 이용할 수 있습니다.
-    </div>     
+    </div>
 </footer>

--- a/_includes/footer/footer-pt-br.html
+++ b/_includes/footer/footer-pt-br.html
@@ -23,7 +23,7 @@
 <footer>
     <div id="footer-content">
         <div id="github">
-            <iframe src="http://ghbtns.com/github-btn.html?user=expressjs&amp;repo=express&amp;type=watch&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe>
+            <iframe src="//ghbtns.com/github-btn.html?user=expressjs&amp;repo=express&amp;type=watch&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe>
         </div>
         <div id="sponsor"><a href="https://github.com/expressjs/express">Express</a> é um projeto da Fundação Node.js.</div>
         <div id="fork">
@@ -33,6 +33,6 @@
 contribuidores do expressjs.com.</div>
     <div id="license">
         <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/"><img alt="Licença Creative Commons" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/3.0/us/80x15.png" /></a> Este obra está licenciado com uma Licença <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/">Creative Commons Atribuição-CompartilhaIgual 3.0 Estados Unidos</a>.
-    </div> 
+    </div>
     </div>
 </footer>

--- a/_includes/footer/footer-ru.html
+++ b/_includes/footer/footer-ru.html
@@ -23,7 +23,7 @@
 <footer>
     <div id="footer-content">
         <div id="github">
-            <iframe src="http://ghbtns.com/github-btn.html?user=expressjs&amp;repo=express&amp;type=watch&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe>
+            <iframe src="//ghbtns.com/github-btn.html?user=expressjs&amp;repo=express&amp;type=watch&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe>
         </div>
         <div id="sponsor"><a href="https://github.com/expressjs/express">Express</a> проект Фонда Node.js.</div>
         <div id="fork"><a href="https://github.com/expressjs/expressjs.com">Создайте клон веб-сайта на GitHub</a>.
@@ -32,5 +32,5 @@
     </div>
     <div id="license">
 <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/"><img alt="Лицензия Creative Commons" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/3.0/us/80x15.png" /></a> Это произведение доступно по <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/">лицензии Creative Commons «Attribution-ShareAlike» («Атрибуция — На тех же условиях») 3.0 США</a>.
-    </div>     
+    </div>
 </footer>

--- a/_includes/footer/footer-uk.html
+++ b/_includes/footer/footer-uk.html
@@ -22,14 +22,14 @@
 <footer>
     <div id="footer-content">
         <div id="github">
-            <iframe src="http://ghbtns.com/github-btn.html?user=expressjs&amp;repo=express&amp;type=watch&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe>
+            <iframe src="//ghbtns.com/github-btn.html?user=expressjs&amp;repo=express&amp;type=watch&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe>
         </div>
         <div id="sponsor"><a href="https://github.com/expressjs/express">Express</a> is a project of the Node.js Foundation.</div>
         <div id="fork"><a href="https://github.com/expressjs/expressjs.com">Fork the website on GitHub</a>.
         </div>
         <div>Copyright &copy; StrongLoop, Inc., and other expressjs.com contributors.</div>
     </div>
-    <div id="license">    
+    <div id="license">
         <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/"><img alt="Ліцензія Creative Commons" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/3.0/us/80x15.png" /></a> Цей твір ліцензовано за <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/">ліцензією Creative Commons Із Зазначенням Авторства - Поширення На Тих Самих Умовах 3.0 Сполучені Штати</a>.
     </div>
 </footer>

--- a/_includes/footer/footer-uz.html
+++ b/_includes/footer/footer-uz.html
@@ -22,7 +22,7 @@
 <footer>
     <div id="footer-content">
         <div id="github">
-            <iframe src="http://ghbtns.com/github-btn.html?user=expressjs&amp;repo=express&amp;type=watch&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe>
+            <iframe src="//ghbtns.com/github-btn.html?user=expressjs&amp;repo=express&amp;type=watch&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe>
         </div>
         <div id="sponsor"><a href="https://github.com/expressjs/express">Express</a> is a project of the Node.js Foundation.</div>
         <div id="fork"><a href="https://github.com/expressjs/expressjs.com">Fork the website on GitHub</a>.
@@ -30,6 +30,6 @@
         <div>Copyright &copy; StrongLoop, Inc., and other expressjs.com contributors.</div>
     </div>
     <div id="license">
-        <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/3.0/us/80x15.png" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/">Creative Commons Attribution-ShareAlike 3.0 United States License</a>.        
-    </div>    
+        <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/3.0/us/80x15.png" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/">Creative Commons Attribution-ShareAlike 3.0 United States License</a>.
+    </div>
 </footer>

--- a/_includes/footer/footer-zh-cn.html
+++ b/_includes/footer/footer-zh-cn.html
@@ -23,7 +23,7 @@
 <footer>
     <div id="footer-content">
         <div id="github">
-            <iframe src="http://ghbtns.com/github-btn.html?user=expressjs&amp;repo=express&amp;type=watch&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe>
+            <iframe src="//ghbtns.com/github-btn.html?user=expressjs&amp;repo=express&amp;type=watch&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe>
         </div>
         <div id="sponsor"><a href="https://github.com/expressjs/express">Express</a>是Node.js的基金会的一个项目</div>
         <div id="fork"><a href="https://github.com/expressjs/expressjs.com">在 GitHub 上派生出网站</a>。</div>
@@ -31,5 +31,5 @@
     </div>
     <div id="license">
 <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/"><img alt="知识共享许可协议" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/3.0/us/80x15.png" /></a> 本作品采用<a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/">知识共享署名-相同方式共享 3.0 美国许可协议</a>进行许可。
-    </div>     
+    </div>
 </footer>

--- a/_includes/footer/footer-zh-tw.html
+++ b/_includes/footer/footer-zh-tw.html
@@ -23,7 +23,7 @@
 <footer>
     <div id="footer-content">
         <div id="github">
-            <iframe src="http://ghbtns.com/github-btn.html?user=expressjs&amp;repo=express&amp;type=watch&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe>
+            <iframe src="//ghbtns.com/github-btn.html?user=expressjs&amp;repo=express&amp;type=watch&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe>
         </div>
         <div id="sponsor"><a href="https://github.com/expressjs/express">Express</a>是Node.js的基金會的一個項目。</div>
         <div id="fork"><a href="https://github.com/expressjs/expressjs.com">GitHub 上的網站分支</a>。
@@ -32,5 +32,5 @@
     </div>
        <div id="license">
             <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/"><img alt="創用 CC 授權條款" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/3.0/us/80x15.png" /></a> 本著作係採用<a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/">創用 CC 姓名標示-相同方式分享 3.0 美國 授權條款</a>授權.
-    </div>  
+    </div>
 </footer>


### PR DESCRIPTION
Mixed Content: The page at 'https://expressjs.com/en/guide/using-middleware.html' was loaded over HTTPS, but requested an insecure resource 'http://ghbtns.com/github-btn.html?user=expressjs&repo=express&type=watch&count=true'. This request has been blocked; the content must be served over HTTPS.