### PR TITLE
fix wrong statements in res.json() documentation

### DIFF
--- a/_includes/api/en/4x/res-json.md
+++ b/_includes/api/en/4x/res-json.md
@@ -3,9 +3,8 @@
 Sends a JSON response. This method sends a response (with the correct content-type) that is the parameter converted to a 
 JSON string using [JSON.stringify()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify).
 
-The parameter can be any JSON type, including object, array, string, Boolean, or number,
-and you can also use it to convert other values to JSON, such as `null`, and `undefined` 
-(although these are technically not valid JSON).
+The parameter can be any JSON type, including object, array, string, Boolean, number, or null,
+and you can also use it to convert other values to JSON.
 
 ```js
 res.json(null);


### PR DESCRIPTION
fix wrong statements in `res.json()` documentation, which:
- implies that `null` is not valid JSON
- states that express converts `undefined` to JSON

They are wrong because:
- According to http://json.org, `null` **IS** valid JSON
- Express does not convert `undefined` to JSON, instead, it yields an empty output
