### PR TITLE
Add express-slick-css to middleware.md

### DIFF
--- a/en/resources/middleware.md
+++ b/en/resources/middleware.md
@@ -52,6 +52,6 @@ These are some additional popular middleware modules.
 | [static-expiry](https://github.com/paulwalker/connect-static-expiry) | Fingerprint URLs or caching headers for static assets.|
 | [view-helpers](https://github.com/madhums/node-view-helpers) | Common helper methods for views.|
 | [sriracha-admin](https://github.com/hdngr/siracha) | Dynamically generate an admin site for Mongoose. |
-| [express-slick-css](https://github.com/ameerthehacker/express-slick-css) | Remove unwanted css rules before sending response |
+| [express-slick-css](https://github.com/ameerthehacker/express-slick-css) | Remove unused css rules before sending response |
 
 For more middleware modules, see [http-framework](https://github.com/Raynos/http-framework#modules).

--- a/en/resources/middleware.md
+++ b/en/resources/middleware.md
@@ -52,5 +52,5 @@ These are some additional popular middleware modules.
 | [static-expiry](https://github.com/paulwalker/connect-static-expiry) | Fingerprint URLs or caching headers for static assets.|
 | [view-helpers](https://github.com/madhums/node-view-helpers) | Common helper methods for views.|
 | [sriracha-admin](https://github.com/hdngr/siracha) | Dynamically generate an admin site for Mongoose. |
-
+| [express-slick-css](https://github.com/ameerthehacker/express-slick-css) | Remove unwanted css rules before sending response |
 For more middleware modules, see [http-framework](https://github.com/Raynos/http-framework#modules).

--- a/en/resources/middleware.md
+++ b/en/resources/middleware.md
@@ -53,4 +53,5 @@ These are some additional popular middleware modules.
 | [view-helpers](https://github.com/madhums/node-view-helpers) | Common helper methods for views.|
 | [sriracha-admin](https://github.com/hdngr/siracha) | Dynamically generate an admin site for Mongoose. |
 | [express-slick-css](https://github.com/ameerthehacker/express-slick-css) | Remove unwanted css rules before sending response |
+
 For more middleware modules, see [http-framework](https://github.com/Raynos/http-framework#modules).


### PR DESCRIPTION
I have developed a middleware called [https://github.com/ameerthehacker/express-slick-css](express-slick-css). It removes all the unused CSS rules before sending the response as a page. It is relatively new yet I believe this is one way I can take this to a huge audience of expressjs If you people feel my middleware is up to it!