### PR TITLE
Update req.query example for collection values of same key

### DIFF
--- a/_includes/api/en/4x/req-query.md
+++ b/_includes/api/en/4x/req-query.md
@@ -21,4 +21,8 @@ req.query.shoe.color
 
 req.query.shoe.type
 // => "converse"
+
+// GET /shoes?color[]=blue&color[]=black&color[]=red
+req.query.color
+// => [blue, black, red]
 ```


### PR DESCRIPTION
- This PR will add a missing example to `req.query` documentation.
- To show case how express.js parses the query string when the url contains multiple values or a collection for the same key.
- This is internally done by the `parse` method in `qs` module used by express.js 

```
http://example.com/users?id[]=1&id[]=2&id[]=3

req.query.id => [1, 2, 3];
```