### PR TITLE
Add BitMidi to open source users

### DIFF
--- a/en/resources/open-source-using-express.md
+++ b/en/resources/open-source-using-express.md
@@ -10,6 +10,7 @@ redirect_from: "/resources/open-source-using-express.html"
 
 - **[Builder Book](https://github.com/builderbook/builderbook)**: Open source web app to publish documentation or books. Built with React, Material-UI, Next, Express, Mongoose, MongoDB.
 - **[SaaS Boilerplate](https://github.com/async-labs/saas)**: Open source web app to build your own SaaS product. Built with React, Material-UI, Next, MobX, Express, Mongoose, MongoDB, Typescript.
+- **[BitMidi](https://bitmidi.com)**: Open source web app powered by Express. BitMidi is a historical archive of MIDI files from the early web era. It uses the latest modern web technology including WebAssembly and Web Audio to bring MIDI back to life. ([source code](https://github.com/feross/bitmidi.com))
 
 ### Add your project here!
 


### PR DESCRIPTION
This PR adds the website [BitMidi](https://bitmidi.com) to the readme.

BitMidi is powered by Express! (see [proof](https://github.com/feross/bitmidi.com/blob/b6cd24f535eaefcbe472063ad5da8418055d77a2/package.json#L73)) It's an amazing joy to work with Express and it would be an honor to be listed as an open source user of Express.

Website screenshot: 

<img width="1085" alt="bitmidi-screenshot" src="https://user-images.githubusercontent.com/121766/45197926-84192600-b218-11e8-9db2-e54cce3c89e3.png">

Context about the site:

BitMidi is a historical archive of MIDI files from the early web era. It's a fun way to experience the early web aesthetic of Geocities and Angelfire sites, and also a powerful tool for musicians to find "song stems" to use as the basis for song remixes. It uses the latest modern web technology including WebAssembly and Web Audio to bring MIDI back to life.
