### PR TITLE
Remove redirect_from in Thai translation to correct redirects back to English pages

### DIFF
--- a/th/3x/api.md
+++ b/th/3x/api.md
@@ -3,7 +3,6 @@ layout: 3x-api
 title: Express 3.x - API Reference
 menu: api
 lang: th
-redirect_from: "/3x/api.html"
 ---
 <div id="api-doc" markdown="1">
 

--- a/th/4x/api.md
+++ b/th/4x/api.md
@@ -3,7 +3,6 @@ layout: 4x-api
 title: Express 4.x - API Reference
 menu: api
 lang: th
-redirect_from: "/4x/api.html"
 ---
 <div id="api-doc" markdown="1">
 

--- a/th/advanced/best-practice-performance.md
+++ b/th/advanced/best-practice-performance.md
@@ -3,7 +3,6 @@ layout: page
 title: Performance Best Practices Using Express in Production
 menu: advanced
 lang: th
-redirect_from: "/advanced/best-practice-performance.html"
 ---
 
 # Production best practices: performance and reliability

--- a/th/advanced/best-practice-security.md
+++ b/th/advanced/best-practice-security.md
@@ -3,7 +3,6 @@ layout: page
 title: Security Best Practices for Express in Production
 menu: advanced
 lang: th
-redirect_from: "/advanced/best-practice-security.html"
 ---
 
 # Production Best Practices: Security

--- a/th/advanced/developing-template-engines.md
+++ b/th/advanced/developing-template-engines.md
@@ -3,7 +3,6 @@ layout: page
 title: Developing template engines for Express
 menu: advanced
 lang: th
-redirect_from: "/advanced/developing-template-engines.html"
 ---
 
 # Developing template engines for Express

--- a/th/advanced/pm.md
+++ b/th/advanced/pm.md
@@ -3,7 +3,6 @@ layout: page
 title: Process managers for Express apps
 menu: advanced
 lang: th
-redirect_from: "/advanced/pm.html"
 ---
 
 # Process managers for Express apps

--- a/th/advanced/security-updates.md
+++ b/th/advanced/security-updates.md
@@ -3,7 +3,6 @@ layout: page
 title: Express security updates
 menu: advanced
 lang: th
-redirect_from: "/advanced/security-updates.html"
 ---
 # Security updates
 

--- a/th/api.md
+++ b/th/api.md
@@ -2,7 +2,6 @@
 layout: 4x-api
 title: Express 4.x - การอ้างอิง API
 lang: th
-redirect_from: "/api.html"
 ---
 <div id="api-doc" markdown="1">
 

--- a/th/guide/behind-proxies.md
+++ b/th/guide/behind-proxies.md
@@ -3,7 +3,6 @@ layout: page
 title: Express behind proxies
 menu: guide
 lang: th
-redirect_from: "/guide/behind-proxies.html"
 ---
 # Express behind proxies
 

--- a/th/guide/database-integration.md
+++ b/th/guide/database-integration.md
@@ -3,7 +3,6 @@ layout: page
 title: Express database integration
 menu: guide
 lang: th
-redirect_from: "/guide/database-integration.html"
 ---
 # Database integration
 

--- a/th/guide/debugging.md
+++ b/th/guide/debugging.md
@@ -3,7 +3,6 @@ layout: page
 title: Debugging Express
 menu: guide
 lang: th
-redirect_from: "/guide/debugging.html"
 ---
 # Debugging Express
 

--- a/th/guide/error-handling.md
+++ b/th/guide/error-handling.md
@@ -3,7 +3,6 @@ layout: page
 title: Express error handling
 menu: guide
 lang: th
-redirect_from: "/guide/error-handling.html"
 ---
 # Error handling
 

--- a/th/guide/migrating-4.md
+++ b/th/guide/migrating-4.md
@@ -3,7 +3,6 @@ layout: page
 title: Migrating to Express 4
 menu: guide
 lang: th
-redirect_from: "/guide/migrating-4.html"
 ---
 # Moving to Express 4
 

--- a/th/guide/migrating-5.md
+++ b/th/guide/migrating-5.md
@@ -3,7 +3,6 @@ layout: page
 title: Migrating to Express 5
 menu: guide
 lang: th
-redirect_from: "/guide/migrating-5.html"
 ---
 # Moving to Express 5
 

--- a/th/guide/routing.md
+++ b/th/guide/routing.md
@@ -3,7 +3,6 @@ layout: page
 title: Express routing
 menu: guide
 lang: th
-redirect_from: "/guide/routing.html"
 ---
 
 # Routing

--- a/th/guide/using-middleware.md
+++ b/th/guide/using-middleware.md
@@ -3,7 +3,6 @@ layout: page
 title: Using Express middleware
 menu: guide
 lang: th
-redirect_from: "/guide/using-middleware.html"
 ---
 # Using middleware
 

--- a/th/guide/using-template-engines.md
+++ b/th/guide/using-template-engines.md
@@ -3,7 +3,6 @@ layout: page
 title: Using template engines with Express
 menu: guide
 lang: th
-redirect_from: "/guide/using-template-engines.html"
 ---
 # Using template engines with Express
 

--- a/th/guide/writing-middleware.md
+++ b/th/guide/writing-middleware.md
@@ -3,7 +3,6 @@ layout: page
 title: Writing middleware for use in Express apps
 menu: guide
 lang: th
-redirect_from: "/guide/writing-middleware.html"
 ---
 # Writing middleware for use in Express apps
 

--- a/th/index.md
+++ b/th/index.md
@@ -3,7 +3,6 @@ layout: home
 title: Express - เว็บแอปพลิเคชันเฟรมเวอร์คสำหรับ Node.js
 menu: home
 lang: th
-redirect_from: "/en/index.html"
 ---
 <section id="home-content">
   {% include header/header-{{ page.lang }}.html %}

--- a/th/resources/books-blogs.md
+++ b/th/resources/books-blogs.md
@@ -3,7 +3,6 @@ layout: page
 title: Express books and blogs
 menu: resources
 lang: th
-redirect_from: "/resources/books-blogs.html"
 ---
 
 # Books and blogs

--- a/th/resources/community.md
+++ b/th/resources/community.md
@@ -3,7 +3,6 @@ layout: page
 title: Express community
 menu: resources
 lang: th
-redirect_from: "/resources/community.html"
 ---
 
 # Community

--- a/th/resources/companies-using-express.md
+++ b/th/resources/companies-using-express.md
@@ -3,7 +3,6 @@ layout: page
 title: Companies using Express
 menu: resources
 lang: th
-redirect_from: "/resources/companies-using-express.html"
 ---
 
 # Companies using Express in production

--- a/th/resources/contributing.md
+++ b/th/resources/contributing.md
@@ -3,7 +3,6 @@ layout: page
 title: Contributing to Express
 menu: resources
 lang: th
-redirect_from: "/resources/community.html"
 ---
 
 # Contributing to Express

--- a/th/resources/glossary.md
+++ b/th/resources/glossary.md
@@ -3,7 +3,6 @@ layout: page
 title: Express glossary
 menu: resources
 lang: th
-redirect_from: "/resources/glossary.html"
 ---
 
 # Glossary

--- a/th/resources/middleware.md
+++ b/th/resources/middleware.md
@@ -3,7 +3,6 @@ layout: middleware
 title: Express middleware
 menu: resources
 lang: th
-redirect_from: "/resources/middleware.html"
 module: mw-home
 ---
 

--- a/th/resources/middleware/body-parser.md
+++ b/th/resources/middleware/body-parser.md
@@ -3,6 +3,5 @@ layout: middleware
 title: Express body-parser middleware
 menu: resources
 lang: en
-redirect_from: '/resources/middleware/body-parser.html'
 module: body-parser
 ---

--- a/th/resources/middleware/compression.md
+++ b/th/resources/middleware/compression.md
@@ -3,6 +3,5 @@ layout: middleware
 title: Express compression middleware
 menu: resources
 lang: en
-redirect_from: '/resources/middleware/compression.html'
 module: compression
 ---

--- a/th/resources/middleware/connect-rid.md
+++ b/th/resources/middleware/connect-rid.md
@@ -3,6 +3,5 @@ layout: middleware
 title: Express connect-rid middleware
 menu: resources
 lang: en
-redirect_from: '/resources/middleware/connect-rid.html'
 module: connect-rid
 ---

--- a/th/resources/middleware/cookie-parser.md
+++ b/th/resources/middleware/cookie-parser.md
@@ -3,6 +3,5 @@ layout: middleware
 title: Express cookie-parser middleware
 menu: resources
 lang: en
-redirect_from: '/resources/middleware/cookie-parser.html'
 module: cookie-parser
 ---

--- a/th/resources/middleware/cookie-session.md
+++ b/th/resources/middleware/cookie-session.md
@@ -3,6 +3,5 @@ layout: middleware
 title: Express cookie-session middleware
 menu: resources
 lang: en
-redirect_from: '/resources/middleware/cookie-session.html'
 module: cookie-session
 ---

--- a/th/resources/middleware/cors.md
+++ b/th/resources/middleware/cors.md
@@ -3,6 +3,5 @@ layout: middleware
 title: Express cors middleware
 menu: resources
 lang: en
-redirect_from: '/resources/middleware/cors.html'
 module: cors
 ---

--- a/th/resources/middleware/csurf.md
+++ b/th/resources/middleware/csurf.md
@@ -3,6 +3,5 @@ layout: middleware
 title: Express csurf middleware
 menu: resources
 lang: en
-redirect_from: '/resources/middleware/csurf.html'
 module: csurf
 ---

--- a/th/resources/middleware/errorhandler.md
+++ b/th/resources/middleware/errorhandler.md
@@ -3,6 +3,5 @@ layout: middleware
 title: Express errorhandler middleware
 menu: resources
 lang: en
-redirect_from: '/resources/middleware/errorhandler.html'
 module: errorhandler
 ---

--- a/th/resources/middleware/method-override.md
+++ b/th/resources/middleware/method-override.md
@@ -3,6 +3,5 @@ layout: middleware
 title: Express method-override middleware
 menu: resources
 lang: en
-redirect_from: '/resources/middleware/method-override.html'
 module: method-override
 ---

--- a/th/resources/middleware/morgan.md
+++ b/th/resources/middleware/morgan.md
@@ -3,6 +3,5 @@ layout: middleware
 title: Express morgan middleware
 menu: resources
 lang: en
-redirect_from: '/resources/middleware/morgan.html'
 module: morgan
 ---

--- a/th/resources/middleware/multer.md
+++ b/th/resources/middleware/multer.md
@@ -3,6 +3,5 @@ layout: middleware
 title: Express multer middleware
 menu: resources
 lang: en
-redirect_from: '/resources/middleware/multer.html'
 module: multer
 ---

--- a/th/resources/middleware/response-time.md
+++ b/th/resources/middleware/response-time.md
@@ -3,6 +3,5 @@ layout: middleware
 title: Express response-time middleware
 menu: resources
 lang: en
-redirect_from: '/resources/middleware/response-time.html'
 module: response-time
 ---

--- a/th/resources/middleware/serve-favicon.md
+++ b/th/resources/middleware/serve-favicon.md
@@ -3,6 +3,5 @@ layout: middleware
 title: Express serve-favicon middleware
 menu: resources
 lang: en
-redirect_from: '/resources/middleware/serve-favicon.html'
 module: serve-favicon
 ---

--- a/th/resources/middleware/serve-index.md
+++ b/th/resources/middleware/serve-index.md
@@ -3,6 +3,5 @@ layout: middleware
 title: Express serve-index middleware
 menu: resources
 lang: en
-redirect_from: '/resources/middleware/serve-index.html'
 module: serve-index
 ---

--- a/th/resources/middleware/serve-static.md
+++ b/th/resources/middleware/serve-static.md
@@ -3,6 +3,5 @@ layout: middleware
 title: Express serve-static middleware
 menu: resources
 lang: en
-redirect_from: '/resources/middleware/serve-static.html'
 module: serve-static
 ---

--- a/th/resources/middleware/session.md
+++ b/th/resources/middleware/session.md
@@ -3,6 +3,5 @@ layout: middleware
 title: Express session middleware
 menu: resources
 lang: en
-redirect_from: '/resources/middleware/session.html'
 module: session
 ---

--- a/th/resources/middleware/timeout.md
+++ b/th/resources/middleware/timeout.md
@@ -3,6 +3,5 @@ layout: middleware
 title: Express timeout middleware
 menu: resources
 lang: en
-redirect_from: '/resources/middleware/timeout.html'
 module: timeout
 ---

--- a/th/resources/middleware/vhost.md
+++ b/th/resources/middleware/vhost.md
@@ -3,6 +3,5 @@ layout: middleware
 title: Express vhost middleware
 menu: resources
 lang: en
-redirect_from: '/resources/middleware/vhost.html'
 module: vhost
 ---

--- a/th/resources/utils.md
+++ b/th/resources/utils.md
@@ -3,7 +3,6 @@ layout: page
 title: Express utilities
 menu: resources
 lang: th
-redirect_from: "/resources/utilities.html"
 ---
 
 ## Express utility functions

--- a/th/starter/basic-routing.md
+++ b/th/starter/basic-routing.md
@@ -3,7 +3,6 @@ layout: page
 title: Express basic routing
 menu: starter
 lang: th
-redirect_from: "/starter/basic-routing.html"
 ---
 
 # Basic routing

--- a/th/starter/faq.md
+++ b/th/starter/faq.md
@@ -3,7 +3,6 @@ layout: page
 title: Express FAQ
 menu: starter
 lang: th
-redirect_from: "/starter/faq.html"
 ---
 
 # FAQ

--- a/th/starter/generator.md
+++ b/th/starter/generator.md
@@ -3,7 +3,6 @@ layout: page
 title: Express application generator
 menu: starter
 lang: th
-redirect_from: "/starter/generator.html"
 ---
 
 # Express application generator

--- a/th/starter/hello-world.md
+++ b/th/starter/hello-world.md
@@ -3,7 +3,6 @@ layout: page
 title: Express "Hello World" example
 menu: starter
 lang: th
-redirect_from: "/starter/hello-world.html"
 ---
 
 # Hello world example

--- a/th/starter/installing.md
+++ b/th/starter/installing.md
@@ -3,7 +3,6 @@ layout: page
 title: Installing Express
 menu: starter
 lang: th
-redirect_from: "/starter/installing.html"
 ---
 
 # Installing

--- a/th/starter/static-files.md
+++ b/th/starter/static-files.md
@@ -3,7 +3,6 @@ layout: page
 title: Serving static files in Express
 menu: starter
 lang: th
-redirect_from: "/starter/static-files.html"
 ---
 
 # Serving static files in Express


### PR DESCRIPTION
The Thai translation that was added a few weeks ago includes `redirect_from: ...` clauses. These are overriding the English pages so that by default pages like http://expressjs.com/api.html are redirecting to the Thai page rather than the English one (click it to try it out). I noticed this earlier today when a link from a Google search page sent me to the Thai translation.

PR removes the `redirect_from: ...` lines as I'm assuming the English localization is meant to be the default.