### PR TITLE
Fix 404 error for edit on github

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -45,7 +45,7 @@ $(function(){
   var branchPath = 'https://github.com/expressjs/expressjs.com';
   var pathName = document.location.pathname;
 
-  var currentVersion = pathName.split('/').splice(-2)[0] || '4x'; // defaults to current version
+  var currentVersion = (pathName.match(/^(?:\/[a-z]{2})?\/([0-9]x|)/) || [])[1] || '4x'; // defaults to current version
   var fileName = pathName.split('/').splice(-2)[1];
   var pagePath;
   var editPath;


### PR DESCRIPTION
We can also access api.html page through `/<language>/api.html`

For this case, the `edit on github` was sending us to `branchPath + '/tree/gh-pages/_includes/api/en/'+ 'en'`.

I have made an appropriate change to detect whether we are on `/<laguage>/api.html` or `/<language>/<version>/api.html`, and create URL based on that.

#924