### PR TITLE
Add  DEV Community's express tag to community page

### DIFF
--- a/en/resources/learning.md
+++ b/en/resources/learning.md
@@ -60,6 +60,10 @@ self-published, February 2018.
 
 [Edit the Markdown file](https://github.com/expressjs/expressjs.com/blob/gh-pages/{{ page.lang }}/resources/learning.md) and add a link to your blog, then submit a pull request (GitHub login required).  Follow the format of the above listings.
 
+## The DEV community
+
+[DEV's express tag](https://dev.to/t/express) is a place to share Express projects, articles and tutorials as well as start discussions and ask for feedback on Express-related topics. Developers of all skill-levels are welcome to take part.
+
 ## Video tutorials
 - [Learning ExpressJS: Express category](https://getbuzz.io/c/learning-expressjs)
 - [Learn Express.js in 14 days](https://iLoveCoding.org/courses/expressjs) - Practice Projects included


### PR DESCRIPTION
[DEV Community](https://dev.to) is a burgeoning source of guidance and discussion on software topics, especially web dev. This will be a useful link to point to the official place to discuss Express matters on the platform.

A few additional links pertaining to dev.to

Traffic stats: https://www.similarweb.com/website/dev.to
Twitter: https://twitter.com/thepracticaldev
Express tag (as included in PR): https://dev.to/t/express

Some example Express posts:
https://dev.to/aurelkurtula/creating-a-basic-website-with-expressjs-j92
https://dev.to/albertofdzm/making-apis-with-node-and-express
https://dev.to/geoff/writing-asyncawait-middleware-in-express-6i0

Happy coding :heart: