### PR TITLE
Fix throw new Error statement

### DIFF
--- a/en/guide/error-handling.md
+++ b/en/guide/error-handling.md
@@ -90,7 +90,7 @@ more generally when using Promise-returning functions. For example:
 ```js
 app.get("/", function (req, res, next) {
   Promise.resolve().then(function () {
-    throw new new Error("BROKEN");
+    throw new Error("BROKEN");
   }).catch(next); // Errors will be passed to Express.
 });
 ```


### PR DESCRIPTION
Hello,

I think there is a small typo `throw new new Error("BROKEN");` => `throw new Error("BROKEN");`

Please let me know if this makes sense.
Thanks 🙏