### PR TITLE
Use pug = instead of != in "Using template engines" example

### DIFF
--- a/de/guide/using-template-engines.md
+++ b/de/guide/using-template-engines.md
@@ -38,9 +38,9 @@ Erstellen Sie eine Pug-Vorlagendatei namens `index.pug` im Verzeichnis `views` m
 <code class="language-javascript" translate="no">
 html
   head
-    title!= title
+    title= title
   body
-    h1!= message
+    h1= message
 </code>
 </pre>
 

--- a/es/guide/using-template-engines.md
+++ b/es/guide/using-template-engines.md
@@ -40,9 +40,9 @@ Cree un archivo de plantilla Pug denominado `index.pug` en el directorio `views`
 <code class="language-javascript" translate="no">
 html
   head
-    title!= title
+    title= title
   body
-    h1!= message
+    h1= message
 </code>
 </pre>
 

--- a/fr/guide/using-template-engines.md
+++ b/fr/guide/using-template-engines.md
@@ -40,9 +40,9 @@ Créez un fichier de modèle Pug nommé `index.pug` dans le répertoire `views`,
 <code class="language-javascript" translate="no">
 html
   head
-    title!= title
+    title= title
   body
-    h1!= message
+    h1= message
 </code>
 </pre>
 

--- a/it/guide/using-template-engines.md
+++ b/it/guide/using-template-engines.md
@@ -40,9 +40,9 @@ Creare un file di template Pug denominato `index.pug` nella directory `views`, c
 <code class="language-javascript" translate="no">
 html
   head
-    title!= title
+    title= title
   body
-    h1!= message
+    h1= message
 </code>
 </pre>
 

--- a/ja/guide/using-template-engines.md
+++ b/ja/guide/using-template-engines.md
@@ -39,9 +39,9 @@ app.set('view engine', 'pug');
 <code class="language-javascript" translate="no">
 html
   head
-    title!= title
+    title= title
   body
-    h1!= message
+    h1= message
 </code>
 </pre>
 

--- a/ko/guide/using-template-engines.md
+++ b/ko/guide/using-template-engines.md
@@ -40,9 +40,9 @@ app.set('view engine', 'pug');
 <code class="language-javascript" translate="no">
 html
   head
-    title!= title
+    title= title
   body
-    h1!= message
+    h1= message
 </code>
 </pre>
 

--- a/pt-br/guide/using-template-engines.md
+++ b/pt-br/guide/using-template-engines.md
@@ -55,9 +55,9 @@ chamado `index.pug` no diretório
 <code class="language-javascript" translate="no">
 html
   head
-    title!= title
+    title= title
   body
-    h1!= message
+    h1= message
 </code>
 </pre>
 

--- a/ru/guide/using-template-engines.md
+++ b/ru/guide/using-template-engines.md
@@ -40,9 +40,9 @@ app.set('view engine', 'pug');
 <code class="language-javascript" translate="no">
 html
   head
-    title!= title
+    title= title
   body
-    h1!= message
+    h1= message
 </code>
 </pre>
 

--- a/uz/guide/using-template-engines.md
+++ b/uz/guide/using-template-engines.md
@@ -35,9 +35,9 @@ Create a Pug template files named "index.pug" in the views directory, with the f
 <pre><code class="language-javascript" translate="no">
 html
   head
-    title!= title
+    title= title
   body
-    h1!= message
+    h1= message
 </code></pre>
 
 Then create a route to render the "index.pug" file. If the `view engine` property is not set, you will have to specify the extension of the view file, else you can omit it.

--- a/zh-cn/guide/using-template-engines.md
+++ b/zh-cn/guide/using-template-engines.md
@@ -39,9 +39,9 @@ app.set('view engine', 'pug');
 <code class="language-javascript" translate="no">
 html
   head
-    title!= title
+    title= title
   body
-    h1!= message
+    h1= message
 </code>
 </pre>
 

--- a/zh-tw/guide/using-template-engines.md
+++ b/zh-tw/guide/using-template-engines.md
@@ -40,9 +40,9 @@ app.set('view engine', 'pug');
 <code class="language-javascript" translate="no">
 html
   head
-    title!= title
+    title= title
   body
-    h1!= message
+    h1= message
 </code>
 </pre>
 


### PR DESCRIPTION
I think using `!=` is not secure and it is not good to use in the example. 

#562 reported this issue and it is fixed for english documentation in #563 .
But in other languages, it is not fixed.
e.g. http://expressjs.com/ja/guide/using-template-engines.html

So I fixed this issue for other languages.