### PR TITLE
Update using-middleware.md

### DIFF
--- a/en/guide/using-middleware.md
+++ b/en/guide/using-middleware.md
@@ -107,13 +107,13 @@ app.get('/user/:id', function (req, res, next) {
   // otherwise pass the control to the next middleware function in this stack
   else next()
 }, function (req, res, next) {
-  // render a regular page
-  res.render('regular')
+  // send a regular response
+  res.send('regular')
 })
 
-// handler for the /user/:id path, which renders a special page
+// handler for the /user/:id path, which sends a special response
 app.get('/user/:id', function (req, res, next) {
-  res.render('special')
+  res.send('special')
 })
 ```
 


### PR DESCRIPTION
Substitute `res.send` for `res.render` in the last example for Application-level middleware. The examples before all use `res.send`, so `res.render` creates unnecessary confusion, since it hasn't been introduced in the documentation just yet (it will be in the next guide)