### PR TITLE
Fixed some typos in latest changelog

### DIFF
--- a/en/changelog/4x.md
+++ b/en/changelog/4x.md
@@ -7,10 +7,10 @@ lang: en
 
 # Release Change Log
 
-## 4.16.3 - Release date: 2017-03-12
+## 4.16.3 - Release date: 2018-03-12
 {: id="4.16.3"}
 
-The 4.16.2 patch release includes various bug fixes:
+The 4.16.3 patch release includes various bug fixes:
 
 <ul>
   <li markdown="1" class="changelog-item">


### PR DESCRIPTION
The wrong year and version number appear to have been used for the latest release.