### PR TITLE
Fix req.protocol hash link

### DIFF
--- a/_includes/api/en/4x/req-protocol.md
+++ b/_includes/api/en/4x/req-protocol.md
@@ -2,7 +2,7 @@
 
 Contains the request protocol string: either `http` or (for TLS requests) `https`.
 
-When the [`trust proxy` setting](/4x/api.html#trust.proxy.options.table) does not evaluate to `false`,
+When the [`trust proxy` setting](#trust.proxy.options.table) does not evaluate to `false`,
 this property will use the value of the `X-Forwarded-Proto` header field if present.
 This header can be set by the client or by the proxy.
 


### PR DESCRIPTION
When using with `/4x/api.html` it skips language check and breaks the hash-link.

Check it out: http://expressjs.com/en/4x/api.html#req.protocol