### PR TITLE
Add content to starter page for Turkish

### DIFF
--- a/tr/starter/basic-routing.md
+++ b/tr/starter/basic-routing.md
@@ -1,66 +1,66 @@
 ---
 layout: page
-title: Express basic routing
+title: Express yol atama
 menu: starter
 lang: tr
 ---
-<div id="page-doc" markdown="1">
-# Basic routing
+# Basit yol atama
 
-_Routing_ refers to determining how an application responds to a client request to a particular endpoint, which is a URI (or path) and a specific HTTP request method (GET, POST, and so on).
+Yol atama, bir uygulamanın belrili bir adreste belirli bir HTTP methodu ile (GET, POST gibi) gelen isteğe ne şekilde cevap vereceğine karşılık gelir.
 
-Each route can have one or more handler functions, which are executed when the route is matched.
+Her yol, girilen adres eşleştiğinde bir veya daha fazla fonksiyon tarafından işlenebilir.
 
-Route definition takes the following structure:
+Yol tanımları aşağıdaki şekilde yapılanmıştır:
 
 ```js
 app.METHOD(PATH, HANDLER)
 ```
 
-Where:
+Burada:
 
-- `app` is an instance of `express`.
-- `METHOD` is an [HTTP request method](https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Request_methods), in lowercase.
-- `PATH` is a path on the server.
-- `HANDLER` is the function executed when the route is matched.
+- `app`, `express`'in bir örneği.
+- `METHOD`, [HTTP istek methodu](https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Request_methods), küçük harflerle.
+- `PATH`, sunucuda bulunan yol.
+- `HANDLER`, adres bu yol ile eşleştiğinde çalıştırılan fonksiyon.
 
 <div class="doc-box doc-notice" markdown="1">
-This tutorial assumes that an instance of `express` named `app` is created and the server is running. If you are not familiar with creating an app and starting it, see the [Hello world example](/{{ page.lang }}/starter/hello-world.html).
+Bu konu `express` ve `app` örneklerinin bulunduğunu ve sunucunun çalıştığını varsayar. Eğer bir uygulama oluşturup çalıştırmak hakkında bir bilginiz yoksa, [Merhaba Dünya örneği](/{{ page.lang }}/starter/hello-world.html) sayfasını ziyaret edin.
 </div>
 
-The following examples illustrate defining simple routes.
+Aşağıdaki örnekler nasıl basit bir şekilde yol tanımlayabileceğinizi gösterir.
 
-Respond with `Hello World!` on the homepage:
+Anasayfada `Merhaba Dünya!` ile cevap verin:
 
 ```js
 app.get('/', function (req, res) {
-  res.send('Hello World!')
+  res.send('Merhaba Dünya!')
 })
 ```
 
-Respond to POST request on the root route (`/`), the application's home page:
+Kök dizine (`/`) gelen POST isteğine bir cevap verin:
 
 ```js
 app.post('/', function (req, res) {
-  res.send('Got a POST request')
+  res.send('POST isteği geldi!')
 })
 ```
 
-Respond to a PUT request to the `/user` route:
+`/user` yoluna gelen PUT isteği:
 
 ```js
 app.put('/user', function (req, res) {
-  res.send('Got a PUT request at /user')
+  res.send('/user adresinde bir PUT isteği')
 })
 ```
 
-Respond to a DELETE request to the `/user` route:
+`/user` yoluna gelen DELETE isteği:
 
 ```js
 app.delete('/user', function (req, res) {
-  res.send('Got a DELETE request at /user')
+  res.send('/user adresinde bir DELETE isteği')
 })
 ```
 
-For more details about routing, see the [routing guide](/{{ page.lang }}/guide/routing.html).
-</div>
+Yol atama ile ilgili daha fazla detay için, [yol atama](/{{ page.lang }}/guide/routing.html) sayfasını ziyaret edin.
+
+###  [Previous: Express application generator ](/{{ page.lang }}/starter/generator.html)&nbsp;&nbsp;&nbsp;&nbsp;[Next: Serving static files in Express ](/{{ page.lang }}/starter/static-files.html)

--- a/tr/starter/faq.md
+++ b/tr/starter/faq.md
@@ -1,89 +1,68 @@
 ---
 layout: page
-title: Express FAQ
+title: Express Sıkça Sorulan Sorular
 menu: starter
 lang: tr
 ---
-<div id="page-doc" markdown="1">
-# FAQ
+# Sıkça Sorulan Sorular
 
-## How should I structure my application?
+## Uygulamamın yapısı nasıl olmalı?
 
-There is no definitive answer to this question. The answer depends
-on the scale of your application and the team that is involved. To be as
-flexible as possible, Express makes no assumptions in terms of structure.
+Bu soruya verilebilecek kesin bir cevap yoktur. Cevap, uygulamanızın boyutuna ve uygulamaya dahil ekibe göre değişir. En üst seviyede esneklik için Express uygulama yapısı için herhangi bir varsayım yapmaz.
 
-Routes and other application-specific logic can live in as many files
-as you wish, in any directory structure you prefer. View the following
-examples for inspiration:
+Yollar ve diğer uygulamaya özel mantık istediğiniz yapıda, istediğiniz kadar dosyanın içinde barınabilir. Örnek olarak şunlara göz atabilirsiniz:
 
-* [Route listings](https://github.com/strongloop/express/blob/4.13.1/examples/route-separation/index.js#L32-47)
+* [Route listings](https://github.com/strongloop/express/blob/4.13.1/examples/route-separation/index.js#L32-L47)
 * [Route map](https://github.com/strongloop/express/blob/4.13.1/examples/route-map/index.js#L52-L66)
 * [MVC style controllers](https://github.com/strongloop/express/tree/master/examples/mvc)
 
-Also, there are third-party extensions for Express, which simplify some of these patterns:
+Ayrıca, bu dizaynlardan bazılarını basitleştiren, üçüncü parti bir Express uzantısı bulunmaktadır:
 
 * [Resourceful routing](https://github.com/expressjs/express-resource)
 
-## How do I define models?
+## Nasıl model tanımlarım?
 
-Express has no notion of a database. This concept is
-left up to third-party Node modules, allowing you to
-interface with nearly any database.
+Express'te veritabanı kavramı bulunmamaktadır. Bu konsept diğer üçüncü parti modüllerine bırakılmıştır, bu sayede neredeyse herhangi bir veritabanına bağlantı sağlayabilirsiniz.
 
-See [LoopBack](http://loopback.io) for an Express-based framework that is centered around models.
+Model üzerine Express tabanlı bir framework için [LoopBack](http://loopback.io) adresini ziyaret edin.
 
-## How can I authenticate users?
+## Kimlik doğrulamasını nasıl sağlarım?
 
-Authentication is another opinionated area that Express does not
-venture into.  You may use any authentication scheme you wish.
-For a simple username / password scheme, see [this example](https://github.com/strongloop/express/tree/master/examples/auth).
+Kimlik doğrulama Express'in bulundurmayı tercih etmediği başka bir konu. İstediğiniz herhangi bir kimlik doğrulama planını kullanabilirsiniz. Basit kullanıcı adı / şifre planı için [bu örneğe](https://github.com/expressjs/express/tree/master/examples/auth) göz atın.
 
+## Express hangi görünüm (view) motorlarını destekliyor?
 
-## Which template engines does Express support?
+Express `(path, locals, callback)` kalıbını sağlayan herhangi bir görünüm motorunu destekler. Şablon motoru arayüzlerini ve önbelleklemeyi normalleştirmek için, [consolidate.js](https://github.com/visionmedia/consolidate.js)'e göz atın. Listelenmeyen görünüm motorları da Express'in yapısına uygun olabilir.
 
-Express supports any template engine that conforms with the `(path, locals, callback)` signature.
-To normalize template engine interfaces and caching, see the
-[consolidate.js](https://github.com/visionmedia/consolidate.js)
-project for support. Unlisted template engines might still support the Express signature.
+Daha fazla bilgi için, [Express ile görünüm motorlarını kullanmak](/{{page.lang}}/guide/using-template-engines.html).
 
-## How do I handle 404 responses?
+## 404 cevapları ile nasıl başa çıkarım?
 
-In Express, 404 responses are not the result of an error, so
-the error-handler middleware will not capture them. This behavior is
-because a 404 response simply indicates the absence of additional work to do;
-in other words, Express has executed all middleware functions and routes,
-and found that none of them responded. All you need to
-do is add a middleware function at the very bottom of the stack (below all other functions)
-to handle a 404 response:
+Express'te 404 cevapları bir hatanın sonucu olarak ortaya çıkmaz, bu yüzden hata işleyici ara katman bunları yakalamaz. Bunun sebebi 404 cevabı sadece yapılacak ekstra işin eksik olduğunu belirtir; başka bir sözle, Express tüm ara katman fonksiyonlarını ve yolları çalıştırdı, ve bunların hiçbirinin cevap döndürmediğini fark etti. Tek yapmanız gereken, bu yığının (tüm fonksiyonların) en sonuna 404'ü işleyen bir ara katman fonksiyonu yazmak:
 
 ```js
 app.use(function (req, res, next) {
-  res.status(404).send("Sorry can't find that!")
+  res.status(404).send("Üzgünüm, dosyayı bulamadım!")
 })
 ```
 
-Add routes dynamically at runtime on an instance of `express.Router()`
-so the routes are not superseded by a middleware function.
+Yolları dinamik olarak `express.Router()`'ın bir örneği üzerine tanımlayın, böylece tanımlarınızın yerine ara katman fonksiyonları geçmez.
 
-## How do I setup an error handler?
+## Hata işleyici fonksiyonları nasıl kullanabilirim?
 
-You define error-handling middleware in the same way as other middleware,
-except with four arguments instead of three; specifically with the signature `(err, req, res, next)`:
+Hata ile ilgili ara katman fonksiyonları da tıpkı diğer ara katman fonksiyonları gibi tanımlanır. Aradaki tek fark üç argüman yerine şu şekilde dört argüman kullanılmasıdır `(err, req, res, next)`:
 
 ```js
 app.use(function (err, req, res, next) {
   console.error(err.stack)
-  res.status(500).send('Something broke!')
+  res.status(500).send('Bir hata oluştu!')
 })
 ```
 
-For more information, see [Error handling](/{{ page.lang }}/guide/error-handling.html).
+Daha fazla bilgi için, [Hata işleme](/{{ page.lang }}/guide/error-handling.html).
 
-## How do I render plain HTML?
+## Yalın HTML dosyalarını nasıl işlerim?
 
-You don't! There's no need to "render" HTML with the `res.render()` function.
-If you have a specific file, use the `res.sendFile()` function.
-If you are serving many assets from a directory, use the `express.static()`
-middleware function.
-</div>
+Yalın HTML için `res.render()` fonksiyonun kullanmak zorunda değilsiniz. Eğer dosyanız belirli ise, `res.sendFile()` fonksiyonunu kullanın. Eğer bir dizinden birden çok içerik sunuyorsanız, `express.static()` ara katman fonksiyonunu kullanın.
+
+###  [Önceki: Statik Dosyalar ](/{{ page.lang }}/starter/static-files.html)

--- a/tr/starter/generator.md
+++ b/tr/starter/generator.md
@@ -1,21 +1,20 @@
 ---
 layout: page
-title: Express application generator
+title: Express uygulama oluşturucu
 menu: starter
 lang: tr
 ---
-<div id="page-doc" markdown="1">
-# Express application generator
+# Express uygulama oluşturucu
 
-Use the application generator tool, `express-generator`, to quickly create an application skeleton.
+Çabukça bir uygulama iskeleti oluşturmak için, `express-generator` aracını kullanın.
 
-The `express-generator` package installs the `express` command-line tool. Use the following command to do so:
+`express-generator` paketi `express` komut-satır aracını kurar. Bunu yapmak için aşağıdaki komutu çalıştırın:
 
 ```sh
 $ npm install express-generator -g
 ```
 
-Display the command options with the `-h` option:
+Komut seçeneklerini `-h` opsiyonu ile görüntüleyin:
 
 ```sh
 $ express -h
@@ -37,7 +36,7 @@ $ express -h
     -f, --force         force on non-empty directory
 ```
 
-For example, the following creates an Express app named _myapp_. The app will be created in a folder named _myapp_ in the current working directory and the view engine will be set to <a href="https://pugjs.org/" target="_blank" title="Pug documentation">Pug</a>:
+aşağıdaki örnek, _myapp_ adında bir Express uygulaması yaratır. Uygulama _myapp_ dizininde barınacak ve görünüm (view) motoru <a href="https://pugjs.org/" target="_blank" title="Pug documentation">Pug</a> olarak ayarlanacaktır.
 
 ```sh
 $ express --view=pug myapp
@@ -61,28 +60,28 @@ $ express --view=pug myapp
    create : myapp/bin/www
 ```
 
-Then install dependencies:
+Daha sonrasında bağımlılıkları kurun:
 
 ```sh
 $ cd myapp
 $ npm install
 ```
 
-On MacOS or Linux, run the app with this command:
+MacOS veya Linux için uygulamayı bu komut ile çalıştırın:
 
 ```sh
 $ DEBUG=myapp:* npm start
 ```
 
-On Windows, use this command:
+Windows için bu komutu kullanın:
 
 ```sh
 > set DEBUG=myapp:* & npm start
 ```
 
-Then load `http://localhost:3000/` in your browser to access the app.
+Uygulamaya erişmek için tarayıcınızda `http://localhost:3000/` adresini ziyaret edin.
 
-The generated app has the following directory structure:
+Oluşturulan uygulamanın dizini aşağıdaki yapıda olacaktır:
 
 ```sh
 .
@@ -107,6 +106,7 @@ The generated app has the following directory structure:
 ```
 
 <div class="doc-box doc-info" markdown="1">
-The app structure created by the generator is just one of many ways to structure Express apps. Feel free to use this structure or modify it to best suit your needs.
+Burada oluşturulan dizin yapısı, Express uygulamasını yapılandırabileceğiniz birçok seçenekten sadece birisidir. İhtiyacınıza en uygun şekilde bu yapıyı kullanabilir ya da düzenleyebilirsiniz.
 </div>
-</div>
+
+###  [Önceki: Merhaba Dünya ](/{{ page.lang }}/starter/hello-world.html)&nbsp;&nbsp;&nbsp;&nbsp;[Sonraki: Basit Yol Atama](/{{ page.lang }}/starter/basic-routing.html)

--- a/tr/starter/hello-world.md
+++ b/tr/starter/hello-world.md
@@ -1,46 +1,54 @@
 ---
 layout: page
-title: Express "Hello World" example
+title: Express "Merhaba Dünya" örneği
 menu: starter
 lang: tr
 ---
-<div id="page-doc" markdown="1">
+
 # Merhaba Dünya Örneği
 
 <div class="doc-box doc-info" markdown="1">
-This is essentially going to be the simplest Express app you can create. It is a single file app &mdash; _not_ what you'd get if you use the [Express generator](/{{ page.lang }}/starter/generator.html), which creates the scaffolding for a full app with numerous JavaScript files, Jade templates, and sub-directories for various purposes.
+Aşağıda verilmiş olan, Express ile oluşturabileceğiniz en basit uygulamadır. Bu, birçok JavaScript dosyası, Jade şablonları ve çeşitli alt dizinler içeren [Express generator](/{{ page.lang }}/starter/generator.html) ile oluşturacağınız projelerin aksine tek dosyadan oluşan bir projedir.
 </div>
 
-First create a directory named `myapp`, change to it and run `npm init`. Then install `express` as a dependency, as per the [installation guide](/{{ page.lang }}/starter/installing.html).
-
-In the `myapp` directory, create a file named `app.js` and add the following code:
-
-```js
+<script src="https://embed.runkit.com" data-element-id="hello-example" data-mode="endpoint" async defer></script>
+<div id="hello-example"><pre><code class="language-js">
 const express = require('express')
 const app = express()
+const port = 3000
 
-app.get('/', function (req, res) {
-  res.send('Hello World!')
-})
+app.get('/', (req, res) => res.send('Merhaba Dünya!'))
 
-app.listen(3000, function () {
-  console.log('Example app listening on port 3000!')
-})
-```
+app.listen(port, () => console.log(`Example app listening on port ${port}!`))
+</code></pre></div>
 
-The app starts a server and listens on port 3000 for connections. The app responds with "Hello World!" for requests
-to the root URL (`/`) or _route_. For every other path, it will respond with a **404 Not Found**.
+Bu uygulama bir sunucu çalıştırır ve gelen bağlantılar için 3000 portunu dinler. (`/`) kök dizinine gelen isteklere "Hello World!" ile yanıt verir. Bunun haricindeki tüm adreslere, **404 Not Found** hatası verecektir.
 
-<div class="doc-box doc-notice" markdown="1">
-The `req` (request) and `res` (response) are the exact same objects that Node provides, so you can invoke
-`req.pipe()`, `req.on('data', callback)`, and anything else you would do without Express involved.
+Yukarıdaki örnek gerçekten de çalışmakta olan bir sunucudur: Yukarıda verilen adrese tıklayın. Gerçek zamanlı günlüklerle sunucunun bir cevap verdiğini göreceksiniz, ve yukarıda yapacağınız her değişiklik eş zamanlı olarak çalıştırılacaktır. Bu özellik arkada bir Node sistemine bağlı olup, tarayıcınızda bu sisteme bir arayüz sağlayan [RunKit](https://runkit.com) sayesinde bulunmaktadır.
+
+
+<div class="doc-box doc-info" markdown="1">
+RunKit bir üçüncü parti uygulamasıdır ve Express projesi ile bir bağı yoktur.
 </div>
 
-Run the app with the following command:
+### Bilgisayarınızda Çalıştırmak
+
+İlk olarak `myapp` adında bir dizin oluşturun, o dizine geçin ve `npm init` komutunu çalıştırın. Sonra `express`i [bu sayfada](/{{ page.lang }}/starter/installing.html) gösterildiği gibi bir bağımlılık olarak kurun.
+
+`myapp` dizininde `app.js` adında bir dosya oluşturun ve yukarıdaki kodu bu dosyaya kopyalayın.
+
+<div class="doc-box doc-notice" markdown="1">
+`req` (request/istek) ve `res` (response/cevap) objeleri Node'da bulunanlar ile birebir aynıdır, bu yüzden
+`req.pipe()`, `req.on('data', callback)`, gibi komutları Express dahil olmadan kullanabilirsiniz.
+</div>
+
+Uygulamayı aşağıdaki komutla çalıştırın:
 
 ```sh
 $ node app.js
 ```
 
-Then, load `http://localhost:3000/` in a browser to see the output.
-</div>
+Sonucu görmek için sunucunuzda `http://localhost:3000/` adresini ziyaret edin.
+
+###  [Önceki: Kurulum ](/{{ page.lang }}/starter/installing.html)&nbsp;&nbsp;&nbsp;&nbsp;[Sonraki: Express Oluşturucu ](/{{ page.lang }}/starter/generator.html)
+

--- a/tr/starter/installing.md
+++ b/tr/starter/installing.md
@@ -1,48 +1,53 @@
 ---
 layout: page
-title: Installing Express
+title: Express Kurulumu
 menu: starter
 lang: tr
 ---
-<div id="page-doc" markdown="1">
-# Installing
 
-Assuming you've already installed [Node.js](https://nodejs.org/), create a directory to hold your application, and make that your working directory.
+# Kurulum
+
+[Node.js](https://nodejs.org/)'in kurulu olduğunu varsayarak, uygulamanızı
+barındıracak bir dizin oluşturun ve o dizine geçiş yapın.
 
 ```sh
 $ mkdir myapp
 $ cd myapp
 ```
 
-Use the `npm init` command to create a `package.json` file for your application.
-For more information on how `package.json` works, see [Specifics of npm's package.json handling](https://docs.npmjs.com/files/package.json).
+Uygulamanız için `package.json` dosyasını oluşturmak için `npm init` komutunu
+çalıştırın. 
+`package.json` dosyasının nasıl çalıştığı hakkında daha fazla bilgi edinmek için [Specifics of npm's package.json handling](https://docs.npmjs.com/files/package.json) adresini kullanın.
 
 ```sh
 $ npm init
 ```
 
-This command prompts you for a number of things, such as the name and version of your application.
-For now, you can simply hit RETURN to accept the defaults for most of them, with the following exception:
+Bu komut size uygulamanızın adı ve versiyonu gibi bir kaç soru yöneltecektir.
+Şimdilik, çoğu soru için ENTER tuşuna basıp varsayılan ayarları uygulayabilirsiniz, aşağıdaki hariç:
+
 
 ```sh
 entry point: (index.js)
 ```
 
-Enter `app.js`, or whatever you want the name of the main file to be. If you want it to be `index.js`, hit RETURN to accept the suggested default file name.
+`app.js` ya da ana dosyanıza vermek istediğiniz ismi girin. Eğer ana dosyanızın `index.js` olmasını istiyorsanız, ENTER tuşu ile varsayılanı uygulayabilirsiniz.
 
-Now install Express in the `myapp` directory and save it in the dependencies list. For example:
+Şimdi Express'i `myapp` dizinine kurun ve bağımlı uygulamalar listesine ekleyin. Örneğin:
+
 
 ```sh
 $ npm install express --save
 ```
 
-To install Express temporarily and not add it to the dependencies list:
+Express'i geçici olarak kurmak ve bağımlı uygulamalar listesine eklememek istiyorsanız:
 
 ```sh
 $ npm install express --no-save
 ```
 
 <div class="doc-box doc-info" markdown="1">
-By default with version npm 5.0+ npm install adds the module to the `dependencies` list in the `package.json` file; with earlier versions of npm, you must specify the `--save` option explicitly. Then, afterwards, running `npm install` in the app directory will automatically install modules in the dependencies list.
+npm 5.0+ versiyonları için npm install komutu, kurulacak modülü varsayılan olarak `package.json` içindeki bağımlılıklar listesine ekler; daha eski npm versiyonları için `--save` ayrıca belirtilmelidir. Daha sonrasında, uygulama dizininde `npm install` komutunu çalıştırmak, bağımlılık listesindeki uygulamaları otomatik olarak yükler.
 </div>
-</div>
+
+###  [Sonraki: Merhaba Dünya ](/{{ page.lang }}/starter/hello-world.html)

--- a/tr/starter/static-files.md
+++ b/tr/starter/static-files.md
@@ -1,21 +1,29 @@
 ---
 layout: page
-title: Serving static files in Express
+title: Express ile statik dosyalar
 menu: starter
 lang: tr
 ---
-<div id="page-doc" markdown="1">
-# Serving static files in Express
+# Express ile statik dosyaları sunmak
 
-To serve static files such as images, CSS files, and JavaScript files, use the `express.static` built-in middleware function in Express.
+Görseller, CSS dosyaları ve JavaScript dosyaları gibi statik dosyaları sunmak için, Express'te bulunan `express.static` ara katmanını kullanın.
 
-Pass the name of the directory that contains the static assets to the `express.static` middleware function to start serving the files directly. For example, use the following code to serve images, CSS files, and JavaScript files in a directory named `public`:
+Fonksiyonun yapısı şu şekildedir:
+
+```js
+express.static(root, [options])
+```
+
+`root` argümanı statik dosyaların bulunduğu ana dizine karşılık gelir. 
+`options` argümanı hakkında detaylı bilgi için, [express.static](/{{page.lang}}/4x/api.html#express.static) sayfasını ziyaret edin.
+
+Örneğin, `public` dizininde bulunan görselleri, CSS dosyalarını ve JavaScript dosyalarını sunmak için bunu kullanın:
 
 ```js
 app.use(express.static('public'))
 ```
 
-Now, you can load the files that are in the `public` directory:
+Artık `public` dizininde bulunan statik dosyaları görebilirsiniz:
 
 ```plain-text
 http://localhost:3000/images/kitten.jpg
@@ -26,25 +34,29 @@ http://localhost:3000/hello.html
 ```
 
 <div class="doc-box doc-info">
-Express looks up the files relative to the static directory, so the name of the static directory is not part of the URL.
+Express statik dosyaların yerlerine ana dizine bağlı olarak bakar. Bu yüzden statik dosyaları barındıran ana dizin URL'de bulunmaz.
 </div>
 
-To use multiple static assets directories, call the `express.static` middleware function multiple times:
+Birden fazla statik dosya dizini kullanmak için `express.static` fonksiyonun birden fazla kullanabilirsiniz.
 
 ```js
 app.use(express.static('public'))
 app.use(express.static('files'))
 ```
 
-Express looks up the files in the order in which you set the static directories with the `express.static` middleware function.
+Express statik dosyalara `express.static` ile tanımladığınız sırayla bakar.
 
-To create a virtual path prefix (where the path does not actually exist in the file system) for files that are served by the `express.static` function, [specify a mount path](/{{ page.lang }}/4x/api.html#app.use) for the static directory, as shown below:
+<div class="doc-box doc-info" markdown="1">NOT: En iyi sonuç için, statik dosyaları sunarken performansı artırmak için [reverse proxy](/{{page.lang}}/advanced/ önbelleği kullanın.
+</div>
+
+`express.static` ile sunulan dosyalar için sanal bir yol (statik dizinin aslında gerçekte bulunmadığı) yaratmak için, statik dizine aşağıdaki gibi bir [path tanımlayın](/{{ page.lang }}/4x/api.html#app.use).
+
 
 ```js
 app.use('/static', express.static('public'))
 ```
 
-Now, you can load the files that are in the `public` directory from the `/static` path prefix.
+Artık `public` dizinindeki dosyalara `/static` önekiyle ulaşabilirsiniz.
 
 ```plain-text
 http://localhost:3000/static/images/kitten.jpg
@@ -54,9 +66,12 @@ http://localhost:3000/static/images/bg.png
 http://localhost:3000/static/hello.html
 ```
 
-However, the path that you provide to the `express.static` function is relative to the directory from where you launch your `node` process. If you run the express app from another directory, it's safer to use the absolute path of the directory that you want to serve:
+`express.static` fonksiyonu ile tanımladığınız yollar `node` processini çalıştırdığınız dizine bağlıdır. Bu yüzden, eğer express uygulamasını başka bir dizinden çalıştırıyorsanız, statik dizini tam adres olarak tanımlamanız daha güvenli olur.
 
 ```js
 app.use('/static', express.static(path.join(__dirname, 'public')))
 ```
-</div>
+
+`serve-static` hakkında daha fazla bilgi almak için, [serve-static](/{{page.lang}}/resources/middleware/serve-static.html) sayfasına göz atın.
+
+### [Önceki: Basit Yol Atama ](/{{ page.lang }}/starter/basic-routing.html)&nbsp;&nbsp;&nbsp;&nbsp;[Sonraki: Sıkça Sorulan Sorular ](/{{ page.lang }}/starter/faq.html)


### PR DESCRIPTION
Add starter page and sub pages in Turkish. Previously these pages existed, but the content was in English and of earlier versions of expressjscom.