### PR TITLE
Define the `wrap` function for the async example in Best Practices page

### DIFF
--- a/en/advanced/best-practice-performance.md
+++ b/en/advanced/best-practice-performance.md
@@ -150,6 +150,8 @@ However, there are two caveats:
 2.  Event emitters (like streams) can still cause uncaught exceptions. So make sure you are handling the error event properly; for example:
 
 ```js
+const wrap = fn => (...args) => fn(...args).catch(args[2])
+
 app.get('/', wrap(async (req, res, next) => {
   let company = await getCompanyById(req.query.id)
   let stream = getLogoStreamById(company.id)
@@ -157,10 +159,11 @@ app.get('/', wrap(async (req, res, next) => {
 }))
 ```
 
-For more information about error-handling by using promises, see:
+The `wrap()` function is a wrapper that catches rejected promises and calls `next()` with the error as the first argument.
+For details, see [https://strongloop.com/strongblog/async-error-handling-expressjs-es7-promises-generators/#cleaner-code-with-generators](Asynchronous
+Error Handling in Express with Promises, Generators and ES7).
 
-* [Asynchronous Error Handling in Express with Promises, Generators and ES7](https://strongloop.com/strongblog/async-error-handling-expressjs-es7-promises-generators/)
-* [Promises in Node.js with Q – An Alternative to Callbacks](https://strongloop.com/strongblog/promises-in-node-js-with-q-an-alternative-to-callbacks/)
+For more information about error-handling by using promises, see [Promises in Node.js with Q – An Alternative to Callbacks](https://strongloop.com/strongblog/promises-in-node-js-with-q-an-alternative-to-callbacks/).
 
 ## Things to do in your environment / setup {#in-environment}
 


### PR DESCRIPTION
This example came from https://strongloop.com/strongblog/async-error-handling-expressjs-es7-promises-generators/ but the definition of `wrap()` wasn't replicated here.  This adds the definition to avoid confusion.