### PR TITLE
🐛Document behavior when request body is null

### DIFF
--- a/_includes/api/en/4x/req-is.md
+++ b/_includes/api/en/4x/req-is.md
@@ -1,7 +1,7 @@
 <h3 id='req.is'>req.is(type)</h3>
 
 Returns the matching content type if the incoming request's "Content-Type" HTTP header field
-matches the MIME type specified by the `type` parameter.
+matches the MIME type specified by the `type` parameter. If the request has no body, returns `null`.
 Returns `false` otherwise.
 
 ```js


### PR DESCRIPTION
The [implementation](https://github.com/jshttp/type-is/blob/master/index.js#L127) clearly returns `null` when the request body is `null`, but the documentation did not reflect this, causing the behavior described in [expressjs/express #3669](https://github.com/expressjs/express/issues/3669).