### PR TITLE
Don't use the term "route name".

### DIFF
--- a/en/guide/routing.md
+++ b/en/guide/routing.md
@@ -142,7 +142,7 @@ app.get('/ab(cd)?e', function (req, res) {
 
 Examples of route paths based on regular expressions:
 
-This route path will match anything with an "a" in the route name.
+This route path will match anything with an "a" in it.
 
 ```js
 app.get(/a/, function (req, res) {


### PR DESCRIPTION
The term "route name" is only used in one place so it was a bit confusing for a newbie. I propose it's simply remove to match the rest of the docs.
