### PR TITLE
Remove orphan closing div

### DIFF
--- a/en/changelog/4x.md
+++ b/en/changelog/4x.md
@@ -241,4 +241,3 @@ The 4.14.0 minor release includes bug fixes, security update, performance improv
 </ul>
 
 For a complete list of changes in this release, see [History.md](https://github.com/expressjs/express/blob/master/History.md#4140--2016-06-16).
-</div>


### PR DESCRIPTION
This fixes the [changelog](https://expressjs.com/en/changelog/4x.html) documentation rendering a orphan closing div at the end of the v4.14.0 section.