### PR TITLE
Improve local setup steps formatting & readme URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # expressjs.com
 
-This is the repository of the website [expressjs.com](http://expressjs.com). It is hosted directly from the repository as a [GitHub Pages](https://pages.github.com/) website.
+This is the repository of the website [expressjs.com](https://expressjs.com). It is hosted directly from the repository as a [GitHub Pages](https://pages.github.com/) website.
 
 ## Local Setup
 
@@ -8,35 +8,36 @@ To preview the website locally:
 
 1. Install [Ruby and Bundler](https://help.github.com/articles/setting-up-your-pages-site-locally-with-jekyll/) if you don't have them already.
 
-2. Install the [jekyll-redirect-from](https://github.com/jekyll/jekyll-redirect-from) gem:
-```
-$ gem install jekyll-redirect-from
-```
+1. Install the [jekyll-redirect-from](https://github.com/jekyll/jekyll-redirect-from) gem:
+
+   ```
+   $ gem install jekyll-redirect-from
+   ```
 
 1. `cd` to the repository directory and run the following command:
 
-```
-$ cd expressjs.com
-$ bundle install
-```
+   ```
+   $ cd expressjs.com
+   $ bundle install
+   ```
 
-Bundler will look in the Gemfile for which gems to install. The `github-pages` gem includes the same version of Jekyll and other dependencies as used by GitHub Pages, so that your local setup mirrors GitHub Pages as closely as possible.
+   Bundler will look in the Gemfile for which gems to install. The `github-pages` gem includes the same version of Jekyll and other dependencies as used by GitHub Pages, so that your local setup mirrors GitHub Pages as closely as possible.
 
-Run Jekyll using the following command:
+1. Run Jekyll using the following command:
 
-```
-$ bundle exec jekyll serve
-```
+   ```
+   $ bundle exec jekyll serve
+   ```
 
-Then, load [http://localhost:4000/](http://localhost:4000/) on your browser.
+   Then, load <http://localhost:4000> in your browser.
 
 ## Formatting
 
-Jekyll uses a variant of Markdown known as [Kramdown](http://kramdown.gettalong.org/quickref.html).
+Jekyll uses a variant of Markdown known as [Kramdown](https://kramdown.gettalong.org/quickref.html).
 
 Jekyll uses the [Liquid template engine](http://liquidmarkup.org/) for templating.
 
-You can use [GFM](http://kramdown.gettalong.org/parser/gfm.html) fenced code blocks for JavaScript; for example:
+You can use [GFM](https://kramdown.gettalong.org/parser/gfm.html) fenced code blocks for JavaScript; for example:
 
 <pre>
 ```js
@@ -54,7 +55,7 @@ var app = express()
 app.listen(3000)
 ```
 
-The default GitHub Pages syntax highlighting has been disabled in `_config.yml` to allow highlighting with [prism.js](http://prismjs.com/).
+The default GitHub Pages syntax highlighting has been disabled in `_config.yml` to allow highlighting with [prism.js](https://prismjs.com/).
 
 ## Contributing
 


### PR DESCRIPTION
Previously, the steps were 1, 2, 1, no further numbering.  This tidies that up into 1, 2, 3, 4.  A few minor http --> https adjustments for URLs are included as well.