### PR TITLE
Fixed #891: Middleware tables are duplicated in the middleware page

### DIFF
--- a/_layouts/middleware.html
+++ b/_layouts/middleware.html
@@ -26,6 +26,5 @@ layout: page
     {% else %}
       <h3>ERROR: No source specified for README {{page.module}}</h3>
     {% endif %}
-    {{content}}
   </div>
 </div>


### PR DESCRIPTION
Fixed Issue #891 : Middleware tables are duplicated in the middleware page
  
  