### PR TITLE
Copy 5x documentation files

### DIFF
--- a/_includes/api/en/5x/app-METHOD.md
+++ b/_includes/api/en/5x/app-METHOD.md
@@ -1,0 +1,62 @@
+<h3 id='app.METHOD'>app.METHOD(path, callback [, callback ...])</h3>
+
+Routes an HTTP request, where METHOD is the HTTP method of the request, such as GET,
+PUT, POST, and so on, in lowercase. Thus, the actual methods are `app.get()`,
+`app.post()`, `app.put()`, and so on.  See [Routing methods](#routing-methods) below for the complete list.
+
+{% include api/en/4x/routing-args.html %}
+
+#### Routing methods
+
+Express supports the following routing methods corresponding to the HTTP methods of the same names:
+
+<table style="border: 0px; background: none">
+<tr>
+<td style="background: none; border: 0px;" markdown="1">
+* `checkout`
+* `copy`
+* `delete`
+* `get`
+* `head`
+* `lock`
+* `merge`
+* `mkactivity`
+</td>
+<td style="background: none; border: 0px;" markdown="1">
+* `mkcol`
+* `move`
+* `m-search`
+* `notify`
+* `options`
+* `patch`
+* `post`
+</td>
+<td style="background: none; border: 0px;" markdown="1">
+* `purge`
+* `put`
+* `report`
+* `search`
+* `subscribe`
+* `trace`
+* `unlock`
+* `unsubscribe`
+</td>
+</tr>
+</table>
+
+The API documentation has explicit entries only for the most popular HTTP methods `app.get()`,
+`app.post()`, `app.put()`, and `app.delete()`.
+However, the other methods listed above work in exactly the same way.
+
+To route methods that translate to invalid JavaScript variable names, use the bracket notation. For example, `app['m-search']('/', function ...`.
+
+<div class="doc-box doc-info" markdown="1">
+  The `app.get()` function is automatically called for the HTTP `HEAD` method in addition to the `GET`
+  method if `app.head()` was not called for the path before `app.get()`.
+</div>
+
+The method, `app.all()`, is not derived from any HTTP method and loads middleware at
+the specified path for _all_ HTTP request methods.
+For more information, see [app.all](#app.all).
+
+For more information on routing, see the [routing guide](/guide/routing.html).

--- a/_includes/api/en/5x/app-all.md
+++ b/_includes/api/en/5x/app-all.md
@@ -1,0 +1,44 @@
+<h3 id='app.all'>app.all(path, callback [, callback ...])</h3>
+
+This method is like the standard [app.METHOD()](#app.METHOD) methods,
+except it matches all HTTP verbs.
+
+{% include api/en/4x/routing-args.html %}
+
+#### Examples
+
+The following callback is executed for requests to `/secret` whether using
+GET, POST, PUT, DELETE, or any other HTTP request method:
+
+```js
+app.all('/secret', function (req, res, next) {
+  console.log('Accessing the secret section ...')
+  next() // pass control to the next handler
+});
+```
+
+The `app.all()` method is useful for mapping "global" logic for specific path prefixes or arbitrary matches.  For example, if you put the following at the top of all other
+route definitions, it requires that all routes from that point on
+require authentication, and automatically load a user. Keep in mind
+that these callbacks do not have to act as end-points: `loadUser`
+can perform a task, then call `next()` to continue matching subsequent
+routes.
+
+```js
+app.all('*', requireAuthentication, loadUser);
+```
+
+Or the equivalent:
+
+```js
+app.all('*', requireAuthentication);
+app.all('*', loadUser);
+```
+
+Another example is white-listed "global" functionality.
+The example is similar to the ones above, but it only restricts paths that start with
+"/api":
+
+```js
+app.all('/api/*', requireAuthentication);
+```

--- a/_includes/api/en/5x/app-all.md
+++ b/_includes/api/en/5x/app-all.md
@@ -14,7 +14,7 @@ GET, POST, PUT, DELETE, or any other HTTP request method:
 app.all('/secret', function (req, res, next) {
   console.log('Accessing the secret section ...')
   next() // pass control to the next handler
-});
+})
 ```
 
 The `app.all()` method is useful for mapping "global" logic for specific path prefixes or arbitrary matches.  For example, if you put the following at the top of all other
@@ -25,14 +25,14 @@ can perform a task, then call `next()` to continue matching subsequent
 routes.
 
 ```js
-app.all('*', requireAuthentication, loadUser);
+app.all('*', requireAuthentication, loadUser)
 ```
 
 Or the equivalent:
 
 ```js
-app.all('*', requireAuthentication);
-app.all('*', loadUser);
+app.all('*', requireAuthentication)
+app.all('*', loadUser)
 ```
 
 Another example is white-listed "global" functionality.
@@ -40,5 +40,5 @@ The example is similar to the ones above, but it only restricts paths that start
 "/api":
 
 ```js
-app.all('/api/*', requireAuthentication);
+app.all('/api/*', requireAuthentication)
 ```

--- a/_includes/api/en/5x/app-delete-method.md
+++ b/_includes/api/en/5x/app-delete-method.md
@@ -1,0 +1,14 @@
+<h3 id='app.delete.method'>app.delete(path, callback [, callback ...])</h3>
+
+Routes HTTP DELETE requests to the specified path with the specified callback functions.
+For more information, see the [routing guide](/guide/routing.html).
+
+{% include api/en/4x/routing-args.html %}
+
+#### Example
+
+```js
+app.delete('/', function (req, res) {
+  res.send('DELETE request to homepage');
+});
+```

--- a/_includes/api/en/5x/app-delete-method.md
+++ b/_includes/api/en/5x/app-delete-method.md
@@ -9,6 +9,6 @@ For more information, see the [routing guide](/guide/routing.html).
 
 ```js
 app.delete('/', function (req, res) {
-  res.send('DELETE request to homepage');
-});
+  res.send('DELETE request to homepage')
+})
 ```

--- a/_includes/api/en/5x/app-disable.md
+++ b/_includes/api/en/5x/app-disable.md
@@ -1,0 +1,12 @@
+<h3 id='app.disable'>app.disable(name)</h3>
+
+Sets the Boolean setting `name` to `false`, where `name` is one of the properties from the [app settings table](#app.settings.table).
+Calling `app.set('foo', false)` for a Boolean property is the same as calling `app.disable('foo')`.
+
+For example:
+
+```js
+app.disable('trust proxy');
+app.get('trust proxy');
+// => false
+```

--- a/_includes/api/en/5x/app-disable.md
+++ b/_includes/api/en/5x/app-disable.md
@@ -6,7 +6,7 @@ Calling `app.set('foo', false)` for a Boolean property is the same as calling `a
 For example:
 
 ```js
-app.disable('trust proxy');
-app.get('trust proxy');
+app.disable('trust proxy')
+app.get('trust proxy')
 // => false
 ```

--- a/_includes/api/en/5x/app-disabled.md
+++ b/_includes/api/en/5x/app-disabled.md
@@ -1,0 +1,13 @@
+<h3 id='app.disabled'>app.disabled(name)</h3>
+
+Returns `true` if the Boolean setting `name` is disabled (`false`), where `name` is one of the properties from
+the [app settings table](#app.settings.table).
+
+```js
+app.disabled('trust proxy');
+// => true
+
+app.enable('trust proxy');
+app.disabled('trust proxy');
+// => false
+```

--- a/_includes/api/en/5x/app-disabled.md
+++ b/_includes/api/en/5x/app-disabled.md
@@ -4,10 +4,10 @@ Returns `true` if the Boolean setting `name` is disabled (`false`), where `name`
 the [app settings table](#app.settings.table).
 
 ```js
-app.disabled('trust proxy');
+app.disabled('trust proxy')
 // => true
 
-app.enable('trust proxy');
-app.disabled('trust proxy');
+app.enable('trust proxy')
+app.disabled('trust proxy')
 // => false
 ```

--- a/_includes/api/en/5x/app-enable.md
+++ b/_includes/api/en/5x/app-enable.md
@@ -1,0 +1,10 @@
+<h3 id='app.enable'>app.enable(name)</h3>
+
+Sets the Boolean setting `name` to `true`, where `name` is one of the properties from the [app settings table](#app.settings.table).
+Calling `app.set('foo', true)` for a Boolean property is the same as calling `app.enable('foo')`.
+
+```js
+app.enable('trust proxy');
+app.get('trust proxy');
+// => true
+```

--- a/_includes/api/en/5x/app-enable.md
+++ b/_includes/api/en/5x/app-enable.md
@@ -4,7 +4,7 @@ Sets the Boolean setting `name` to `true`, where `name` is one of the properties
 Calling `app.set('foo', true)` for a Boolean property is the same as calling `app.enable('foo')`.
 
 ```js
-app.enable('trust proxy');
-app.get('trust proxy');
+app.enable('trust proxy')
+app.get('trust proxy')
 // => true
 ```

--- a/_includes/api/en/5x/app-enabled.md
+++ b/_includes/api/en/5x/app-enabled.md
@@ -1,0 +1,13 @@
+<h3 id='app.enabled'>app.enabled(name)</h3>
+
+Returns `true` if the setting `name` is enabled (`true`), where `name` is one of the
+properties from the [app settings table](#app.settings.table).
+
+```js
+app.enabled('trust proxy');
+// => false
+
+app.enable('trust proxy');
+app.enabled('trust proxy');
+// => true
+```

--- a/_includes/api/en/5x/app-enabled.md
+++ b/_includes/api/en/5x/app-enabled.md
@@ -4,10 +4,10 @@ Returns `true` if the setting `name` is enabled (`true`), where `name` is one of
 properties from the [app settings table](#app.settings.table).
 
 ```js
-app.enabled('trust proxy');
+app.enabled('trust proxy')
 // => false
 
-app.enable('trust proxy');
-app.enabled('trust proxy');
+app.enable('trust proxy')
+app.enabled('trust proxy')
 // => true
 ```

--- a/_includes/api/en/5x/app-engine.md
+++ b/_includes/api/en/5x/app-engine.md
@@ -1,0 +1,36 @@
+<h3 id='app.engine'>app.engine(ext, callback)</h3>
+
+Registers the given template engine `callback` as `ext`.
+
+By default, Express will `require()` the engine based on the file extension.
+For example, if you try to render a "foo.pug" file, Express invokes the
+following internally, and caches the `require()` on subsequent calls to increase
+performance.
+
+```js
+app.engine('pug', require('pug').__express);
+```
+
+Use this method for engines that do not provide `.__express` out of the box,
+or if you wish to "map" a different extension to the template engine.
+
+For example, to map the EJS template engine to ".html" files:
+
+```js
+app.engine('html', require('ejs').renderFile);
+```
+
+In this case, EJS provides a `.renderFile()` method with
+the same signature that Express expects: `(path, options, callback)`,
+though note that it aliases this method as `ejs.__express` internally
+so if you're using ".ejs" extensions you don't need to do anything.
+
+Some template engines do not follow this convention.  The
+[consolidate.js](https://github.com/tj/consolidate.js) library maps Node template engines to follow this convention,
+so they work seamlessly with Express.
+
+```js
+var engines = require('consolidate');
+app.engine('haml', engines.haml);
+app.engine('html', engines.hogan);
+```

--- a/_includes/api/en/5x/app-engine.md
+++ b/_includes/api/en/5x/app-engine.md
@@ -8,7 +8,7 @@ following internally, and caches the `require()` on subsequent calls to increase
 performance.
 
 ```js
-app.engine('pug', require('pug').__express);
+app.engine('pug', require('pug').__express)
 ```
 
 Use this method for engines that do not provide `.__express` out of the box,
@@ -17,7 +17,7 @@ or if you wish to "map" a different extension to the template engine.
 For example, to map the EJS template engine to ".html" files:
 
 ```js
-app.engine('html', require('ejs').renderFile);
+app.engine('html', require('ejs').renderFile)
 ```
 
 In this case, EJS provides a `.renderFile()` method with
@@ -30,7 +30,7 @@ Some template engines do not follow this convention.  The
 so they work seamlessly with Express.
 
 ```js
-var engines = require('consolidate');
-app.engine('haml', engines.haml);
-app.engine('html', engines.hogan);
+var engines = require('consolidate')
+app.engine('haml', engines.haml)
+app.engine('html', engines.hogan)
 ```

--- a/_includes/api/en/5x/app-get-method.md
+++ b/_includes/api/en/5x/app-get-method.md
@@ -1,0 +1,15 @@
+<h3 id='app.get.method'>app.get(path, callback [, callback ...])</h3>
+
+Routes HTTP GET requests to the specified path with the specified callback functions.
+
+{% include api/en/4x/routing-args.html %}
+
+For more information, see the [routing guide](/guide/routing.html).
+
+#### Example
+
+```js
+app.get('/', function (req, res) {
+  res.send('GET request to homepage');
+});
+```

--- a/_includes/api/en/5x/app-get-method.md
+++ b/_includes/api/en/5x/app-get-method.md
@@ -10,6 +10,6 @@ For more information, see the [routing guide](/guide/routing.html).
 
 ```js
 app.get('/', function (req, res) {
-  res.send('GET request to homepage');
-});
+  res.send('GET request to homepage')
+})
 ```

--- a/_includes/api/en/5x/app-get.md
+++ b/_includes/api/en/5x/app-get.md
@@ -1,0 +1,13 @@
+<h3 id='app.get'>app.get(name)</h3>
+
+Returns the value of `name` app setting, where `name` is one of the strings in the
+[app settings table](#app.settings.table). For example:
+
+```js
+app.get('title');
+// => undefined
+
+app.set('title', 'My Site');
+app.get('title');
+// => "My Site"
+```

--- a/_includes/api/en/5x/app-get.md
+++ b/_includes/api/en/5x/app-get.md
@@ -4,10 +4,10 @@ Returns the value of `name` app setting, where `name` is one of the strings in t
 [app settings table](#app.settings.table). For example:
 
 ```js
-app.get('title');
+app.get('title')
 // => undefined
 
-app.set('title', 'My Site');
-app.get('title');
+app.set('title', 'My Site')
+app.get('title')
 // => "My Site"
 ```

--- a/_includes/api/en/5x/app-listen.md
+++ b/_includes/api/en/5x/app-listen.md
@@ -4,9 +4,9 @@ Starts a UNIX socket and listens for connections on the given path.
 This method is identical to Node's [http.Server.listen()](https://nodejs.org/api/http.html#http_server_listen).
 
 ```js
-var express = require('express');
-var app = express();
-app.listen('/tmp/sock');
+var express = require('express')
+var app = express()
+app.listen('/tmp/sock')
 ```
 
 <h3 id='app.listen'>app.listen([port[, host[, backlog]]][, callback])</h3>
@@ -18,9 +18,9 @@ If port is omitted or is 0, the operating system will assign an arbitrary unused
 port, which is useful for cases like automated tasks (tests, etc.).
 
 ```js
-var express = require('express');
-var app = express();
-app.listen(3000);
+var express = require('express')
+var app = express()
+app.listen(3000)
 ```
 
 The `app` returned by `express()` is in fact a JavaScript
@@ -30,22 +30,22 @@ your app with the same code base, as the app does not inherit from these
 (it is simply a callback):
 
 ```js
-var express = require('express');
-var https = require('https');
-var http = require('http');
-var app = express();
+var express = require('express')
+var https = require('https')
+var http = require('http')
+var app = express()
 
-http.createServer(app).listen(80);
-https.createServer(options, app).listen(443);
+http.createServer(app).listen(80)
+https.createServer(options, app).listen(443)
 ```
 
 The `app.listen()` method returns an [http.Server](https://nodejs.org/api/http.html#http_class_http_server) object and (for HTTP) is a convenience method for the following:
 
 ```js
-app.listen = function() {
-  var server = http.createServer(this);
-  return server.listen.apply(server, arguments);
-};
+app.listen = function () {
+  var server = http.createServer(this)
+  return server.listen.apply(server, arguments)
+}
 ```
 
 <div class="doc-box doc-info" markdown="1">

--- a/_includes/api/en/5x/app-listen.md
+++ b/_includes/api/en/5x/app-listen.md
@@ -1,0 +1,55 @@
+<h3 id='app.listen_path_callback'>app.listen(path, [callback])</h3>
+
+Starts a UNIX socket and listens for connections on the given path.
+This method is identical to Node's [http.Server.listen()](https://nodejs.org/api/http.html#http_server_listen).
+
+```js
+var express = require('express');
+var app = express();
+app.listen('/tmp/sock');
+```
+
+<h3 id='app.listen'>app.listen([port[, host[, backlog]]][, callback])</h3>
+
+Binds and listens for connections on the specified host and port.
+This method is identical to Node's [http.Server.listen()](https://nodejs.org/api/http.html#http_server_listen).
+
+If port is omitted or is 0, the operating system will assign an arbitrary unused
+port, which is useful for cases like automated tasks (tests, etc.).
+
+```js
+var express = require('express');
+var app = express();
+app.listen(3000);
+```
+
+The `app` returned by `express()` is in fact a JavaScript
+`Function`, designed to be passed to Node's HTTP servers as a callback
+to handle requests. This makes it easy to provide both HTTP and HTTPS versions of
+your app with the same code base, as the app does not inherit from these
+(it is simply a callback):
+
+```js
+var express = require('express');
+var https = require('https');
+var http = require('http');
+var app = express();
+
+http.createServer(app).listen(80);
+https.createServer(options, app).listen(443);
+```
+
+The `app.listen()` method returns an [http.Server](https://nodejs.org/api/http.html#http_class_http_server) object and (for HTTP) is a convenience method for the following:
+
+```js
+app.listen = function() {
+  var server = http.createServer(this);
+  return server.listen.apply(server, arguments);
+};
+```
+
+<div class="doc-box doc-info" markdown="1">
+NOTE: All the forms of Node's
+[http.Server.listen()](https://nodejs.org/api/http.html#http_server_listen)
+method are in fact actually supported.
+</div>

--- a/_includes/api/en/5x/app-locals.md
+++ b/_includes/api/en/5x/app-locals.md
@@ -1,0 +1,25 @@
+<h3 id='app.locals'>app.locals</h3>
+
+The `app.locals` object has properties that are local variables within the application.
+
+```js
+app.locals.title
+// => 'My App'
+
+app.locals.email
+// => 'me@myapp.com'
+```
+
+Once set, the value of `app.locals` properties persist throughout the life of the application,
+in contrast with [res.locals](#res.locals) properties that
+are valid only for the lifetime of the request.
+
+You can access local variables in templates rendered within the application.
+This is useful for providing helper functions to templates, as well as application-level data.
+Local variables are available in middleware via `req.app.locals` (see [req.app](#req.app))
+
+```js
+app.locals.title = 'My App';
+app.locals.strftime = require('strftime');
+app.locals.email = 'me@myapp.com';
+```

--- a/_includes/api/en/5x/app-locals.md
+++ b/_includes/api/en/5x/app-locals.md
@@ -3,10 +3,10 @@
 The `app.locals` object has properties that are local variables within the application.
 
 ```js
-app.locals.title
+console.dir(app.locals.title)
 // => 'My App'
 
-app.locals.email
+console.dir(app.locals.email)
 // => 'me@myapp.com'
 ```
 

--- a/_includes/api/en/5x/app-locals.md
+++ b/_includes/api/en/5x/app-locals.md
@@ -19,7 +19,7 @@ This is useful for providing helper functions to templates, as well as applicati
 Local variables are available in middleware via `req.app.locals` (see [req.app](#req.app))
 
 ```js
-app.locals.title = 'My App';
-app.locals.strftime = require('strftime');
-app.locals.email = 'me@myapp.com';
+app.locals.title = 'My App'
+app.locals.strftime = require('strftime')
+app.locals.email = 'me@myapp.com'
 ```

--- a/_includes/api/en/5x/app-mountpath.md
+++ b/_includes/api/en/5x/app-mountpath.md
@@ -1,0 +1,45 @@
+<h3 id='app.mountpath'>app.mountpath</h3>
+
+The `app.mountpath` property contains one or more path patterns on which a sub-app was mounted.
+
+<div class="doc-box doc-info" markdown="1">
+  A sub-app is an instance of `express` that may be used for handling the request to a route.
+</div>
+
+```js
+var express = require('express');
+
+var app = express(); // the main app
+var admin = express(); // the sub app
+
+admin.get('/', function (req, res) {
+  console.log(admin.mountpath); // /admin
+  res.send('Admin Homepage');
+});
+
+app.use('/admin', admin); // mount the sub app
+```
+
+It is similar to the [baseUrl](#req.baseUrl) property of the `req` object, except `req.baseUrl`
+returns the matched URL path, instead of the matched patterns.
+
+If a sub-app is mounted on multiple path patterns, `app.mountpath` returns the list of
+patterns it is mounted on, as shown in the following example.
+
+```js
+var admin = express();
+
+admin.get('/', function (req, res) {
+  console.log(admin.mountpath); // [ '/adm*n', '/manager' ]
+  res.send('Admin Homepage');
+});
+
+var secret = express();
+secret.get('/', function (req, res) {
+  console.log(secret.mountpath); // /secr*t
+  res.send('Admin Secret');
+});
+
+admin.use('/secr*t', secret); // load the 'secret' router on '/secr*t', on the 'admin' sub app
+app.use(['/adm*n', '/manager'], admin); // load the 'admin' router on '/adm*n' and '/manager', on the parent app
+```

--- a/_includes/api/en/5x/app-mountpath.md
+++ b/_includes/api/en/5x/app-mountpath.md
@@ -7,17 +7,17 @@ The `app.mountpath` property contains one or more path patterns on which a sub-a
 </div>
 
 ```js
-var express = require('express');
+var express = require('express')
 
-var app = express(); // the main app
-var admin = express(); // the sub app
+var app = express() // the main app
+var admin = express() // the sub app
 
 admin.get('/', function (req, res) {
-  console.log(admin.mountpath); // /admin
-  res.send('Admin Homepage');
-});
+  console.log(admin.mountpath) // /admin
+  res.send('Admin Homepage')
+})
 
-app.use('/admin', admin); // mount the sub app
+app.use('/admin', admin) // mount the sub app
 ```
 
 It is similar to the [baseUrl](#req.baseUrl) property of the `req` object, except `req.baseUrl`
@@ -27,19 +27,19 @@ If a sub-app is mounted on multiple path patterns, `app.mountpath` returns the l
 patterns it is mounted on, as shown in the following example.
 
 ```js
-var admin = express();
+var admin = express()
 
 admin.get('/', function (req, res) {
-  console.log(admin.mountpath); // [ '/adm*n', '/manager' ]
-  res.send('Admin Homepage');
-});
+  console.log(admin.mountpath) // [ '/adm*n', '/manager' ]
+  res.send('Admin Homepage')
+})
 
-var secret = express();
+var secret = express()
 secret.get('/', function (req, res) {
-  console.log(secret.mountpath); // /secr*t
-  res.send('Admin Secret');
-});
+  console.log(secret.mountpath) // /secr*t
+  res.send('Admin Secret')
+})
 
-admin.use('/secr*t', secret); // load the 'secret' router on '/secr*t', on the 'admin' sub app
-app.use(['/adm*n', '/manager'], admin); // load the 'admin' router on '/adm*n' and '/manager', on the parent app
+admin.use('/secr*t', secret) // load the 'secret' router on '/secr*t', on the 'admin' sub app
+app.use(['/adm*n', '/manager'], admin) // load the 'admin' router on '/adm*n' and '/manager', on the parent app
 ```

--- a/_includes/api/en/5x/app-onmount.md
+++ b/_includes/api/en/5x/app-onmount.md
@@ -1,0 +1,29 @@
+<h3 id='app.onmount'>app.on('mount', callback(parent))</h3>
+
+The `mount` event is fired on a sub-app, when it is mounted on a parent app. The parent app is passed to the callback function.
+
+<div class="doc-box doc-info" markdown="1">
+**NOTE**
+
+Sub-apps will:
+
+* Not inherit the value of settings that have a default value.  You must set the value in the sub-app.
+* Inherit the value of settings with no default value.
+
+For details, see [Application settings](/en/4x/api.html#app.settings.table).
+</div>
+
+```js
+var admin = express();
+
+admin.on('mount', function (parent) {
+  console.log('Admin Mounted');
+  console.log(parent); // refers to the parent app
+});
+
+admin.get('/', function (req, res) {
+  res.send('Admin Homepage');
+});
+
+app.use('/admin', admin);
+```

--- a/_includes/api/en/5x/app-onmount.md
+++ b/_includes/api/en/5x/app-onmount.md
@@ -14,16 +14,16 @@ For details, see [Application settings](/en/4x/api.html#app.settings.table).
 </div>
 
 ```js
-var admin = express();
+var admin = express()
 
 admin.on('mount', function (parent) {
-  console.log('Admin Mounted');
-  console.log(parent); // refers to the parent app
-});
+  console.log('Admin Mounted')
+  console.log(parent) // refers to the parent app
+})
 
 admin.get('/', function (req, res) {
-  res.send('Admin Homepage');
-});
+  res.send('Admin Homepage')
+})
 
-app.use('/admin', admin);
+app.use('/admin', admin)
 ```

--- a/_includes/api/en/5x/app-param.md
+++ b/_includes/api/en/5x/app-param.md
@@ -1,0 +1,157 @@
+<h3 id='app.param'>app.param([name], callback)</h3>
+
+Add callback triggers to [route parameters](/{{ page.lang }}/guide/routing.html#route-parameters), where `name` is the name of the parameter or an array of them, and `callback` is the callback function. The parameters of the callback function are the request object, the response object, the next middleware, the value of the parameter and the name of the parameter, in that order.
+
+If `name` is an array, the `callback` trigger is registered for each parameter declared in it, in the order in which they are declared. Furthermore, for each declared parameter except the last one, a call to `next` inside the callback will call the callback for the next declared parameter. For the last parameter, a call to `next` will call the next middleware in place for the route currently being processed, just like it would if `name` were just a string.
+
+For example, when `:user` is present in a route path, you may map user loading logic to automatically provide `req.user` to the route, or perform validations on the parameter input.
+
+```js
+app.param('user', function(req, res, next, id) {
+
+  // try to get the user details from the User model and attach it to the request object
+  User.find(id, function(err, user) {
+    if (err) {
+      next(err);
+    } else if (user) {
+      req.user = user;
+      next();
+    } else {
+      next(new Error('failed to load user'));
+    }
+  });
+});
+```
+
+Param callback functions are local to the router on which they are defined. They are not inherited by mounted apps or routers. Hence, param callbacks defined on `app` will be triggered only by route parameters defined on `app` routes.
+
+All param callbacks will be called before any handler of any route in which the param occurs, and they will each be called only once in a request-response cycle, even if the parameter is matched in multiple routes, as shown in the following examples.
+
+```js
+app.param('id', function (req, res, next, id) {
+  console.log('CALLED ONLY ONCE');
+  next();
+});
+
+app.get('/user/:id', function (req, res, next) {
+  console.log('although this matches');
+  next();
+});
+
+app.get('/user/:id', function (req, res) {
+  console.log('and this matches too');
+  res.end();
+});
+```
+
+On `GET /user/42`, the following is printed:
+
+```sh
+CALLED ONLY ONCE
+although this matches
+and this matches too
+```
+
+```js
+app.param(['id', 'page'], function (req, res, next, value) {
+  console.log('CALLED ONLY ONCE with', value);
+  next();
+});
+
+app.get('/user/:id/:page', function (req, res, next) {
+  console.log('although this matches');
+  next();
+});
+
+app.get('/user/:id/:page', function (req, res) {
+  console.log('and this matches too');
+  res.end();
+});
+```
+
+On `GET /user/42/3`, the following is printed:
+
+```sh
+CALLED ONLY ONCE with 42
+CALLED ONLY ONCE with 3
+although this matches
+and this matches too
+```
+
+<div class="doc-box doc-warn" markdown="1">
+The following section describes `app.param(callback)`, which is deprecated as of v4.11.0.
+</div>
+
+The behavior of the `app.param(name, callback)` method can be altered entirely by passing only a function to `app.param()`. This function is a custom implementation of how `app.param(name, callback)` should behave - it accepts two parameters and must return a middleware.
+
+The first parameter of this function is the name of the URL parameter that should be captured, the second parameter can be any JavaScript object which might be used for returning the middleware implementation.
+
+The middleware returned by the function decides the behavior of what happens when a URL parameter is captured.
+
+In this example, the `app.param(name, callback)` signature is modified to `app.param(name, accessId)`. Instead of accepting a name and a callback, `app.param()` will now accept a name and a number.
+
+```js
+var express = require('express');
+var app = express();
+
+// customizing the behavior of app.param()
+app.param(function(param, option) {
+  return function (req, res, next, val) {
+    if (val == option) {
+      next();
+    }
+    else {
+      next('route');
+    }
+  }
+});
+
+// using the customized app.param()
+app.param('id', 1337);
+
+// route to trigger the capture
+app.get('/user/:id', function (req, res) {
+  res.send('OK');
+});
+
+app.listen(3000, function () {
+  console.log('Ready');
+});
+```
+
+In this example, the `app.param(name, callback)` signature remains the same, but instead of a middleware callback, a custom data type checking function has been defined to validate the data type of the user id.
+
+```js
+app.param(function(param, validator) {
+  return function (req, res, next, val) {
+    if (validator(val)) {
+      next();
+    }
+    else {
+      next('route');
+    }
+  }
+});
+
+app.param('id', function (candidate) {
+  return !isNaN(parseFloat(candidate)) && isFinite(candidate);
+});
+```
+
+<div class="doc-box doc-info" markdown="1">
+The '`.`' character can't be used to capture a character in your capturing regexp. For example you can't use `'/user-.+/'` to capture `'users-gami'`, use `[\\s\\S]` or `[\\w\\W]` instead (as in `'/user-[\\s\\S]+/'`.
+
+Examples:
+
+<pre><code class="language-js">
+//captures '1-a_6' but not '543-azser-sder'
+router.get('/[0-9]+-[[\\w]]*', function);
+
+//captures '1-a_6' and '543-az(ser"-sder' but not '5-a s'
+router.get('/[0-9]+-[[\\S]]*', function);
+
+//captures all (equivalent to '.*')
+router.get('[[\\s\\S]]*', function);
+</code></pre>
+
+</div>

--- a/_includes/api/en/5x/app-param.md
+++ b/_includes/api/en/5x/app-param.md
@@ -96,7 +96,7 @@ var app = express()
 // customizing the behavior of app.param()
 app.param(function (param, option) {
   return function (req, res, next, val) {
-    if (val == option) {
+    if (val === option) {
       next()
     } else {
       next('route')

--- a/_includes/api/en/5x/app-param.md
+++ b/_includes/api/en/5x/app-param.md
@@ -7,20 +7,19 @@ If `name` is an array, the `callback` trigger is registered for each parameter d
 For example, when `:user` is present in a route path, you may map user loading logic to automatically provide `req.user` to the route, or perform validations on the parameter input.
 
 ```js
-app.param('user', function(req, res, next, id) {
-
+app.param('user', function (req, res, next, id) {
   // try to get the user details from the User model and attach it to the request object
-  User.find(id, function(err, user) {
+  User.find(id, function (err, user) {
     if (err) {
-      next(err);
+      next(err)
     } else if (user) {
-      req.user = user;
-      next();
+      req.user = user
+      next()
     } else {
-      next(new Error('failed to load user'));
+      next(new Error('failed to load user'))
     }
-  });
-});
+  })
+})
 ```
 
 Param callback functions are local to the router on which they are defined. They are not inherited by mounted apps or routers. Hence, param callbacks defined on `app` will be triggered only by route parameters defined on `app` routes.
@@ -29,19 +28,19 @@ All param callbacks will be called before any handler of any route in which the 
 
 ```js
 app.param('id', function (req, res, next, id) {
-  console.log('CALLED ONLY ONCE');
-  next();
-});
+  console.log('CALLED ONLY ONCE')
+  next()
+})
 
 app.get('/user/:id', function (req, res, next) {
-  console.log('although this matches');
-  next();
-});
+  console.log('although this matches')
+  next()
+})
 
 app.get('/user/:id', function (req, res) {
-  console.log('and this matches too');
-  res.end();
-});
+  console.log('and this matches too')
+  res.end()
+})
 ```
 
 On `GET /user/42`, the following is printed:
@@ -54,19 +53,19 @@ and this matches too
 
 ```js
 app.param(['id', 'page'], function (req, res, next, value) {
-  console.log('CALLED ONLY ONCE with', value);
-  next();
-});
+  console.log('CALLED ONLY ONCE with', value)
+  next()
+})
 
 app.get('/user/:id/:page', function (req, res, next) {
-  console.log('although this matches');
-  next();
-});
+  console.log('although this matches')
+  next()
+})
 
 app.get('/user/:id/:page', function (req, res) {
-  console.log('and this matches too');
-  res.end();
-});
+  console.log('and this matches too')
+  res.end()
+})
 ```
 
 On `GET /user/42/3`, the following is printed:
@@ -91,51 +90,49 @@ The middleware returned by the function decides the behavior of what happens whe
 In this example, the `app.param(name, callback)` signature is modified to `app.param(name, accessId)`. Instead of accepting a name and a callback, `app.param()` will now accept a name and a number.
 
 ```js
-var express = require('express');
-var app = express();
+var express = require('express')
+var app = express()
 
 // customizing the behavior of app.param()
-app.param(function(param, option) {
+app.param(function (param, option) {
   return function (req, res, next, val) {
     if (val == option) {
-      next();
-    }
-    else {
-      next('route');
+      next()
+    } else {
+      next('route')
     }
   }
-});
+})
 
 // using the customized app.param()
-app.param('id', 1337);
+app.param('id', 1337)
 
 // route to trigger the capture
 app.get('/user/:id', function (req, res) {
-  res.send('OK');
-});
+  res.send('OK')
+})
 
 app.listen(3000, function () {
-  console.log('Ready');
-});
+  console.log('Ready')
+})
 ```
 
 In this example, the `app.param(name, callback)` signature remains the same, but instead of a middleware callback, a custom data type checking function has been defined to validate the data type of the user id.
 
 ```js
-app.param(function(param, validator) {
+app.param(function (param, validator) {
   return function (req, res, next, val) {
     if (validator(val)) {
-      next();
-    }
-    else {
-      next('route');
+      next()
+    } else {
+      next('route')
     }
   }
-});
+})
 
 app.param('id', function (candidate) {
-  return !isNaN(parseFloat(candidate)) && isFinite(candidate);
-});
+  return !isNaN(parseFloat(candidate)) && isFinite(candidate)
+})
 ```
 
 <div class="doc-box doc-info" markdown="1">

--- a/_includes/api/en/5x/app-path.md
+++ b/_includes/api/en/5x/app-path.md
@@ -1,0 +1,19 @@
+<h3 id='app.path'>app.path()</h3>
+
+Returns the canonical path of the app, a string.
+
+```js
+var app = express()
+  , blog = express()
+  , blogAdmin = express();
+
+app.use('/blog', blog);
+blog.use('/admin', blogAdmin);
+
+console.log(app.path()); // ''
+console.log(blog.path()); // '/blog'
+console.log(blogAdmin.path()); // '/blog/admin'
+```
+
+The behavior of this method can become very complicated in complex cases of mounted apps:
+it is usually better to use [req.baseUrl](#req.baseUrl) to get the canonical path of the app.

--- a/_includes/api/en/5x/app-path.md
+++ b/_includes/api/en/5x/app-path.md
@@ -4,15 +4,15 @@ Returns the canonical path of the app, a string.
 
 ```js
 var app = express()
-  , blog = express()
-  , blogAdmin = express();
+var blog = express()
+var blogAdmin = express()
 
-app.use('/blog', blog);
-blog.use('/admin', blogAdmin);
+app.use('/blog', blog)
+blog.use('/admin', blogAdmin)
 
-console.log(app.path()); // ''
-console.log(blog.path()); // '/blog'
-console.log(blogAdmin.path()); // '/blog/admin'
+console.log(app.path()) // ''
+console.log(blog.path()) // '/blog'
+console.log(blogAdmin.path()) // '/blog/admin'
 ```
 
 The behavior of this method can become very complicated in complex cases of mounted apps:

--- a/_includes/api/en/5x/app-post-method.md
+++ b/_includes/api/en/5x/app-post-method.md
@@ -1,0 +1,14 @@
+<h3 id='app.post.method'>app.post(path, callback [, callback ...])</h3>
+
+Routes HTTP POST requests to the specified path with the specified callback functions.
+For more information, see the [routing guide](/guide/routing.html).
+
+{% include api/en/4x/routing-args.html %}
+
+#### Example
+
+```js
+app.post('/', function (req, res) {
+  res.send('POST request to homepage');
+});
+```

--- a/_includes/api/en/5x/app-post-method.md
+++ b/_includes/api/en/5x/app-post-method.md
@@ -9,6 +9,6 @@ For more information, see the [routing guide](/guide/routing.html).
 
 ```js
 app.post('/', function (req, res) {
-  res.send('POST request to homepage');
-});
+  res.send('POST request to homepage')
+})
 ```

--- a/_includes/api/en/5x/app-put-method.md
+++ b/_includes/api/en/5x/app-put-method.md
@@ -1,0 +1,13 @@
+<h3 id='app.put.method'>app.put(path, callback [, callback ...])</h3>
+
+Routes HTTP PUT requests to the specified path with the specified callback functions.
+
+{% include api/en/4x/routing-args.html %}
+
+#### Example
+
+```js
+app.put('/', function (req, res) {
+  res.send('PUT request to homepage');
+});
+```

--- a/_includes/api/en/5x/app-put-method.md
+++ b/_includes/api/en/5x/app-put-method.md
@@ -8,6 +8,6 @@ Routes HTTP PUT requests to the specified path with the specified callback funct
 
 ```js
 app.put('/', function (req, res) {
-  res.send('PUT request to homepage');
-});
+  res.send('PUT request to homepage')
+})
 ```

--- a/_includes/api/en/5x/app-render.md
+++ b/_includes/api/en/5x/app-render.md
@@ -1,0 +1,25 @@
+<h3 id='app.render'>app.render(view, [locals], callback)</h3>
+
+Returns the rendered HTML of a view via the `callback` function. It accepts an optional parameter
+that is an object containing local variables for the view. It is like [res.render()](#res.render),
+except it cannot send the rendered view to the client on its own.
+
+<div class="doc-box doc-info" markdown="1">
+Think of `app.render()` as a utility function for generating rendered view strings.
+Internally `res.render()` uses `app.render()` to render views.
+</div>
+
+<div class="doc-box doc-notice" markdown="1">
+The local variable `cache` is reserved for enabling view cache. Set it to `true`, if you want to
+cache view during development; view caching is enabled in production by default.
+</div>
+
+```js
+app.render('email', function(err, html){
+  // ...
+});
+
+app.render('email', { name: 'Tobi' }, function(err, html){
+  // ...
+});
+```

--- a/_includes/api/en/5x/app-render.md
+++ b/_includes/api/en/5x/app-render.md
@@ -15,11 +15,11 @@ cache view during development; view caching is enabled in production by default.
 </div>
 
 ```js
-app.render('email', function(err, html){
+app.render('email', function (err, html) {
   // ...
-});
+})
 
-app.render('email', { name: 'Tobi' }, function(err, html){
+app.render('email', { name: 'Tobi' }, function (err, html) {
   // ...
-});
+})
 ```

--- a/_includes/api/en/5x/app-route.md
+++ b/_includes/api/en/5x/app-route.md
@@ -1,0 +1,20 @@
+<h3 id='app.route'>app.route(path)</h3>
+
+Returns an instance of a single route, which you can then use to handle HTTP verbs with optional middleware.
+Use `app.route()` to avoid duplicate route names (and thus typo errors).
+
+```js
+var app = express();
+
+app.route('/events')
+.all(function(req, res, next) {
+  // runs for all HTTP verbs first
+  // think of it as route specific middleware!
+})
+.get(function(req, res, next) {
+  res.json(...);
+})
+.post(function(req, res, next) {
+  // maybe add a new event...
+});
+```

--- a/_includes/api/en/5x/app-route.md
+++ b/_includes/api/en/5x/app-route.md
@@ -4,17 +4,17 @@ Returns an instance of a single route, which you can then use to handle HTTP ver
 Use `app.route()` to avoid duplicate route names (and thus typo errors).
 
 ```js
-var app = express();
+var app = express()
 
 app.route('/events')
-.all(function(req, res, next) {
-  // runs for all HTTP verbs first
-  // think of it as route specific middleware!
-})
-.get(function(req, res, next) {
-  res.json(...);
-})
-.post(function(req, res, next) {
-  // maybe add a new event...
-});
+  .all(function (req, res, next) {
+    // runs for all HTTP verbs first
+    // think of it as route specific middleware!
+  })
+  .get(function (req, res, next) {
+    res.json({})
+  })
+  .post(function (req, res, next) {
+    // maybe add a new event...
+  })
 ```

--- a/_includes/api/en/5x/app-set.md
+++ b/_includes/api/en/5x/app-set.md
@@ -1,0 +1,20 @@
+<h3 id='app.set'>app.set(name, value)</h3>
+
+Assigns setting `name` to `value`. You may store any value that you want,
+but certain names can be used to configure the behavior of the server. These
+special names are listed in the [app settings table](#app.settings.table).
+
+Calling `app.set('foo', true)` for a Boolean property is the same as calling
+`app.enable('foo')`. Similarly, calling `app.set('foo', false)` for a Boolean
+property is the same as calling `app.disable('foo')`.
+
+Retrieve the value of a setting with [`app.get()`](#app.get).
+
+```js
+app.set('title', 'My Site');
+app.get('title'); // "My Site"
+```
+
+<h4 id='app.settings.table'>Application Settings</h4>
+
+{% include api/en/4x/app-settings.md %}

--- a/_includes/api/en/5x/app-set.md
+++ b/_includes/api/en/5x/app-set.md
@@ -11,8 +11,8 @@ property is the same as calling `app.disable('foo')`.
 Retrieve the value of a setting with [`app.get()`](#app.get).
 
 ```js
-app.set('title', 'My Site');
-app.get('title'); // "My Site"
+app.set('title', 'My Site')
+app.get('title') // "My Site"
 ```
 
 <h4 id='app.settings.table'>Application Settings</h4>

--- a/_includes/api/en/5x/app-settings.md
+++ b/_includes/api/en/5x/app-settings.md
@@ -227,19 +227,19 @@ A custom query string parsing function will receive the complete query string, a
 Specify a single subnet:
 
 ```js
-app.set('trust proxy', 'loopback') 
+app.set('trust proxy', 'loopback')
 ```
 
 Specify a subnet and an address:
 
 ```js
-app.set('trust proxy', 'loopback, 123.123.123.123') 
+app.set('trust proxy', 'loopback, 123.123.123.123')
 ```
 
 Specify multiple subnets as CSV:
 
 ```js
-app.set('trust proxy', 'loopback, linklocal, uniquelocal') 
+app.set('trust proxy', 'loopback, linklocal, uniquelocal')
 ```
 
 Specify multiple subnets as an array:
@@ -264,9 +264,9 @@ app.set('trust proxy', ['loopback', 'linklocal', 'uniquelocal'])
 
 ```js
 app.set('trust proxy', function (ip) {
-  if (ip === '127.0.0.1' || ip === '123.123.123.123') return true; // trusted IPs
-  else return false;
-});
+  if (ip === '127.0.0.1' || ip === '123.123.123.123') return true // trusted IPs
+  else return false
+})
 ```
   </td>
       </tr>
@@ -309,8 +309,8 @@ The [express.static](#express.static) middleware ignores these settings.
 
 ```js
 app.set('etag', function (body, encoding) {
-  return generateHash(body, encoding); // consider the function is defined
-});
+  return generateHash(body, encoding) // consider the function is defined
+})
 ```
   </td>
       </tr>

--- a/_includes/api/en/5x/app-settings.md
+++ b/_includes/api/en/5x/app-settings.md
@@ -1,0 +1,319 @@
+The following table lists application settings.
+
+Note that sub-apps will:
+
+* Not inherit the value of settings that have a default value.  You must set the value in the sub-app.
+* Inherit the value of settings with no default value; these are explicitly noted in the table below.
+
+Exceptions: Sub-apps will inherit the value of `trust proxy` even though it has a default value (for backward-compatibility);
+Sub-apps will not inherit the value of `view cache` in production (when `NODE_ENV` is "production").
+
+<div class="table-scroller">
+  <table class="doctable" border="1">
+    <thead><tr><th id="app-settings-property">Property</th><th>Type</th><th>Description</th><th>Default</th></tr></thead>
+    <tbody>
+    <tr>
+  <td markdown="1">
+  `case sensitive routing`
+  </td>
+      <td>Boolean</td>
+      <td><p>Enable case sensitivity.
+      When enabled, "/Foo" and "/foo" are different routes.
+      When disabled, "/Foo" and "/foo" are treated the same.</p>
+        <p><b>NOTE</b>: Sub-apps will inherit the value of this setting.</p>
+      </td>
+      <td>N/A (undefined)
+      </td>
+    </tr>
+    <tr>
+  <td markdown="1">
+  `env`
+  </td>
+      <td>String</td>
+      <td>Environment mode.
+      Be sure to set to "production" in a production environment;
+      see <a href="/advanced/best-practice-performance.html#env">Production best practices: performance and reliability</a>.
+    </td>
+  <td markdown="1">
+  `process.env.NODE_ENV` (`NODE_ENV` environment variable) or "development" if `NODE_ENV` is not set.
+  </td>
+    </tr>
+    <tr>
+  <td markdown="1">
+  `etag`
+  </td>
+  <td>Varied</td>
+  <td markdown="1">
+  Set the ETag response header. For possible values, see the [`etag` options table](#etag.options.table).
+
+  [More about the HTTP ETag header](http://en.wikipedia.org/wiki/HTTP_ETag).
+  </td>
+  <td markdown="1">
+  `weak`
+  </td>
+    </tr>
+    <tr>
+  <td markdown="1">
+  `jsonp callback name`
+  </td>
+      <td>String</td>
+      <td>Specifies the default JSONP callback name.</td>
+  <td markdown="1">
+  "callback"
+  </td>
+    </tr>
+    <tr>
+  <td markdown="1">
+  `json escape`
+  </td>
+  <td>Boolean</td>
+  <td markdown="1">
+  Enable escaping JSON responses from the `res.json`, `res.jsonp`, and `res.send` APIs. This will escape the characters `<`, `>`, and `&` as Unicode escape sequences in JSON. The purpose of this it to assist with [mitigating certain types of persistent XSS attacks](https://blog.mozilla.org/security/2017/07/18/web-service-audits-firefox-accounts/) when clients sniff responses for HTML.
+  <p><b>NOTE</b>: Sub-apps will inherit the value of this setting.</p>
+  </td>
+  <td>N/A (undefined)</td>
+    </tr>
+    <tr>
+  <td markdown="1">
+  `json replacer`
+  </td>
+      <td>Varied</td>
+      <td>The <a href="https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#The_replacer_parameter">'replacer' argument used by `JSON.stringify`</a>.
+        <p><b>NOTE</b>: Sub-apps will inherit the value of this setting.</p>
+      </td>
+  <td>N/A (undefined)
+  </td>
+    </tr>
+    <tr>
+  <td markdown="1">
+  `json spaces`
+  </td>
+      <td>Varied</td>
+      <td>The <a href="https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#The_space_argument">'space' argument used by `JSON.stringify`</a>.
+This is typically set to the number of spaces to use to indent prettified JSON.
+        <p><b>NOTE</b>: Sub-apps will inherit the value of this setting.</p>
+      </td>
+      <td>N/A (undefined)</td>
+    </tr>
+    <tr>
+  <td markdown="1">
+  `query parser`
+  </td>
+      <td>Varied</td>
+  <td markdown="1">
+Disable query parsing by setting the value to `false`, or set the query parser to use either "simple" or "extended" or a custom query string parsing function.
+
+The simple query parser is based on Node's native query parser, [querystring](http://nodejs.org/api/querystring.html).
+
+The extended query parser is based on [qs](https://www.npmjs.org/package/qs).
+
+A custom query string parsing function will receive the complete query string, and must return an object of query keys and their values.
+  </td>
+      <td>"extended"</td>
+    </tr>
+    <tr>
+  <td markdown="1">
+  `strict routing`
+  </td>
+      <td>Boolean</td>
+      <td><p>Enable strict routing.
+      When enabled, the router treats "/foo" and "/foo/" as different.
+      Otherwise, the router treats "/foo" and "/foo/" as the same.</p>
+        <p><b>NOTE</b>: Sub-apps will inherit the value of this setting.</p>
+      </td>
+      <td>N/A (undefined) </td>
+    </tr>
+    <tr>
+  <td markdown="1">
+  `subdomain offset`
+  </td>
+      <td>Number</td>
+      <td>The number of dot-separated parts of the host to remove to access subdomain.</td>
+      <td>2</td>
+    </tr>
+    <tr>
+  <td markdown="1">
+  `trust proxy`
+  </td>
+      <td>Varied</td>
+  <td markdown="1">
+  Indicates the app is behind a front-facing proxy, and to use the `X-Forwarded-*` headers to determine the connection and the IP address of the client. NOTE: `X-Forwarded-*` headers are easily spoofed and the detected IP addresses are unreliable.
+<p>
+  When enabled, Express attempts to determine the IP address of the client connected through the front-facing proxy, or series of proxies. The `req.ips` property, then contains an array of IP addresses the client is connected through. To enable it, use the values described in the <a href="#trust.proxy.options.table">trust proxy options table</a>.
+</p><p>
+  The `trust proxy` setting is implemented using the <a href="https://www.npmjs.org/package/proxy-addr">proxy-addr</a> package.  For more information, see its documentation.
+</p><p>
+<b>NOTE</b>: Sub-apps <i>will</i> inherit the value of this setting, even though it has a default value.
+</p>
+  </td>
+  <td markdown="1">
+  `false` (disabled)
+  </td>
+    </tr>
+    <tr>
+  <td markdown="1">
+  `views`
+  </td>
+      <td>String or Array</td>
+      <td>A directory or an array of directories for the application's views. If an array, the views are looked up in the order they occur in the array.</td>
+  <td markdown="1">
+  `process.cwd() + '/views'`
+  </td>
+    </tr>
+    <tr>
+  <td markdown="1">
+  `view cache`
+  </td>
+      <td>Boolean</td>
+      <td><p>Enables view template compilation caching.</p>
+      <p><b>NOTE</b>: Sub-apps will not inherit the value of this setting in production (when `NODE_ENV` is "production").</p>
+      </td>
+  <td markdown="1">
+  `true` in production, otherwise undefined.
+  </td>
+    </tr>
+    <tr>
+  <td markdown="1">
+  `view engine`
+  </td>
+      <td>String</td>
+      <td>The default engine extension to use when omitted.
+        <p><b>NOTE</b>: Sub-apps will inherit the value of this setting.</p>
+      </td>
+      <td>N/A (undefined)</td>
+    </tr>
+    <tr>
+  <td markdown="1">
+  `x-powered-by`
+  </td>
+      <td>Boolean</td>
+      <td>Enables the "X-Powered-By: Express" HTTP header.</td>
+  <td markdown="1">
+  `true`
+  </td>
+    </tr>
+    </tbody>
+  </table>
+
+  <h5 id="trust.proxy.options.table">Options for `trust proxy` setting</h5>
+
+  <p markdown="1">
+  Read [Express behind proxies](/guide/behind-proxies.html) for more
+  information.
+  </p>
+
+  <table class="doctable" border="1">
+    <thead><tr><th>Type</th><th>Value</th></tr></thead>
+    <tbody>
+      <tr>
+        <td>Boolean</td>
+  <td markdown="1">
+  If `true`, the client's IP address is understood as the left-most entry in the `X-Forwarded-*` header.
+
+  If `false`, the app is understood as directly facing the Internet and the client's IP address is derived from `req.connection.remoteAddress`. This is the default setting.
+  </td>
+      </tr>
+      <tr>
+        <td>String<br/>String containing comma-separated values<br/>Array of strings </td>
+  <td markdown="1">
+  An IP address, subnet, or an array of IP addresses, and subnets to trust. Pre-configured subnet names are:
+
+  * loopback - `127.0.0.1/8`, `::1/128`
+  * linklocal - `169.254.0.0/16`, `fe80::/10`
+  * uniquelocal - `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `fc00::/7`
+
+  Set IP addresses in any of the following ways:
+
+Specify a single subnet:
+
+```js
+app.set('trust proxy', 'loopback') 
+```
+
+Specify a subnet and an address:
+
+```js
+app.set('trust proxy', 'loopback, 123.123.123.123') 
+```
+
+Specify multiple subnets as CSV:
+
+```js
+app.set('trust proxy', 'loopback, linklocal, uniquelocal') 
+```
+
+Specify multiple subnets as an array:
+
+```js
+app.set('trust proxy', ['loopback', 'linklocal', 'uniquelocal'])
+```
+
+  When specified, the IP addresses or the subnets are excluded from the address determination process, and the untrusted IP address nearest to the application server is determined as the client's IP address.
+  </td>
+      </tr>
+      <tr>
+        <td>Number</td>
+  <td markdown="1">
+  Trust the <i>n</i><sup>th</sup> hop from the front-facing proxy server as the client.
+  </td>
+      </tr>
+      <tr>
+        <td>Function</td>
+  <td markdown="1">
+  Custom trust implementation. Use this only if you know what you are doing.
+
+```js
+app.set('trust proxy', function (ip) {
+  if (ip === '127.0.0.1' || ip === '123.123.123.123') return true; // trusted IPs
+  else return false;
+});
+```
+  </td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h5 id="etag.options.table">Options for `etag` setting</h5>
+
+<p markdown="1">
+**NOTE**:  These settings apply only to dynamic files, not static files.
+The [express.static](#express.static) middleware ignores these settings.
+</p>
+
+  <p markdown="1">
+  The ETag functionality is implemented using the
+  [etag](https://www.npmjs.org/package/etag) package.
+  For more information, see its documentation.
+  </p>
+
+  <table class="doctable" border="1">
+    <thead><tr><th>Type</th><th>Value</th></tr></thead>
+    <tbody>
+      <tr>
+        <td>Boolean</td>
+  <td markdown="1">
+  `true` enables weak ETag. This is the default setting.<br>
+  `false` disables ETag altogether.
+  </td>
+      </tr>
+      <tr>
+        <td>String</td>
+        <td>
+            If "strong", enables strong ETag.<br>
+            If "weak", enables weak ETag.
+        </td>
+      </tr>
+      <tr>
+        <td>Function</td>
+  <td markdown="1">Custom ETag function implementation. Use this only if you know what you are doing.
+
+```js
+app.set('etag', function (body, encoding) {
+  return generateHash(body, encoding); // consider the function is defined
+});
+```
+  </td>
+      </tr>
+    </tbody>
+  </table>
+</div>

--- a/_includes/api/en/5x/app-use.md
+++ b/_includes/api/en/5x/app-use.md
@@ -1,0 +1,278 @@
+<h3 id='app.use'>app.use([path,] callback [, callback...])</h3>
+
+Mounts the specified [middleware](/guide/using-middleware.html) function or functions
+at the specified path:
+the middleware function is executed when the base of the requested path matches `path`.
+
+{% include api/en/4x/routing-args.html %}
+
+#### Description
+
+A route will match any path that follows its path immediately with a "`/`".
+For example: `app.use('/apple', ...)` will match "/apple", "/apple/images",
+"/apple/images/news", and so on.
+
+Since `path` defaults to "/", middleware mounted without a path will be executed for every request to the app.  
+For example, this middleware function will be executed for _every_ request to the app:
+
+```js
+app.use(function (req, res, next) {
+  console.log('Time: %d', Date.now());
+  next();
+});
+```
+
+<div class="doc-box doc-info" markdown="1">
+**NOTE**
+
+Sub-apps will:
+
+* Not inherit the value of settings that have a default value.  You must set the value in the sub-app.
+* Inherit the value of settings with no default value.
+
+For details, see [Application settings](/en/4x/api.html#app.settings.table).
+</div>
+
+Middleware functions are executed sequentially, therefore the order of middleware inclusion is important.
+
+```js
+// this middleware will not allow the request to go beyond it
+app.use(function(req, res, next) {
+  res.send('Hello World');
+});
+
+// requests will never reach this route
+app.get('/', function (req, res) {
+  res.send('Welcome');
+});
+```
+
+**Error-handling middleware**
+
+Error-handling middleware always takes _four_ arguments.  You must provide four arguments to identify it as an error-handling middleware function. Even if you don't need to use the `next` object, you must specify it to maintain the signature. Otherwise, the `next` object will be interpreted as regular middleware and will fail to handle errors. For details about error-handling middleware, see: [Error handling](/{{ page.lang }}/guide/error-handling.html).
+
+Define error-handling middleware functions in the same way as other middleware functions, except with four arguments instead of three, specifically with the signature `(err, req, res, next)`):
+
+```js
+app.use(function(err, req, res, next) {
+  console.error(err.stack);
+  res.status(500).send('Something broke!');
+});
+```
+
+#### Path examples
+
+The following table provides some simple examples of valid `path` values for
+mounting middleware.
+
+<div class="table-scroller">
+<table class="doctable" border="1">
+
+  <thead>
+    <tr>
+      <th> Type </th>
+      <th> Example </th>
+    </tr>
+  </thead>
+  <tbody>
+
+    <tr>
+      <td>Path</td>
+      <td>
+      This will match paths starting with `/abcd`:
+        <pre><code class="language-js">app.use('/abcd', function (req, res, next) {
+  next();
+});
+</code></pre>
+      </td>
+    </tr>
+
+    <tr>
+      <td>Path Pattern</td>
+      <td>
+      This will match paths starting with `/abcd` and `/abd`:
+        <pre><code class="language-js">app.use('/abc?d', function (req, res, next) {
+  next();
+});
+</code></pre>
+
+This will match paths starting with `/abcd`, `/abbcd`, `/abbbbbcd`, and so on:
+<pre><code class="language-js">app.use('/ab+cd', function (req, res, next) {
+  next();
+});</code></pre>
+
+This will match paths starting with `/abcd`, `/abxcd`, `/abFOOcd`, `/abbArcd`, and so on:
+<pre><code class="language-js">app.use('/ab\*cd', function (req, res, next) {
+  next();
+});</code></pre>
+
+This will match paths starting with `/ad` and `/abcd`:
+<pre><code class="language-js">app.use('/a(bc)?d', function (req, res, next) {
+  next();
+});</code></pre>
+      </td>
+    </tr>
+
+    <tr>
+      <td>Regular Expression</td>
+      <td>
+      This will match paths starting with `/abc` and `/xyz`:
+        <pre><code class="language-js">app.use(/\/abc|\/xyz/, function (req, res, next) {
+  next();
+});</code></pre>
+      </td>
+    </tr>
+
+    <tr>
+      <td>Array</td>
+      <td>
+      This will match paths starting with `/abcd`, `/xyza`, `/lmn`, and `/pqr`:
+        <pre><code class="language-js">app.use(['/abcd', '/xyza', /\/lmn|\/pqr/], function (req, res, next) {
+  next();
+});</code></pre>
+      </td>
+    </tr>
+
+  </tbody>
+
+</table>
+</div>
+
+#### Middleware callback function examples
+
+The following table provides some simple examples of middleware functions that
+can be used as the `callback` argument to `app.use()`, `app.METHOD()`, and `app.all()`.
+Even though the examples are for `app.use()`, they are also valid for `app.use()`, `app.METHOD()`, and `app.all()`.
+
+<table class="doctable" border="1">
+
+  <thead>
+    <tr>
+      <th>Usage</th>
+      <th>Example</th>
+    </tr>
+  </thead>
+  <tbody>
+
+    <tr>
+      <td>Single Middleware</td>
+      <td>You can define and mount a middleware function locally.
+<pre><code class="language-js">app.use(function (req, res, next) {
+  next();
+});
+</code></pre>
+A router is valid middleware.
+
+<pre><code class="language-js">var router = express.Router();
+router.get('/', function (req, res, next) {
+  next();
+});
+app.use(router);
+</code></pre>
+
+An Express app is valid middleware.
+<pre><code class="language-js">var subApp = express();
+subApp.get('/', function (req, res, next) {
+  next();
+});
+app.use(subApp);
+</code></pre>
+      </td>
+    </tr>
+
+    <tr>
+      <td>Series of Middleware</td>
+      <td>
+        You can specify more than one middleware function at the same mount path.
+<pre><code class="language-js">var r1 = express.Router();
+r1.get('/', function (req, res, next) {
+  next();
+});
+
+var r2 = express.Router();
+r2.get('/', function (req, res, next) {
+  next();
+});
+
+app.use(r1, r2);
+</code></pre>
+      </td>
+    </tr>
+
+    <tr>
+      <td>Array</td>
+      <td>
+      Use an array to group middleware logically.
+      If you pass an array of middleware as the first or only middleware parameters,
+      then you <em>must</em> specify the mount path.
+<pre><code class="language-js">var r1 = express.Router();
+r1.get('/', function (req, res, next) {
+  next();
+});
+
+var r2 = express.Router();
+r2.get('/', function (req, res, next) {
+  next();
+});
+
+app.use('/', [r1, r2]);
+</code></pre>
+      </td>
+    </tr>
+
+    <tr>
+      <td>Combination</td>
+      <td>
+        You can combine all the above ways of mounting middleware.
+<pre><code class="language-js">function mw1(req, res, next) { next(); }
+function mw2(req, res, next) { next(); }
+
+var r1 = express.Router();
+r1.get('/', function (req, res, next) { next(); });
+
+var r2 = express.Router();
+r2.get('/', function (req, res, next) { next(); });
+
+var subApp = express();
+subApp.get('/', function (req, res, next) { next(); });
+
+app.use(mw1, [mw2, r1, r2], subApp);
+</code></pre>
+      </td>
+    </tr>
+
+  </tbody>
+
+</table>
+
+Following are some examples of using the [express.static](/guide/using-middleware.html#middleware.built-in)
+middleware in an Express app.
+
+Serve static content for the app from the "public" directory in the application directory:
+
+```js
+// GET /style.css etc
+app.use(express.static(__dirname + '/public'));
+```
+
+Mount the middleware at "/static" to serve static content only when their request path is prefixed with "/static":
+
+```js
+// GET /static/style.css etc.
+app.use('/static', express.static(__dirname + '/public'));
+```
+
+Disable logging for static content requests by loading the logger middleware after the static middleware:
+
+```js
+app.use(express.static(__dirname + '/public'));
+app.use(logger());
+```
+
+Serve static files from multiple directories, but give precedence to "./public" over the others:
+
+```js
+app.use(express.static(__dirname + '/public'));
+app.use(express.static(__dirname + '/files'));
+app.use(express.static(__dirname + '/uploads'));
+```

--- a/_includes/api/en/5x/app-use.md
+++ b/_includes/api/en/5x/app-use.md
@@ -252,27 +252,27 @@ Serve static content for the app from the "public" directory in the application 
 
 ```js
 // GET /style.css etc
-app.use(express.static(__dirname + '/public'))
+app.use(express.static(path.join(__dirname, 'public')))
 ```
 
 Mount the middleware at "/static" to serve static content only when their request path is prefixed with "/static":
 
 ```js
 // GET /static/style.css etc.
-app.use('/static', express.static(__dirname + '/public'))
+app.use('/static', express.static(path.join(__dirname, 'public')))
 ```
 
 Disable logging for static content requests by loading the logger middleware after the static middleware:
 
 ```js
-app.use(express.static(__dirname + '/public'))
+app.use(express.static(path.join(__dirname, 'public')))
 app.use(logger())
 ```
 
 Serve static files from multiple directories, but give precedence to "./public" over the others:
 
 ```js
-app.use(express.static(__dirname + '/public'))
-app.use(express.static(__dirname + '/files'))
-app.use(express.static(__dirname + '/uploads'))
+app.use(express.static(path.join(__dirname, 'public')))
+app.use(express.static(path.join(__dirname, 'files')))
+app.use(express.static(path.join(__dirname, 'uploads')))
 ```

--- a/_includes/api/en/5x/app-use.md
+++ b/_includes/api/en/5x/app-use.md
@@ -17,9 +17,9 @@ For example, this middleware function will be executed for _every_ request to th
 
 ```js
 app.use(function (req, res, next) {
-  console.log('Time: %d', Date.now());
-  next();
-});
+  console.log('Time: %d', Date.now())
+  next()
+})
 ```
 
 <div class="doc-box doc-info" markdown="1">
@@ -37,14 +37,14 @@ Middleware functions are executed sequentially, therefore the order of middlewar
 
 ```js
 // this middleware will not allow the request to go beyond it
-app.use(function(req, res, next) {
-  res.send('Hello World');
-});
+app.use(function (req, res, next) {
+  res.send('Hello World')
+})
 
 // requests will never reach this route
 app.get('/', function (req, res) {
-  res.send('Welcome');
-});
+  res.send('Welcome')
+})
 ```
 
 **Error-handling middleware**
@@ -54,10 +54,10 @@ Error-handling middleware always takes _four_ arguments.  You must provide four 
 Define error-handling middleware functions in the same way as other middleware functions, except with four arguments instead of three, specifically with the signature `(err, req, res, next)`):
 
 ```js
-app.use(function(err, req, res, next) {
-  console.error(err.stack);
-  res.status(500).send('Something broke!');
-});
+app.use(function (err, req, res, next) {
+  console.error(err.stack)
+  res.status(500).send('Something broke!')
+})
 ```
 
 #### Path examples
@@ -252,27 +252,27 @@ Serve static content for the app from the "public" directory in the application 
 
 ```js
 // GET /style.css etc
-app.use(express.static(__dirname + '/public'));
+app.use(express.static(__dirname + '/public'))
 ```
 
 Mount the middleware at "/static" to serve static content only when their request path is prefixed with "/static":
 
 ```js
 // GET /static/style.css etc.
-app.use('/static', express.static(__dirname + '/public'));
+app.use('/static', express.static(__dirname + '/public'))
 ```
 
 Disable logging for static content requests by loading the logger middleware after the static middleware:
 
 ```js
-app.use(express.static(__dirname + '/public'));
-app.use(logger());
+app.use(express.static(__dirname + '/public'))
+app.use(logger())
 ```
 
 Serve static files from multiple directories, but give precedence to "./public" over the others:
 
 ```js
-app.use(express.static(__dirname + '/public'));
-app.use(express.static(__dirname + '/files'));
-app.use(express.static(__dirname + '/uploads'));
+app.use(express.static(__dirname + '/public'))
+app.use(express.static(__dirname + '/files'))
+app.use(express.static(__dirname + '/uploads'))
 ```

--- a/_includes/api/en/5x/app.md
+++ b/_includes/api/en/5x/app.md
@@ -1,0 +1,123 @@
+<h2 id="app">Application</h2>
+
+The `app` object conventionally denotes the Express application.
+Create it by calling the top-level `express()` function exported by the Express module:
+
+```js
+var express = require('express');
+var app = express();
+
+app.get('/', function(req, res){
+  res.send('hello world');
+});
+
+app.listen(3000);
+```
+
+The `app` object has methods for
+
+* Routing HTTP requests; see for example, [app.METHOD](#app.METHOD) and [app.param](#app.param).
+* Configuring middleware; see [app.route](#app.route).
+* Rendering HTML views; see [app.render](#app.render).
+* Registering a template engine; see [app.engine](#app.engine).
+
+It also has settings (properties) that affect how the application behaves;
+for more information, see [Application settings](#app.settings.table).
+
+<div class="doc-box doc-info" markdown="1">
+The Express application object can be referred from the [request object](#req) and the [response object](#res) as `req.app`, and `res.app`, respectively.
+</div>
+
+<h3 id='app.properties'>Properties</h3>
+
+<section markdown="1">
+  {% include api/en/4x/app-locals.md %}
+</section>
+
+<section markdown="1">
+  {% include api/en/4x/app-mountpath.md %}
+</section>
+
+<h3 id='app.events'>Events</h3>
+
+<section markdown="1">
+  {% include api/en/4x/app-onmount.md %}
+</section>
+
+<h3 id='app.methods'>Methods</h3>
+
+<section markdown="1">
+  {% include api/en/4x/app-all.md %}
+</section>
+
+<section markdown="1">
+  {% include api/en/4x/app-delete-method.md %}
+</section>
+
+<section markdown="1">
+  {% include api/en/4x/app-disable.md %}
+</section>
+
+<section markdown="1">
+  {% include api/en/4x/app-disabled.md %}
+</section>
+
+<section markdown="1">
+  {% include api/en/4x/app-enable.md %}
+</section>
+
+<section markdown="1">
+  {% include api/en/4x/app-enabled.md %}
+</section>
+
+<section markdown="1">
+  {% include api/en/4x/app-engine.md %}
+</section>
+
+<section markdown="1">
+  {% include api/en/4x/app-get.md %}
+</section>
+
+<section markdown="1">
+  {% include api/en/4x/app-get-method.md %}
+</section>
+
+<section markdown="1">
+  {% include api/en/4x/app-listen.md %}
+</section>
+
+<section markdown="1">
+  {% include api/en/4x/app-METHOD.md %}
+</section>
+
+<section markdown="1">
+  {% include api/en/4x/app-param.md %}
+</section>
+
+<section markdown="1">
+  {% include api/en/4x/app-path.md %}
+</section>
+
+<section markdown="1">
+  {% include api/en/4x/app-post-method.md %}
+</section>
+
+<section markdown="1">
+  {% include api/en/4x/app-put-method.md %}
+</section>
+
+<section markdown="1">
+  {% include api/en/4x/app-render.md %}
+</section>
+
+<section markdown="1">
+  {% include api/en/4x/app-route.md %}
+</section>
+
+<section markdown="1">
+  {% include api/en/4x/app-set.md %}
+</section>
+
+<section markdown="1">
+  {% include api/en/4x/app-use.md %}
+</section>

--- a/_includes/api/en/5x/app.md
+++ b/_includes/api/en/5x/app.md
@@ -4,14 +4,14 @@ The `app` object conventionally denotes the Express application.
 Create it by calling the top-level `express()` function exported by the Express module:
 
 ```js
-var express = require('express');
-var app = express();
+var express = require('express')
+var app = express()
 
-app.get('/', function(req, res){
-  res.send('hello world');
-});
+app.get('/', function (req, res) {
+  res.send('hello world')
+})
 
-app.listen(3000);
+app.listen(3000)
 ```
 
 The `app` object has methods for

--- a/_includes/api/en/5x/express.json.md
+++ b/_includes/api/en/5x/express.json.md
@@ -1,0 +1,38 @@
+<h3 id='express.json' class='h2'>express.json([options])</h3>
+
+<div class="doc-box doc-info" markdown="1">
+This middleware is available in Express v4.16.0 onwards.
+</div>
+
+This is a built-in middleware function in Express. It parses incoming requests
+with JSON payloads and is based on
+[body-parser](/{{ page.lang }}/resources/middleware/body-parser.html).
+
+Returns middleware that only parses JSON and only looks at requests where
+the `Content-Type` header matches the `type` option. This parser accepts any
+Unicode encoding of the body and supports automatic inflation of `gzip` and
+`deflate` encodings.
+
+A new `body` object containing the parsed data is populated on the `request`
+object after the middleware (i.e. `req.body`), or an empty object (`{}`) if
+there was no body to parse, the `Content-Type` was not matched, or an error
+occurred.
+
+<div class="doc-box doc-warn" markdown="1">
+As `req.body`'s shape is based on user-controlled input, all properties and
+values in this object are untrusted and should be validated before trusting.
+For example, `req.body.foo.toString()` may fail in multiple ways, for example
+`foo` may not be there or may not be a string, and `toString` may not be a
+function and instead a string or other user-input.
+</div>
+
+The following table describes the properties of the optional `options` object.
+
+| Property      | Description                                                           |   Type      | Default         |
+|---------------|-----------------------------------------------------------------------|-------------|-----------------|
+| `inflate`     | Enables or disables handling deflated (compressed) bodies; when disabled, deflated bodies are rejected. | Boolean | `true` |
+| `limit`       | Controls the maximum request body size. If this is a number, then the value specifies the number of bytes; if it is a string, the value is passed to the [bytes](https://www.npmjs.com/package/bytes) library for parsing. | Mixed | `"100kb"` |
+| `reviver`     | The `reviver` option is passed directly to `JSON.parse` as the second argument. You can find more information on this argument [in the MDN documentation about JSON.parse](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse#Example.3A_Using_the_reviver_parameter). | Function | `null` |
+| `strict`      | Enables or disables only accepting arrays and objects; when disabled will accept anything `JSON.parse` accepts. | Boolean | `true` |
+| `type`        | This is used to determine what media type the middleware will parse. This option can be a string, array of strings, or a function. If not a function, `type` option is passed directly to the [type-is](https://www.npmjs.org/package/type-is#readme) library and this can be an extension name (like `json`), a mime type (like `application/json`), or a mime type with a wildcard (like `*/*` or `*/json`). If a function, the `type` option is called as `fn(req)` and the request is parsed if it returns a truthy value. | Mixed | `"application/json"` |
+| `verify`      | This option, if supplied, is called as `verify(req, res, buf, encoding)`, where `buf` is a `Buffer` of the raw request body and `encoding` is the encoding of the request. The parsing can be aborted by throwing an error. | Function | `undefined` |

--- a/_includes/api/en/5x/express.md
+++ b/_includes/api/en/5x/express.md
@@ -3,8 +3,8 @@
 Creates an Express application. The `express()` function is a top-level function exported by the `express` module.
 
 ```js
-var express = require('express');
-var app = express();
+var express = require('express')
+var app = express()
 ```
 
 <h3 id='express.methods'>Methods</h3>

--- a/_includes/api/en/5x/express.md
+++ b/_includes/api/en/5x/express.md
@@ -1,0 +1,26 @@
+<h2 id="express">express()</h2>
+
+Creates an Express application. The `express()` function is a top-level function exported by the `express` module.
+
+```js
+var express = require('express');
+var app = express();
+```
+
+<h3 id='express.methods'>Methods</h3>
+
+<section markdown="1">
+  {% include api/en/4x/express.json.md %}
+</section>
+
+<section markdown="1">
+  {% include api/en/4x/express.static.md %}
+</section>
+
+<section markdown="1">
+  {% include api/en/4x/express.router.md %}
+</section>
+
+<section markdown="1">
+  {% include api/en/4x/express.urlencoded.md %}
+</section>

--- a/_includes/api/en/5x/express.router.md
+++ b/_includes/api/en/5x/express.router.md
@@ -1,0 +1,24 @@
+<h3 id='express.router' class='h2'>express.Router([options])</h3>
+
+Creates a new [router](#router) object.
+
+```js
+var router = express.Router([options]);
+```
+
+The optional `options` parameter specifies the behavior of the router.
+
+<div class="table-scroller" markdown="1">
+
+| Property        | Description                                     | Default     | Availability  |
+|-----------------|-------------------------------------------------|-------------|---------------|
+| `caseSensitive` | Enable case sensitivity. | Disabled by default, treating "/Foo" and "/foo" as the same.|  |
+| `mergeParams`   | Preserve the `req.params` values from the parent router. If the parent and the child have conflicting param names, the child's value take precedence.| `false` | 4.5.0+ |
+| `strict`        | Enable strict routing. | Disabled by default, "/foo" and "/foo/" are treated the same by the router.| &nbsp; |
+
+</div>
+
+You can add middleware and HTTP method routes (such as `get`, `put`, `post`, and
+so on) to `router` just like an application.
+
+For more information, see [Router](#router).

--- a/_includes/api/en/5x/express.router.md
+++ b/_includes/api/en/5x/express.router.md
@@ -3,7 +3,7 @@
 Creates a new [router](#router) object.
 
 ```js
-var router = express.Router([options]);
+var router = express.Router([options])
 ```
 
 The optional `options` parameter specifies the behavior of the router.

--- a/_includes/api/en/5x/express.static.md
+++ b/_includes/api/en/5x/express.static.md
@@ -1,0 +1,90 @@
+<h3 id='express.static' class='h2'>express.static(root, [options])</h3>
+
+This is a built-in middleware function in Express.
+It serves static files and is based on  [serve-static](/{{page.lang}}/resources/middleware/serve-static.html).
+
+<div class="doc-box doc-info" markdown="1">NOTE: For best results, [use a reverse proxy](/{{page.lang}}/advanced/best-practice-performance.html#use-a-reverse-proxy) cache to improve performance of serving static assets.
+</div>
+
+The `root` argument specifies the root directory from which to serve static assets.
+The function determines the file to serve by combining `req.url` with the provided `root` directory.
+When a file is not found, instead of sending a 404 response, it instead calls `next()`
+to move on to the next middleware, allowing for stacking and fall-backs.
+
+The following table describes the properties of the `options` object.
+See also the [example below](#example.of.express.static).
+
+| Property      | Description                                                           |   Type      | Default         |
+|---------------|-----------------------------------------------------------------------|-------------|-----------------|
+| `dotfiles`    | Determines how dotfiles (files or directories that begin with a dot ".") are treated.  <br/><br/>See [dotfiles](#dotfiles) below. | String | "ignore"|
+| `etag`        | Enable or disable etag generation <br/><br/>NOTE: `express.static` always sends weak ETags. | Boolean | `true` |
+| `extensions`  | Sets file extension fallbacks: If a file is not found, search for files with the specified extensions and serve the first one found. Example: `['html', 'htm']`.| Mixed | `false` |
+| `fallthrough`  | Let client errors fall-through as unhandled requests, otherwise forward a client error. <br/><br/>See [fallthrough](#fallthrough) below.| Boolean | `true` |
+| `immutable`   | Enable or disable the `immutable` directive in the `Cache-Control` response header. If enabled, the `maxAge` option should also be specified to enable caching. The `immutable` directive will prevent supported clients from making conditional requests during the life of the `maxAge` option to check if the file has changed. | Boolean | `false` |
+| `index`       | Sends the specified directory index file. Set to `false` to disable directory indexing. | Mixed | "index.html" |
+| `lastModified` | Set the `Last-Modified` header to the last modified date of the file on the OS. | Boolean | `true` |
+| `maxAge`      | Set the max-age property of the Cache-Control header in milliseconds or a string in [ms format](https://www.npmjs.org/package/ms). | Number | 0 |
+| `redirect`    | Redirect to trailing "/" when the pathname is a directory. | Boolean | `true` |
+| `setHeaders`  | Function for setting HTTP headers to serve with the file. <br/><br/>See [setHeaders](#setHeaders) below. | Function |  |
+
+For more information, see [Serving static files in Express](/starter/static-files.html).
+and [Using middleware - Built-in middleware](/{{page.lang}}/guide/using-middleware.html#middleware.built-in).
+
+<h5 id='dotfiles'> dotfiles</h5>
+
+Possible values for this option are:
+
+- "allow" - No special treatment for dotfiles.
+- "deny" - Deny a request for a dotfile, respond with `403`, then call `next()`.
+- "ignore" - Act as if the dotfile does not exist, respond with `404`, then call `next()`.
+
+**NOTE**: With the default value, it will not ignore files in a directory that begins with a dot.
+
+<h5 id='fallthrough'>fallthrough</h5>
+
+When this option is `true`, client errors such as a bad request or a request to a non-existent
+file will cause this middleware to simply call `next()` to invoke the next middleware in the stack.
+When false, these errors (even 404s), will invoke `next(err)`.
+
+Set this option to `true` so you can map multiple physical directories
+to the same web address or for routes to fill in non-existent files.
+
+Use `false` if you have mounted this middleware at a path designed
+to be strictly a single file system directory, which allows for short-circuiting 404s
+for less overhead. This middleware will also reply to all methods.
+
+<h5 id='setHeaders'>setHeaders</h5>
+
+For this option, specify a function to set custom response headers. Alterations to the headers must occur synchronously.
+
+The signature of the function is:
+
+```js
+fn(res, path, stat)
+```
+
+Arguments:
+
+- `res`, the [response object](#res).
+- `path`, the file path that is being sent.
+- `stat`, the `stat` object of the file that is being sent.
+
+<h4 id='example.of.express.static'>Example of express.static</h4>
+
+Here is an example of using the `express.static` middleware function with an elaborate options object:
+
+```js
+var options = {
+  dotfiles: 'ignore',
+  etag: false,
+  extensions: ['htm', 'html'],
+  index: false,
+  maxAge: '1d',
+  redirect: false,
+  setHeaders: function (res, path, stat) {
+    res.set('x-timestamp', Date.now())
+  }
+}
+
+app.use(express.static('public', options))
+```

--- a/_includes/api/en/5x/express.urlencoded.md
+++ b/_includes/api/en/5x/express.urlencoded.md
@@ -1,0 +1,39 @@
+<h3 id='express.urlencoded' class='h2'>express.urlencoded([options])</h3>
+
+<div class="doc-box doc-info" markdown="1">
+This middleware is available in Express v4.16.0 onwards.
+</div>
+
+This is a built-in middleware function in Express. It parses incoming requests
+with urlencoded payloads and is based on [body-parser](/{{ page.lang }}/resources/middleware/body-parser.html).
+
+Returns middleware that only parses urlencoded bodies and only looks at
+requests where the `Content-Type` header matches the `type` option. This
+parser accepts only UTF-8 encoding of the body and supports automatic
+inflation of `gzip` and `deflate` encodings.
+
+A new `body` object containing the parsed data is populated on the `request`
+object after the middleware (i.e. `req.body`), or an empty object (`{}`) if
+there was no body to parse, the `Content-Type` was not matched, or an error
+occurred. This object will contain key-value pairs, where the value can be
+a string or array (when `extended` is `false`), or any type (when `extended`
+is `true`).
+
+<div class="doc-box doc-warn" markdown="1">
+As `req.body`'s shape is based on user-controlled input, all properties and
+values in this object are untrusted and should be validated before trusting.
+For example, `req.body.foo.toString()` may fail in multiple ways, for example
+`foo` may not be there or may not be a string, and `toString` may not be a
+function and instead a string or other user-input.
+</div>
+
+The following table describes the properties of the optional `options` object.
+
+| Property         | Description                                                           |   Type      | Default         |
+|------------------|-----------------------------------------------------------------------|-------------|-----------------|
+| `extended`       | This option allows to choose between parsing the URL-encoded data with the `querystring` library (when `false`) or the `qs` library (when `true`). The "extended" syntax allows for rich objects and arrays to be encoded into the URL-encoded format, allowing for a JSON-like experience with URL-encoded. For more information, please [see the qs library](https://www.npmjs.org/package/qs#readme). | Boolean | `true` |
+| `inflate`        | Enables or disables handling deflated (compressed) bodies; when disabled, deflated bodies are rejected. | Boolean | `true` |
+| `limit`          | Controls the maximum request body size. If this is a number, then the value specifies the number of bytes; if it is a string, the value is passed to the [bytes](https://www.npmjs.com/package/bytes) library for parsing. | Mixed | `"100kb"` |
+| `parameterLimit` | This option controls the maximum number of parameters that are allowed in the URL-encoded data. If a request contains more parameters than this value, an error will be raised. | Number | `1000` |
+| `type`           | This is used to determine what media type the middleware will parse. This option can be a string, array of strings, or a function. If not a function, `type` option is passed directly to the [type-is](https://www.npmjs.org/package/type-is#readme) library and this can be an extension name (like `urlencoded`), a mime type (like `application/x-www-form-urlencoded`), or a mime type with a wildcard (like `*/x-www-form-urlencoded`). If a function, the `type` option is called as `fn(req)` and the request is parsed if it returns a truthy value. | Mixed | `"application/x-www-form-urlencoded"` |
+| `verify`         | This option, if supplied, is called as `verify(req, res, buf, encoding)`, where `buf` is a `Buffer` of the raw request body and `encoding` is the encoding of the request. The parsing can be aborted by throwing an error. | Function | `undefined` |

--- a/_includes/api/en/5x/menu.md
+++ b/_includes/api/en/5x/menu.md
@@ -1,0 +1,203 @@
+<ul id="menu">
+
+    <li id="express-api"><a href="#express">express()</a>
+    <ul id="express-menu">
+        <li><em>Methods</em></li>
+        <li id="express-json-middleware"><a href="#express.json">express.json()</a></li>
+        <li id="express-static-middleware"><a href="#express.static">express.static()</a></li>
+        <li id="express-router"><a href="#express.router">express.Router()</a></li>
+        <li id="express-urlencoded-middleware"><a href="#express.urlencoded">express.urlencoded()</a></li>
+    </ul>
+    </li>
+
+    <li id="app-api"><a href="#app">Application</a>
+        <ul id="app-menu">
+            <li><em>Properties</em>
+            </li>
+            <li><a href="#app.locals">app.locals</a>
+            </li>
+            <li><a href="#app.mountpath">app.mountpath</a>
+            </li>
+            <li><em>Events</em>
+            </li>
+            <li><a href="#app.onmount">mount</a>
+            </li>
+            <li><em>Methods</em>
+            </li>
+            <li><a href="#app.all">app.all()</a>
+            </li>
+            <li><a href="#app.delete.method">app.delete()</a>
+            </li>
+            <li><a href="#app.disable">app.disable()</a>
+            </li>
+            <li><a href="#app.disabled">app.disabled()</a>
+            </li>
+            <li><a href="#app.enable">app.enable()</a>
+            </li>
+            <li><a href="#app.enabled">app.enabled()</a>
+            </li>
+            <li><a href="#app.engine">app.engine()</a>
+            </li>
+            <li><a href="#app.get">app.get()</a>
+            </li>
+            <li><a href="#app.get.method">app.get()</a>
+            </li>
+            <li><a href="#app.listen">app.listen()</a>
+            </li>
+            <li><a href="#app.METHOD">app.METHOD()</a>
+            </li>
+            <li><a href="#app.param">app.param()</a>
+            </li>
+            <li><a href="#app.path">app.path()</a>
+            </li>
+            <li><a href="#app.post.method">app.post()</a>
+            </li>
+            <li><a href="#app.put.method">app.put()</a>
+            </li>
+            <li><a href="#app.render">app.render()</a>
+            </li>
+            <li><a href="#app.route">app.route()</a>
+            </li>
+            <li><a href="#app.set">app.set()</a>
+            </li>
+            <li><a href="#app.use">app.use()</a>
+            </li>
+        </ul>
+    </li>
+    <li id="req-api"><a href="#req">Request</a>
+        <ul id="req-menu">
+            <li><em>Properties</em>
+            </li>
+            <li><a href="#req.app">req.app</a>
+            </li>
+            <li><a href="#req.baseUrl">req.baseUrl</a>
+            </li>
+            <li><a href="#req.body">req.body</a>
+            </li>
+            <li><a href="#req.cookies">req.cookies</a>
+            </li>
+            <li><a href="#req.fresh">req.fresh</a>
+            </li>
+            <li><a href="#req.hostname">req.hostname</a>
+            </li>
+            <li><a href="#req.ip">req.ip</a>
+            </li>
+            <li><a href="#req.ips">req.ips</a>
+            </li>
+            <li><a href="#req.method">req.method</a>
+            </li>
+            <li><a href="#req.originalUrl">req.originalUrl</a>
+            </li>
+            <li><a href="#req.params">req.params</a>
+            </li>
+            <li><a href="#req.path">req.path</a>
+            </li>
+            <li><a href="#req.protocol">req.protocol</a>
+            </li>
+            <li><a href="#req.query">req.query</a>
+            </li>
+            <li><a href="#req.route">req.route</a>
+            </li>
+            <li><a href="#req.secure">req.secure</a>
+            </li>
+            <li><a href="#req.signedCookies">req.signedCookies</a>
+            </li>
+            <li><a href="#req.stale">req.stale</a>
+            </li>
+            <li><a href="#req.subdomains">req.subdomains</a>
+            </li>
+            <li><a href="#req.xhr">req.xhr</a>
+            </li>
+            <li><em>Methods</em>
+            </li>
+            <li><a href="#req.accepts">req.accepts()</a>
+            </li>
+            <li><a href="#req.acceptsCharsets">req.acceptsCharsets()</a>
+            </li>
+            <li><a href="#req.acceptsEncodings">req.acceptsEncodings()</a>
+            </li>
+            <li><a href="#req.acceptsLanguages">req.acceptsLanguages()</a>
+            </li>
+            <li><a href="#req.get">req.get()</a>
+            </li>
+            <li><a href="#req.is">req.is()</a>
+            </li>
+            <li><a href="#req.param">req.param()</a>
+            </li>
+            <li><a href="#req.range">req.range()</a>
+            </li>
+        </ul>
+    </li>
+    <li id="res-api"><a href="#res">Response</a>
+        <ul id="res-menu">
+            <li><em>Properties</em>
+            </li>
+            <li><a href="#res.app">res.app      </a>
+            </li>
+            <li><a href="#res.headersSent">res.headersSent</a>
+            </li>
+            <li><a href="#res.locals">res.locals</a>
+            </li>
+            <li><em>Methods</em>
+            </li>
+            <li><a href="#res.append">res.append()</a>
+            </li>
+            <li><a href="#res.attachment">res.attachment()</a>
+            </li>
+            <li><a href="#res.cookie">res.cookie()</a>
+            </li>
+            <li><a href="#res.clearCookie">res.clearCookie()</a>
+            </li>
+            <li><a href="#res.download">res.download()</a>
+            </li>
+            <li><a href="#res.end">res.end()</a>
+            </li>
+            <li><a href="#res.format">res.format()</a>
+            </li>
+            <li><a href="#res.get">res.get()</a>
+            </li>
+            <li><a href="#res.json">res.json()</a>
+            </li>
+            <li><a href="#res.jsonp">res.jsonp()</a>
+            </li>
+            <li><a href="#res.links">res.links()</a>
+            </li>
+            <li><a href="#res.location">res.location()</a>
+            </li>
+            <li><a href="#res.redirect">res.redirect()</a>
+            </li>
+            <li><a href="#res.render">res.render()</a>
+            </li>
+            <li><a href="#res.send">res.send()</a>
+            </li>
+            <li><a href="#res.sendFile">res.sendFile()</a>
+            </li>
+            <li><a href="#res.sendStatus">res.sendStatus()</a>
+            </li>
+            <li><a href="#res.set">res.set()</a>
+            </li>
+            <li><a href="#res.status">res.status()</a>
+            </li>
+            <li><a href="#res.type">res.type()</a>
+            </li>
+            <li><a href="#res.vary">res.vary()</a>
+            </li>
+        </ul>
+    </li>
+    <li id="router-api"><a href="#router">Router</a>
+        <ul id="router-menu">
+            <li><em>Methods</em>
+            </li>
+            <li><a href="#router.all">router.all()</a>
+            </li>
+            <li><a href="#router.METHOD">router.METHOD()</a>
+            </li>
+            <li><a href="#router.param">router.param()</a>
+            </li>
+            <li><a href="#router.route">router.route()</a>
+            </li>
+            <li><a href="#router.use">router.use()</a>
+            </li>
+        </ul>
+    </li>
+</ul>

--- a/_includes/api/en/5x/req-accepts.md
+++ b/_includes/api/en/5x/req-accepts.md
@@ -1,0 +1,36 @@
+<h3 id='req.accepts'>req.accepts(types)</h3>
+
+Checks if the specified content types are acceptable, based on the request's `Accept` HTTP header field.
+The method returns the best match, or if none of the specified content types is acceptable, returns
+`false` (in which case, the application should respond with `406 "Not Acceptable"`).
+
+The `type` value may be a single MIME type string (such as "application/json"),
+an extension name such as "json", a comma-delimited list, or an array. For a
+list or array, the method returns the *best* match (if any).
+
+```js
+// Accept: text/html
+req.accepts('html');
+// => "html"
+
+// Accept: text/*, application/json
+req.accepts('html');
+// => "html"
+req.accepts('text/html');
+// => "text/html"
+req.accepts(['json', 'text']);
+// => "json"
+req.accepts('application/json');
+// => "application/json"
+
+// Accept: text/*, application/json
+req.accepts('image/png');
+req.accepts('png');
+// => undefined
+
+// Accept: text/*;q=.5, application/json
+req.accepts(['html', 'json']);
+// => "json"
+```
+
+For more information, or if you have issues or concerns, see [accepts](https://github.com/expressjs/accepts).

--- a/_includes/api/en/5x/req-accepts.md
+++ b/_includes/api/en/5x/req-accepts.md
@@ -10,26 +10,26 @@ list or array, the method returns the *best* match (if any).
 
 ```js
 // Accept: text/html
-req.accepts('html');
+req.accepts('html')
 // => "html"
 
 // Accept: text/*, application/json
-req.accepts('html');
+req.accepts('html')
 // => "html"
-req.accepts('text/html');
+req.accepts('text/html')
 // => "text/html"
-req.accepts(['json', 'text']);
+req.accepts(['json', 'text'])
 // => "json"
-req.accepts('application/json');
+req.accepts('application/json')
 // => "application/json"
 
 // Accept: text/*, application/json
-req.accepts('image/png');
-req.accepts('png');
+req.accepts('image/png')
+req.accepts('png')
 // => undefined
 
 // Accept: text/*;q=.5, application/json
-req.accepts(['html', 'json']);
+req.accepts(['html', 'json'])
 // => "json"
 ```
 

--- a/_includes/api/en/5x/req-acceptsCharsets.md
+++ b/_includes/api/en/5x/req-acceptsCharsets.md
@@ -1,0 +1,7 @@
+<h3 id='req.acceptsCharsets'>req.acceptsCharsets(charset [, ...])</h3>
+
+Returns the first accepted charset of the specified character sets,
+based on the request's `Accept-Charset` HTTP header field.
+If none of the specified charsets is accepted, returns `false`.
+
+For more information, or if you have issues or concerns, see [accepts](https://github.com/expressjs/accepts).

--- a/_includes/api/en/5x/req-acceptsEncodings.md
+++ b/_includes/api/en/5x/req-acceptsEncodings.md
@@ -1,0 +1,7 @@
+<h3 id='req.acceptsEncodings'>req.acceptsEncodings(encoding [, ...])</h3>
+
+Returns the first accepted encoding of the specified encodings,
+based on the request's `Accept-Encoding` HTTP header field.
+If none of the specified encodings is accepted, returns `false`.
+
+For more information, or if you have issues or concerns, see [accepts](https://github.com/expressjs/accepts).

--- a/_includes/api/en/5x/req-acceptsLanguages.md
+++ b/_includes/api/en/5x/req-acceptsLanguages.md
@@ -1,0 +1,7 @@
+<h3 id='req.acceptsLanguages'>req.acceptsLanguages(lang [, ...])</h3>
+
+Returns the first accepted language of the specified languages,
+based on the request's `Accept-Language` HTTP header field.
+If none of the specified languages is accepted, returns `false`.
+
+For more information, or if you have issues or concerns, see [accepts](https://github.com/expressjs/accepts).

--- a/_includes/api/en/5x/req-app.md
+++ b/_includes/api/en/5x/req-app.md
@@ -1,0 +1,20 @@
+<h3 id='req.app'>req.app</h3>
+
+This property holds a reference to the instance of the Express application that is using the middleware.
+
+If you follow the pattern in which you create a module that just exports a middleware function
+and `require()` it in your main file, then the middleware can access the Express instance via `req.app`
+
+For example:
+
+```js
+//index.js
+app.get('/viewdirectory', require('./mymiddleware.js'))
+```
+
+```js
+//mymiddleware.js
+module.exports = function (req, res) {
+  res.send('The views directory is ' + req.app.get('views'));
+});
+```

--- a/_includes/api/en/5x/req-app.md
+++ b/_includes/api/en/5x/req-app.md
@@ -13,8 +13,8 @@ app.get('/viewdirectory', require('./mymiddleware.js'))
 ```
 
 ```js
-//mymiddleware.js
+// mymiddleware.js
 module.exports = function (req, res) {
-  res.send('The views directory is ' + req.app.get('views'));
-});
+  res.send('The views directory is ' + req.app.get('views'))
+}
 ```

--- a/_includes/api/en/5x/req-app.md
+++ b/_includes/api/en/5x/req-app.md
@@ -8,7 +8,7 @@ and `require()` it in your main file, then the middleware can access the Express
 For example:
 
 ```js
-//index.js
+// index.js
 app.get('/viewdirectory', require('./mymiddleware.js'))
 ```
 

--- a/_includes/api/en/5x/req-baseUrl.md
+++ b/_includes/api/en/5x/req-baseUrl.md
@@ -1,0 +1,30 @@
+<h3 id='req.baseUrl'>req.baseUrl</h3>
+
+The URL path on which a router instance was mounted.
+
+The `req.baseUrl` property is similar to the [mountpath](#app.mountpath) property of the `app` object,
+except `app.mountpath` returns the matched path pattern(s).
+
+For example:
+
+```js
+var greet = express.Router();
+
+greet.get('/jp', function (req, res) {
+  console.log(req.baseUrl); // /greet
+  res.send('Konichiwa!');
+});
+
+app.use('/greet', greet); // load the router on '/greet'
+```
+
+Even if you use a path pattern or a set of path patterns to load the router,
+the `baseUrl` property returns the matched string, not the pattern(s). In the
+following example, the `greet` router is loaded on two path patterns.
+
+```js
+app.use(['/gre+t', '/hel{2}o'], greet); // load the router on '/gre+t' and '/hel{2}o'
+```
+
+When a request is made to `/greet/jp`, `req.baseUrl` is "/greet".  When a request is
+made to `/hello/jp`, `req.baseUrl` is "/hello".

--- a/_includes/api/en/5x/req-baseUrl.md
+++ b/_includes/api/en/5x/req-baseUrl.md
@@ -8,14 +8,14 @@ except `app.mountpath` returns the matched path pattern(s).
 For example:
 
 ```js
-var greet = express.Router();
+var greet = express.Router()
 
 greet.get('/jp', function (req, res) {
-  console.log(req.baseUrl); // /greet
-  res.send('Konichiwa!');
-});
+  console.log(req.baseUrl) // /greet
+  res.send('Konichiwa!')
+})
 
-app.use('/greet', greet); // load the router on '/greet'
+app.use('/greet', greet) // load the router on '/greet'
 ```
 
 Even if you use a path pattern or a set of path patterns to load the router,
@@ -23,7 +23,7 @@ the `baseUrl` property returns the matched string, not the pattern(s). In the
 following example, the `greet` router is loaded on two path patterns.
 
 ```js
-app.use(['/gre+t', '/hel{2}o'], greet); // load the router on '/gre+t' and '/hel{2}o'
+app.use(['/gre+t', '/hel{2}o'], greet) // load the router on '/gre+t' and '/hel{2}o'
 ```
 
 When a request is made to `/greet/jp`, `req.baseUrl` is "/greet".  When a request is

--- a/_includes/api/en/5x/req-body.md
+++ b/_includes/api/en/5x/req-body.md
@@ -1,0 +1,22 @@
+<h3 id='req.body'>req.body</h3>
+
+Contains key-value pairs of data submitted in the request body.
+By default, it is `undefined`, and is populated when you use body-parsing middleware such
+as [body-parser](https://www.npmjs.org/package/body-parser) and [multer](https://www.npmjs.org/package/multer).
+
+The following example shows how to use body-parsing middleware to populate `req.body`.
+
+```js
+var app = require('express')();
+var bodyParser = require('body-parser');
+var multer = require('multer'); // v1.0.5
+var upload = multer(); // for parsing multipart/form-data
+
+app.use(bodyParser.json()); // for parsing application/json
+app.use(bodyParser.urlencoded({ extended: true })); // for parsing application/x-www-form-urlencoded
+
+app.post('/profile', upload.array(), function (req, res, next) {
+  console.log(req.body);
+  res.json(req.body);
+});
+```

--- a/_includes/api/en/5x/req-body.md
+++ b/_includes/api/en/5x/req-body.md
@@ -7,16 +7,16 @@ as [body-parser](https://www.npmjs.org/package/body-parser) and [multer](https:/
 The following example shows how to use body-parsing middleware to populate `req.body`.
 
 ```js
-var app = require('express')();
-var bodyParser = require('body-parser');
-var multer = require('multer'); // v1.0.5
-var upload = multer(); // for parsing multipart/form-data
+var app = require('express')()
+var bodyParser = require('body-parser')
+var multer = require('multer') // v1.0.5
+var upload = multer() // for parsing multipart/form-data
 
-app.use(bodyParser.json()); // for parsing application/json
-app.use(bodyParser.urlencoded({ extended: true })); // for parsing application/x-www-form-urlencoded
+app.use(bodyParser.json()) // for parsing application/json
+app.use(bodyParser.urlencoded({ extended: true })) // for parsing application/x-www-form-urlencoded
 
 app.post('/profile', upload.array(), function (req, res, next) {
-  console.log(req.body);
-  res.json(req.body);
-});
+  console.log(req.body)
+  res.json(req.body)
+})
 ```

--- a/_includes/api/en/5x/req-cookies.md
+++ b/_includes/api/en/5x/req-cookies.md
@@ -1,0 +1,14 @@
+<h3 id='req.cookies'>req.cookies</h3>
+
+When using [cookie-parser](https://www.npmjs.com/package/cookie-parser) middleware, this property is an object that
+contains cookies sent by the request.  If the request contains no cookies, it defaults to `{}`.
+
+```js
+// Cookie: name=tj
+req.cookies.name
+// => "tj"
+```
+
+If the cookie has been signed, you have to use [req.signedCookies](#req.signedCookies).
+
+For more information, issues, or concerns, see [cookie-parser](https://github.com/expressjs/cookie-parser).

--- a/_includes/api/en/5x/req-cookies.md
+++ b/_includes/api/en/5x/req-cookies.md
@@ -5,7 +5,7 @@ contains cookies sent by the request.  If the request contains no cookies, it de
 
 ```js
 // Cookie: name=tj
-req.cookies.name
+console.dir(req.cookies.name)
 // => "tj"
 ```
 

--- a/_includes/api/en/5x/req-fresh.md
+++ b/_includes/api/en/5x/req-fresh.md
@@ -1,0 +1,18 @@
+<h3 id='req.fresh'>req.fresh</h3>
+
+Indicates whether the request is "fresh."  It is the opposite of `req.stale`.
+
+It is true if the `cache-control` request header doesn't have a `no-cache` directive and any
+of the following are true:
+
+* The `if-modified-since` request header is specified  and `last-modified` request header is equal to or earlier than the `modified` response header.
+* The `if-none-match` request header is `*`.
+* The `if-none-match` request header, after being parsed into its directives, does not
+match the `etag` response header.
+
+```js
+req.fresh
+// => true
+```
+
+For more information, issues, or concerns, see [fresh](https://github.com/jshttp/fresh).

--- a/_includes/api/en/5x/req-fresh.md
+++ b/_includes/api/en/5x/req-fresh.md
@@ -11,7 +11,7 @@ of the following are true:
 match the `etag` response header.
 
 ```js
-req.fresh
+console.dir(req.fresh)
 // => true
 ```
 

--- a/_includes/api/en/5x/req-get.md
+++ b/_includes/api/en/5x/req-get.md
@@ -1,0 +1,17 @@
+<h3 id='req.get'>req.get(field)</h3>
+
+Returns the specified HTTP request header field (case-insensitive match).
+The `Referrer` and `Referer` fields are interchangeable.
+
+```js
+req.get('Content-Type');
+// => "text/plain"
+
+req.get('content-type');
+// => "text/plain"
+
+req.get('Something');
+// => undefined
+```
+
+Aliased as `req.header(field)`.

--- a/_includes/api/en/5x/req-get.md
+++ b/_includes/api/en/5x/req-get.md
@@ -4,13 +4,13 @@ Returns the specified HTTP request header field (case-insensitive match).
 The `Referrer` and `Referer` fields are interchangeable.
 
 ```js
-req.get('Content-Type');
+req.get('Content-Type')
 // => "text/plain"
 
-req.get('content-type');
+req.get('content-type')
 // => "text/plain"
 
-req.get('Something');
+req.get('Something')
 // => undefined
 ```
 

--- a/_includes/api/en/5x/req-hostname.md
+++ b/_includes/api/en/5x/req-hostname.md
@@ -1,0 +1,13 @@
+<h3 id='req.hostname'>req.hostname</h3>
+
+Contains the hostname derived from the `Host` HTTP header.
+
+When the [`trust proxy` setting](/4x/api.html#trust.proxy.options.table) does not evaluate to `false`,
+this property will instead have the value of the `X-Forwarded-Host` header field.
+This header can be set by the client or by the proxy.
+
+```js
+// Host: "example.com:3000"
+req.hostname
+// => "example.com"
+```

--- a/_includes/api/en/5x/req-hostname.md
+++ b/_includes/api/en/5x/req-hostname.md
@@ -8,6 +8,6 @@ This header can be set by the client or by the proxy.
 
 ```js
 // Host: "example.com:3000"
-req.hostname
+console.dir(req.hostname)
 // => "example.com"
 ```

--- a/_includes/api/en/5x/req-ip.md
+++ b/_includes/api/en/5x/req-ip.md
@@ -1,0 +1,12 @@
+<h3 id='req.ip'>req.ip</h3>
+
+Contains the remote IP address of the request.
+
+When the [`trust proxy` setting](/4x/api.html#trust.proxy.options.table) does not evaluate to `false`,
+the value of this property is derived from the left-most entry in the
+`X-Forwarded-For` header. This header can be set by the client or by the proxy.
+
+```js
+req.ip
+// => "127.0.0.1"
+```

--- a/_includes/api/en/5x/req-ip.md
+++ b/_includes/api/en/5x/req-ip.md
@@ -7,6 +7,6 @@ the value of this property is derived from the left-most entry in the
 `X-Forwarded-For` header. This header can be set by the client or by the proxy.
 
 ```js
-req.ip
+console.dir(req.ip)
 // => "127.0.0.1"
 ```

--- a/_includes/api/en/5x/req-ips.md
+++ b/_includes/api/en/5x/req-ips.md
@@ -1,0 +1,9 @@
+<h3 id='req.ips'>req.ips</h3>
+
+When the [`trust proxy` setting](/4x/api.html#trust.proxy.options.table) does not evaluate to `false`,
+this property contains an array of IP addresses
+specified in the `X-Forwarded-For` request header. Otherwise, it contains an
+empty array. This header can be set by the client or by the proxy.
+
+For example, if `X-Forwarded-For` is `client, proxy1, proxy2`, `req.ips` would be
+`["client", "proxy1", "proxy2"]`, where `proxy2` is the furthest downstream.

--- a/_includes/api/en/5x/req-is.md
+++ b/_includes/api/en/5x/req-is.md
@@ -6,16 +6,16 @@ Returns `false` otherwise.
 
 ```js
 // With Content-Type: text/html; charset=utf-8
-req.is('html');       // => 'html'
-req.is('text/html');  // => 'text/html'
-req.is('text/*');     // => 'text/*'
+req.is('html') // => 'html'
+req.is('text/html') // => 'text/html'
+req.is('text/*') // => 'text/*'
 
 // When Content-Type is application/json
-req.is('json');              // => 'json'
-req.is('application/json');  // => 'application/json'
-req.is('application/*');     // => 'application/*'
+req.is('json') // => 'json'
+req.is('application/json') // => 'application/json'
+req.is('application/*') // => 'application/*'
 
-req.is('html');
+req.is('html')
 // => false
 ```
 

--- a/_includes/api/en/5x/req-is.md
+++ b/_includes/api/en/5x/req-is.md
@@ -1,0 +1,22 @@
+<h3 id='req.is'>req.is(type)</h3>
+
+Returns the matching content type if the incoming request's "Content-Type" HTTP header field
+matches the MIME type specified by the `type` parameter. If the request has no body, returns `null`.
+Returns `false` otherwise.
+
+```js
+// With Content-Type: text/html; charset=utf-8
+req.is('html');       // => 'html'
+req.is('text/html');  // => 'text/html'
+req.is('text/*');     // => 'text/*'
+
+// When Content-Type is application/json
+req.is('json');              // => 'json'
+req.is('application/json');  // => 'application/json'
+req.is('application/*');     // => 'application/*'
+
+req.is('html');
+// => false
+```
+
+For more information, or if you have issues or concerns, see [type-is](https://github.com/expressjs/type-is).

--- a/_includes/api/en/5x/req-method.md
+++ b/_includes/api/en/5x/req-method.md
@@ -1,0 +1,4 @@
+<h3 id='req.method'>req.method</h3>
+
+Contains a string corresponding to the HTTP method of the request:
+`GET`, `POST`, `PUT`, and so on.

--- a/_includes/api/en/5x/req-originalUrl.md
+++ b/_includes/api/en/5x/req-originalUrl.md
@@ -1,0 +1,26 @@
+<h3 id='req.originalUrl'>req.originalUrl</h3>
+
+<div class="doc-box doc-notice" markdown="1">
+`req.url` is not a native Express property, it is inherited from Node's [http module](https://nodejs.org/api/http.html#http_message_url).
+</div>
+
+This property is much like `req.url`; however, it retains the original request URL,
+allowing you to rewrite `req.url` freely for internal routing purposes. For example,
+the "mounting" feature of [app.use()](#app.use) will rewrite `req.url` to strip the mount point.
+
+```js
+// GET /search?q=something
+req.originalUrl
+// => "/search?q=something"
+```
+
+In a middleware function, `req.originalUrl` is a combination of `req.baseUrl` and `req.path`, as shown in the following example.
+
+```js
+app.use('/admin', function(req, res, next) {  // GET 'http://www.example.com/admin/new'
+  console.log(req.originalUrl); // '/admin/new'
+  console.log(req.baseUrl); // '/admin'
+  console.log(req.path); // '/new'
+  next();
+});
+```

--- a/_includes/api/en/5x/req-originalUrl.md
+++ b/_includes/api/en/5x/req-originalUrl.md
@@ -17,10 +17,10 @@ req.originalUrl
 In a middleware function, `req.originalUrl` is a combination of `req.baseUrl` and `req.path`, as shown in the following example.
 
 ```js
-app.use('/admin', function(req, res, next) {  // GET 'http://www.example.com/admin/new'
-  console.log(req.originalUrl); // '/admin/new'
-  console.log(req.baseUrl); // '/admin'
-  console.log(req.path); // '/new'
-  next();
-});
+app.use('/admin', function (req, res, next) { // GET 'http://www.example.com/admin/new'
+  console.log(req.originalUrl) // '/admin/new'
+  console.log(req.baseUrl) // '/admin'
+  console.log(req.path) // '/new'
+  next()
+})
 ```

--- a/_includes/api/en/5x/req-originalUrl.md
+++ b/_includes/api/en/5x/req-originalUrl.md
@@ -10,7 +10,7 @@ the "mounting" feature of [app.use()](#app.use) will rewrite `req.url` to strip 
 
 ```js
 // GET /search?q=something
-req.originalUrl
+console.dir(req.originalUrl)
 // => "/search?q=something"
 ```
 
@@ -18,9 +18,9 @@ In a middleware function, `req.originalUrl` is a combination of `req.baseUrl` an
 
 ```js
 app.use('/admin', function (req, res, next) { // GET 'http://www.example.com/admin/new'
-  console.log(req.originalUrl) // '/admin/new'
-  console.log(req.baseUrl) // '/admin'
-  console.log(req.path) // '/new'
+  console.dir(req.originalUrl) // '/admin/new'
+  console.dir(req.baseUrl) // '/admin'
+  console.dir(req.path) // '/new'
   next()
 })
 ```

--- a/_includes/api/en/5x/req-param.md
+++ b/_includes/api/en/5x/req-param.md
@@ -1,0 +1,35 @@
+<h3 id='req.param'>req.param(name [, defaultValue])</h3>
+
+<div class="doc-box doc-warn" markdown="1">
+Deprecated. Use either `req.params`, `req.body` or `req.query`, as applicable.
+</div>
+
+Returns the value of param `name` when present.
+
+```js
+// ?name=tobi
+req.param('name')
+// => "tobi"
+
+// POST name=tobi
+req.param('name')
+// => "tobi"
+
+// /user/tobi for /user/:name
+req.param('name')
+// => "tobi"
+```
+
+Lookup is performed in the following order:
+
+* `req.params`
+* `req.body`
+* `req.query`
+
+Optionally, you can specify `defaultValue` to set a default value if the parameter is not found in any of the request objects.
+
+<div class="doc-box doc-warn" markdown="1">
+Direct access to `req.body`, `req.params`, and `req.query` should be favoured for clarity - unless you truly accept input from each object.
+
+Body-parsing middleware must be loaded for `req.param()` to work predictably. Refer [req.body](#req.body) for details.
+</div>

--- a/_includes/api/en/5x/req-params.md
+++ b/_includes/api/en/5x/req-params.md
@@ -1,0 +1,25 @@
+<h3 id='req.params'>req.params</h3>
+
+This property is an object containing properties mapped to the [named route "parameters"](/{{ page.lang }}/guide/routing.html#route-parameters). For example, if you have the route `/user/:name`, then the "name" property is available as `req.params.name`. This object defaults to `{}`.
+
+```js
+// GET /user/tj
+req.params.name
+// => "tj"
+```
+
+When you use a regular expression for the route definition, capture groups are provided in the array using `req.params[n]`, where `n` is the n<sup>th</sup> capture group. This rule is applied to unnamed wild card matches with string routes such as `/file/*`:
+
+```js
+// GET /file/javascripts/jquery.js
+req.params[0]
+// => "javascripts/jquery.js"
+```
+
+If you need to make changes to a key in `req.params`, use the [app.param](/{{ page.lang }}/4x/api.html#app.param) handler. Changes are applicable only to [parameters](/{{ page.lang }}/guide/routing.html#route-parameters) already defined in the route path.
+
+Any changes made to the `req.params` object in a middleware or route handler will be reset.
+
+<div class="doc-box doc-info" markdown="1">
+NOTE: Express automatically decodes the values in `req.params` (using `decodeURIComponent`).
+</div>

--- a/_includes/api/en/5x/req-params.md
+++ b/_includes/api/en/5x/req-params.md
@@ -4,7 +4,7 @@ This property is an object containing properties mapped to the [named route "par
 
 ```js
 // GET /user/tj
-req.params.name
+console.dir(req.params.name)
 // => "tj"
 ```
 
@@ -12,7 +12,7 @@ When you use a regular expression for the route definition, capture groups are p
 
 ```js
 // GET /file/javascripts/jquery.js
-req.params[0]
+console.dir(req.params[0])
 // => "javascripts/jquery.js"
 ```
 

--- a/_includes/api/en/5x/req-path.md
+++ b/_includes/api/en/5x/req-path.md
@@ -1,0 +1,13 @@
+<h3 id='req.path'>req.path</h3>
+
+Contains the path part of the request URL.
+
+```js
+// example.com/users?sort=desc
+req.path
+// => "/users"
+```
+
+<div class="doc-box doc-info" markdown="1">
+When called from a middleware, the mount point is not included in `req.path`. See [app.use()](/4x/api.html#app.use) for more details.
+</div>

--- a/_includes/api/en/5x/req-path.md
+++ b/_includes/api/en/5x/req-path.md
@@ -4,7 +4,7 @@ Contains the path part of the request URL.
 
 ```js
 // example.com/users?sort=desc
-req.path
+console.dir(req.path)
 // => "/users"
 ```
 

--- a/_includes/api/en/5x/req-protocol.md
+++ b/_includes/api/en/5x/req-protocol.md
@@ -1,0 +1,12 @@
+<h3 id='req.protocol'>req.protocol</h3>
+
+Contains the request protocol string: either `http` or (for TLS requests) `https`.
+
+When the [`trust proxy` setting](#trust.proxy.options.table) does not evaluate to `false`,
+this property will use the value of the `X-Forwarded-Proto` header field if present.
+This header can be set by the client or by the proxy.
+
+```js
+req.protocol
+// => "http"
+```

--- a/_includes/api/en/5x/req-protocol.md
+++ b/_includes/api/en/5x/req-protocol.md
@@ -7,6 +7,6 @@ this property will use the value of the `X-Forwarded-Proto` header field if pres
 This header can be set by the client or by the proxy.
 
 ```js
-req.protocol
+console.dir(req.protocol)
 // => "http"
 ```

--- a/_includes/api/en/5x/req-query.md
+++ b/_includes/api/en/5x/req-query.md
@@ -1,0 +1,28 @@
+<h3 id='req.query'>req.query</h3>
+
+This property is an object containing a property for each query string parameter in the route.
+If there is no query string, it is the empty object, `{}`.
+
+<div class="doc-box doc-warn" markdown="1">
+As `req.query`'s shape is based on user-controlled input, all properties and values in this object are untrusted and should be validated before trusting. For example, `req.query.foo.toString()` may fail in multiple ways, for example `foo` may not be there or may not be a string, and `toString` may not be a function and instead a string or other user-input.
+</div>
+
+```js
+// GET /search?q=tobi+ferret
+req.query.q
+// => "tobi ferret"
+
+// GET /shoes?order=desc&shoe[color]=blue&shoe[type]=converse
+req.query.order
+// => "desc"
+
+req.query.shoe.color
+// => "blue"
+
+req.query.shoe.type
+// => "converse"
+
+// GET /shoes?color[]=blue&color[]=black&color[]=red
+req.query.color
+// => [blue, black, red]
+```

--- a/_includes/api/en/5x/req-query.md
+++ b/_includes/api/en/5x/req-query.md
@@ -9,20 +9,20 @@ As `req.query`'s shape is based on user-controlled input, all properties and val
 
 ```js
 // GET /search?q=tobi+ferret
-req.query.q
+console.dir(req.query.q)
 // => "tobi ferret"
 
 // GET /shoes?order=desc&shoe[color]=blue&shoe[type]=converse
-req.query.order
+console.dir(req.query.order)
 // => "desc"
 
-req.query.shoe.color
+console.dir(req.query.shoe.color)
 // => "blue"
 
-req.query.shoe.type
+console.dir(req.query.shoe.type)
 // => "converse"
 
 // GET /shoes?color[]=blue&color[]=black&color[]=red
-req.query.color
+console.dir(req.query.color)
 // => [blue, black, red]
 ```

--- a/_includes/api/en/5x/req-range.md
+++ b/_includes/api/en/5x/req-range.md
@@ -1,0 +1,29 @@
+<h3 id='req.range'>req.range(size[, options])</h3>
+
+`Range` header parser.
+
+The `size` parameter is the maximum size of the resource.
+
+The `options` parameter is an object that can have the following properties.
+
+| Property    | Type |  Description                                                     |
+|-------------|-------------------------------------------------------------------------|
+| `combine`   | Boolean | Specify if overlapping & adjacent ranges should be combined, defaults to `false`. When `true`, ranges will be combined and returned as if they were specified that way in the header.
+
+An array of ranges will be returned or negative numbers indicating an error parsing.
+
+* `-2` signals a malformed header string
+* `-1` signals an unsatisfiable range
+
+```js
+// parse header from request
+var range = req.range(1000)
+
+// the type of the range
+if (range.type === 'bytes') {
+  // the ranges
+  range.forEach(function (r) {
+    // do something with r.start and r.end
+  })
+}
+```

--- a/_includes/api/en/5x/req-route.md
+++ b/_includes/api/en/5x/req-route.md
@@ -1,0 +1,25 @@
+<h3 id='req.route'>req.route</h3>
+
+Contains the currently-matched route, a string.  For example:
+
+```js
+app.get('/user/:id?', function userIdHandler(req, res) {
+  console.log(req.route);
+  res.send('GET');
+});
+```
+
+Example output from the previous snippet:
+
+```js
+{ path: '/user/:id?',
+  stack:
+   [ { handle: [Function: userIdHandler],
+       name: 'userIdHandler',
+       params: undefined,
+       path: undefined,
+       keys: [],
+       regexp: /^\/?$/i,
+       method: 'get' } ],
+  methods: { get: true } }
+```

--- a/_includes/api/en/5x/req-route.md
+++ b/_includes/api/en/5x/req-route.md
@@ -3,10 +3,10 @@
 Contains the currently-matched route, a string.  For example:
 
 ```js
-app.get('/user/:id?', function userIdHandler(req, res) {
-  console.log(req.route);
-  res.send('GET');
-});
+app.get('/user/:id?', function userIdHandler (req, res) {
+  console.log(req.route)
+  res.send('GET')
+})
 ```
 
 Example output from the previous snippet:

--- a/_includes/api/en/5x/req-route.md
+++ b/_includes/api/en/5x/req-route.md
@@ -11,7 +11,7 @@ app.get('/user/:id?', function userIdHandler (req, res) {
 
 Example output from the previous snippet:
 
-```js
+```
 { path: '/user/:id?',
   stack:
    [ { handle: [Function: userIdHandler],

--- a/_includes/api/en/5x/req-secure.md
+++ b/_includes/api/en/5x/req-secure.md
@@ -1,0 +1,7 @@
+<h3 id='req.secure'>req.secure</h3>
+
+A Boolean property that is true if a TLS connection is established. Equivalent to:
+
+```js
+'https' == req.protocol;
+```

--- a/_includes/api/en/5x/req-secure.md
+++ b/_includes/api/en/5x/req-secure.md
@@ -1,7 +1,2 @@
-<h3 id='req.secure'>req.secure</h3>
-
-A Boolean property that is true if a TLS connection is established. Equivalent to:
-
-```js
-'https' == req.protocol;
+req.protocol == 'https';
 ```

--- a/_includes/api/en/5x/req-signedCookies.md
+++ b/_includes/api/en/5x/req-signedCookies.md
@@ -1,0 +1,17 @@
+<h3 id='req.signedCookies'>req.signedCookies</h3>
+
+When using [cookie-parser](https://www.npmjs.com/package/cookie-parser) middleware, this property
+contains signed cookies sent by the request, unsigned and ready for use. Signed cookies reside
+in a different object to show developer intent; otherwise, a malicious attack could be placed on
+`req.cookie` values (which are easy to spoof). Note that signing a cookie does not make it "hidden"
+or encrypted; but simply prevents tampering (because the secret used to sign is private).
+
+If no signed cookies are sent, the property defaults to `{}`.
+
+```js
+// Cookie: user=tobi.CP7AWaXDfAKIRfH49dQzKJx7sKzzSoPq7/AcBBRVwlI3
+req.signedCookies.user
+// => "tobi"
+```
+
+For more information, issues, or concerns, see [cookie-parser](https://github.com/expressjs/cookie-parser).

--- a/_includes/api/en/5x/req-signedCookies.md
+++ b/_includes/api/en/5x/req-signedCookies.md
@@ -10,7 +10,7 @@ If no signed cookies are sent, the property defaults to `{}`.
 
 ```js
 // Cookie: user=tobi.CP7AWaXDfAKIRfH49dQzKJx7sKzzSoPq7/AcBBRVwlI3
-req.signedCookies.user
+console.dir(req.signedCookies.user)
 // => "tobi"
 ```
 

--- a/_includes/api/en/5x/req-stale.md
+++ b/_includes/api/en/5x/req-stale.md
@@ -1,0 +1,9 @@
+<h3 id='req.stale'>req.stale</h3>
+
+Indicates whether the request is "stale," and is the opposite of `req.fresh`.
+For more information, see [req.fresh](#req.fresh).
+
+```js
+req.stale
+// => true
+```

--- a/_includes/api/en/5x/req-stale.md
+++ b/_includes/api/en/5x/req-stale.md
@@ -4,6 +4,6 @@ Indicates whether the request is "stale," and is the opposite of `req.fresh`.
 For more information, see [req.fresh](#req.fresh).
 
 ```js
-req.stale
+console.dir(req.stale)
 // => true
 ```

--- a/_includes/api/en/5x/req-subdomains.md
+++ b/_includes/api/en/5x/req-subdomains.md
@@ -1,0 +1,13 @@
+<h3 id='req.subdomains'>req.subdomains</h3>
+
+An array of subdomains in the domain name of the request.
+
+```js
+// Host: "tobi.ferrets.example.com"
+req.subdomains
+// => ["ferrets", "tobi"]
+```
+
+The application property `subdomain offset`, which defaults to 2, is used for determining the
+beginning of the subdomain segments. To change this behavior, change its value
+using [app.set](/{{ page.lang }}/4x/api.html#app.set).

--- a/_includes/api/en/5x/req-subdomains.md
+++ b/_includes/api/en/5x/req-subdomains.md
@@ -4,7 +4,7 @@ An array of subdomains in the domain name of the request.
 
 ```js
 // Host: "tobi.ferrets.example.com"
-req.subdomains
+console.dir(req.subdomains)
 // => ["ferrets", "tobi"]
 ```
 

--- a/_includes/api/en/5x/req-xhr.md
+++ b/_includes/api/en/5x/req-xhr.md
@@ -1,0 +1,9 @@
+<h3 id='req.xhr'>req.xhr</h3>
+
+A Boolean property that is `true` if the request's `X-Requested-With` header field is
+"XMLHttpRequest", indicating that the request was issued by a client library such as jQuery.
+
+```js
+req.xhr
+// => true
+```

--- a/_includes/api/en/5x/req-xhr.md
+++ b/_includes/api/en/5x/req-xhr.md
@@ -4,6 +4,6 @@ A Boolean property that is `true` if the request's `X-Requested-With` header fie
 "XMLHttpRequest", indicating that the request was issued by a client library such as jQuery.
 
 ```js
-req.xhr
+console.dir(req.xhr)
 // => true
 ```

--- a/_includes/api/en/5x/req.md
+++ b/_includes/api/en/5x/req.md
@@ -1,0 +1,152 @@
+<h2 id="req">Request</h2>
+
+The `req` object represents the HTTP request and has properties for the
+request query string, parameters, body, HTTP headers, and so on.  In this documentation and by convention,
+the object is always referred to as `req` (and the HTTP response is `res`) but its actual name is determined
+by the parameters to the callback function in which you're working.
+
+For example:
+
+```js
+app.get('/user/:id', function(req, res) {
+  res.send('user ' + req.params.id);
+});
+```
+
+But you could just as well have:
+
+```js
+app.get('/user/:id', function(request, response) {
+  response.send('user ' + request.params.id);
+});
+```
+
+The `req` object is an enhanced version of Node's own request object
+and supports all [built-in fields and methods](https://nodejs.org/api/http.html#http_class_http_incomingmessage).
+
+<h3 id='req.properties'>Properties</h3>
+
+<div class="doc-box doc-notice" markdown="1">
+In Express 4, `req.files` is no longer available on the `req` object by default. To access uploaded files
+on the `req.files` object, use multipart-handling middleware like [busboy](https://www.npmjs.
+com/package/busboy), [multer](https://www.npmjs.com/package/multer),
+[formidable](https://www.npmjs.com/package/formidable),
+[multiparty](https://www.npmjs.com/package/multiparty),
+[connect-multiparty](https://www.npmjs.com/package/connect-multiparty),
+or [pez](https://www.npmjs.com/package/pez).
+</div>
+
+<section markdown="1">
+  {% include api/en/4x/req-app.md %}
+</section>
+
+<section markdown="1">
+  {% include api/en/4x/req-baseUrl.md %}
+</section>
+
+<section markdown="1">
+  {% include api/en/4x/req-body.md %}
+</section>
+
+<section markdown="1">
+  {% include api/en/4x/req-cookies.md %}
+</section>
+
+<section markdown="1">
+  {% include api/en/4x/req-fresh.md %}
+</section>
+
+<section markdown="1">
+  {% include api/en/4x/req-hostname.md %}
+</section>
+
+<section markdown="1">
+  {% include api/en/4x/req-ip.md %}
+</section>
+
+<section markdown="1">
+  {% include api/en/4x/req-ips.md %}
+</section>
+
+<section markdown="1">
+  {% include api/en/4x/req-method.md %}
+</section>
+
+<section markdown="1">
+  {% include api/en/4x/req-originalUrl.md %}
+</section>
+
+<section markdown="1">
+  {% include api/en/4x/req-params.md %}
+</section>
+
+<section markdown="1">
+  {% include api/en/4x/req-path.md %}
+</section>
+
+<section markdown="1">
+  {% include api/en/4x/req-protocol.md %}
+</section>
+
+<section markdown="1">
+  {% include api/en/4x/req-query.md %}
+</section>
+
+<section markdown="1">
+  {% include api/en/4x/req-route.md %}
+</section>
+
+<section markdown="1">
+  {% include api/en/4x/req-secure.md %}
+</section>
+
+<section markdown="1">
+  {% include api/en/4x/req-signedCookies.md %}
+</section>
+
+<section markdown="1">
+  {% include api/en/4x/req-stale.md %}
+</section>
+
+<section markdown="1">
+  {% include api/en/4x/req-subdomains.md %}
+</section>
+
+<section markdown="1">
+  {% include api/en/4x/req-xhr.md %}
+</section>
+
+<h3 id='req.methods'>Methods</h3>
+
+<section markdown="1">
+  {% include api/en/4x/req-accepts.md %}
+</section>
+
+<section markdown="1">
+  {% include api/en/4x/req-acceptsCharsets.md %}
+</section>
+
+<section markdown="1">
+  {% include api/en/4x/req-acceptsEncodings.md %}
+</section>
+
+<section markdown="1">
+  {% include api/en/4x/req-acceptsLanguages.md %}
+</section>
+
+<section markdown="1">
+  {% include api/en/4x/req-get.md %}
+</section>
+
+<section markdown="1">
+  {% include api/en/4x/req-is.md %}
+</section>
+
+<section markdown="1">
+  {% include api/en/4x/req-param.md %}
+</section>
+
+<section markdown="1">
+  {% include api/en/4x/req-range.md %}
+</section>
+

--- a/_includes/api/en/5x/req.md
+++ b/_includes/api/en/5x/req.md
@@ -8,17 +8,17 @@ by the parameters to the callback function in which you're working.
 For example:
 
 ```js
-app.get('/user/:id', function(req, res) {
-  res.send('user ' + req.params.id);
-});
+app.get('/user/:id', function (req, res) {
+  res.send('user ' + req.params.id)
+})
 ```
 
 But you could just as well have:
 
 ```js
-app.get('/user/:id', function(request, response) {
-  response.send('user ' + request.params.id);
-});
+app.get('/user/:id', function (request, response) {
+  response.send('user ' + request.params.id)
+})
 ```
 
 The `req` object is an enhanced version of Node's own request object

--- a/_includes/api/en/5x/res-app.md
+++ b/_includes/api/en/5x/res-app.md
@@ -1,0 +1,5 @@
+<h3 id='res.app'>res.app</h3>
+
+This property holds a reference to the instance of the Express application that is using the middleware.
+
+`res.app` is identical to the [req.app](#req.app) property in the request object.

--- a/_includes/api/en/5x/res-append.md
+++ b/_includes/api/en/5x/res-append.md
@@ -1,0 +1,16 @@
+<h3 id='res.append'>res.append(field [, value])</h3>
+
+<div class="doc-box doc-info" markdown="1">
+`res.append()` is supported by Express v4.11.0+
+</div>
+
+Appends the specified `value` to the HTTP response header `field`.  If the header is not already set,
+it creates the header with the specified value.  The `value` parameter can be a string or an array.
+
+Note: calling `res.set()` after `res.append()` will reset the previously-set header value.
+
+```js
+res.append('Link', ['<http://localhost/>', '<http://localhost:3000/>']);
+res.append('Set-Cookie', 'foo=bar; Path=/; HttpOnly');
+res.append('Warning', '199 Miscellaneous warning');
+```

--- a/_includes/api/en/5x/res-append.md
+++ b/_includes/api/en/5x/res-append.md
@@ -10,7 +10,7 @@ it creates the header with the specified value.  The `value` parameter can be a 
 Note: calling `res.set()` after `res.append()` will reset the previously-set header value.
 
 ```js
-res.append('Link', ['<http://localhost/>', '<http://localhost:3000/>']);
-res.append('Set-Cookie', 'foo=bar; Path=/; HttpOnly');
-res.append('Warning', '199 Miscellaneous warning');
+res.append('Link', ['<http://localhost/>', '<http://localhost:3000/>'])
+res.append('Set-Cookie', 'foo=bar; Path=/; HttpOnly')
+res.append('Warning', '199 Miscellaneous warning')
 ```

--- a/_includes/api/en/5x/res-attachment.md
+++ b/_includes/api/en/5x/res-attachment.md
@@ -1,0 +1,14 @@
+<h3 id='res.attachment'>res.attachment([filename])</h3>
+
+Sets the HTTP response `Content-Disposition` header field to "attachment". If a `filename` is given,
+then it sets the Content-Type based on the extension name via `res.type()`,
+and sets the `Content-Disposition` "filename=" parameter.
+
+```js
+res.attachment();
+// Content-Disposition: attachment
+
+res.attachment('path/to/logo.png');
+// Content-Disposition: attachment; filename="logo.png"
+// Content-Type: image/png
+```

--- a/_includes/api/en/5x/res-attachment.md
+++ b/_includes/api/en/5x/res-attachment.md
@@ -5,10 +5,10 @@ then it sets the Content-Type based on the extension name via `res.type()`,
 and sets the `Content-Disposition` "filename=" parameter.
 
 ```js
-res.attachment();
+res.attachment()
 // Content-Disposition: attachment
 
-res.attachment('path/to/logo.png');
+res.attachment('path/to/logo.png')
 // Content-Disposition: attachment; filename="logo.png"
 // Content-Type: image/png
 ```

--- a/_includes/api/en/5x/res-clearCookie.md
+++ b/_includes/api/en/5x/res-clearCookie.md
@@ -1,0 +1,14 @@
+<h3 id='res.clearCookie'>res.clearCookie(name [, options])</h3>
+
+Clears the cookie specified by `name`. For details about the `options` object, see [res.cookie()](#res.cookie).
+
+<div class="doc-box doc-notice" markdown="1">
+Web browsers and other compliant clients will only clear the cookie if the given
+`options` is identical to those given to [res.cookie()](#res.cookie), excluding
+`expires` and `maxAge`.
+</div>
+
+```js
+res.cookie('name', 'tobi', { path: '/admin' });
+res.clearCookie('name', { path: '/admin' });
+```

--- a/_includes/api/en/5x/res-clearCookie.md
+++ b/_includes/api/en/5x/res-clearCookie.md
@@ -9,6 +9,6 @@ Web browsers and other compliant clients will only clear the cookie if the given
 </div>
 
 ```js
-res.cookie('name', 'tobi', { path: '/admin' });
-res.clearCookie('name', { path: '/admin' });
+res.cookie('name', 'tobi', { path: '/admin' })
+res.clearCookie('name', { path: '/admin' })
 ```

--- a/_includes/api/en/5x/res-cookie.md
+++ b/_includes/api/en/5x/res-cookie.md
@@ -1,0 +1,69 @@
+<h3 id='res.cookie'>res.cookie(name, value [, options])</h3>
+
+Sets cookie `name` to `value`.  The `value` parameter may be a string or object converted to JSON.
+
+The `options` parameter is an object that can have the following properties.
+
+| Property    | Type |  Description                                                             |
+|-------------|-------------------------------------------------------------------------|
+| `domain`    | String | Domain name for the cookie. Defaults to the domain name of the app.
+| `encode`    | Function | A synchronous function used for cookie value encoding. Defaults to `encodeURIComponent`.
+| `expires`   | Date | Expiry date of the cookie in GMT. If not specified or set to 0, creates a session cookie.
+| `httpOnly`  | Boolean | Flags the cookie to be accessible only by the web server.
+| `maxAge`    | Number | Convenient option for setting the expiry time relative to the current time in milliseconds.
+| `path`      | String | Path for the cookie. Defaults to "/".
+| `secure`    | Boolean | Marks the cookie to be used with HTTPS only.
+| `signed`    | Boolean | Indicates if the cookie should be signed.
+| `sameSite`  | Boolean or String | Value of the "SameSite" **Set-Cookie** attribute. More information at [https://tools.ietf.org/html/draft-ietf-httpbis-cookie-same-site-00#section-4.1.1](https://tools.ietf.org/html/draft-ietf-httpbis-cookie-same-site-00#section-4.1.1).
+
+<div class="doc-box doc-notice" markdown="1">
+All `res.cookie()` does is set the HTTP `Set-Cookie` header with the options provided.
+Any option not specified defaults to the value stated in [RFC 6265](http://tools.ietf.org/html/rfc6265).
+</div>
+
+For example:
+
+```js
+res.cookie('name', 'tobi', { domain: '.example.com', path: '/admin', secure: true });
+res.cookie('rememberme', '1', { expires: new Date(Date.now() + 900000), httpOnly: true });
+```
+
+The `encode` option allows you to choose the function used for cookie value encoding.
+Does not support asynchronous functions.
+
+Example use case: You need to set a domain-wide cookie for another site in your organization.
+This other site (not under your administrative control) does not use URI-encoded cookie values.
+
+```js
+//Default encoding
+res.cookie('some_cross_domain_cookie', 'http://mysubdomain.example.com',{domain:'example.com'});
+// Result: 'some_cross_domain_cookie=http%3A%2F%2Fmysubdomain.example.com; Domain=example.com; Path=/'
+
+//Custom encoding
+res.cookie('some_cross_domain_cookie', 'http://mysubdomain.example.com',{domain:'example.com', encode: String});
+// Result: 'some_cross_domain_cookie=http://mysubdomain.example.com; Domain=example.com; Path=/;'
+```
+
+The `maxAge` option is a convenience option for setting "expires" relative to the current time in milliseconds.
+The following is equivalent to the second example above.
+
+```js
+res.cookie('rememberme', '1', { maxAge: 900000, httpOnly: true });
+```
+
+You can pass an object as the `value` parameter; it is then serialized as JSON and parsed by `bodyParser()` middleware.
+
+```js
+res.cookie('cart', { items: [1,2,3] });
+res.cookie('cart', { items: [1,2,3] }, { maxAge: 900000 });
+```
+
+When using [cookie-parser](https://www.npmjs.com/package/cookie-parser) middleware, this method also
+supports signed cookies. Simply include the `signed` option set to `true`.
+Then `res.cookie()` will use the secret passed to `cookieParser(secret)` to sign the value.
+
+```js
+res.cookie('name', 'tobi', { signed: true });
+```
+
+Later you may access this value through the [req.signedCookie](#req.signedCookies) object.

--- a/_includes/api/en/5x/res-cookie.md
+++ b/_includes/api/en/5x/res-cookie.md
@@ -24,8 +24,8 @@ Any option not specified defaults to the value stated in [RFC 6265](http://tools
 For example:
 
 ```js
-res.cookie('name', 'tobi', { domain: '.example.com', path: '/admin', secure: true });
-res.cookie('rememberme', '1', { expires: new Date(Date.now() + 900000), httpOnly: true });
+res.cookie('name', 'tobi', { domain: '.example.com', path: '/admin', secure: true })
+res.cookie('rememberme', '1', { expires: new Date(Date.now() + 900000), httpOnly: true })
 ```
 
 The `encode` option allows you to choose the function used for cookie value encoding.
@@ -35,12 +35,12 @@ Example use case: You need to set a domain-wide cookie for another site in your 
 This other site (not under your administrative control) does not use URI-encoded cookie values.
 
 ```js
-//Default encoding
-res.cookie('some_cross_domain_cookie', 'http://mysubdomain.example.com',{domain:'example.com'});
+// Default encoding
+res.cookie('some_cross_domain_cookie', 'http://mysubdomain.example.com', { domain: 'example.com' })
 // Result: 'some_cross_domain_cookie=http%3A%2F%2Fmysubdomain.example.com; Domain=example.com; Path=/'
 
-//Custom encoding
-res.cookie('some_cross_domain_cookie', 'http://mysubdomain.example.com',{domain:'example.com', encode: String});
+// Custom encoding
+res.cookie('some_cross_domain_cookie', 'http://mysubdomain.example.com', { domain: 'example.com', encode: String })
 // Result: 'some_cross_domain_cookie=http://mysubdomain.example.com; Domain=example.com; Path=/;'
 ```
 
@@ -48,14 +48,14 @@ The `maxAge` option is a convenience option for setting "expires" relative to th
 The following is equivalent to the second example above.
 
 ```js
-res.cookie('rememberme', '1', { maxAge: 900000, httpOnly: true });
+res.cookie('rememberme', '1', { maxAge: 900000, httpOnly: true })
 ```
 
 You can pass an object as the `value` parameter; it is then serialized as JSON and parsed by `bodyParser()` middleware.
 
 ```js
-res.cookie('cart', { items: [1,2,3] });
-res.cookie('cart', { items: [1,2,3] }, { maxAge: 900000 });
+res.cookie('cart', { items: [1, 2, 3] })
+res.cookie('cart', { items: [1, 2, 3] }, { maxAge: 900000 })
 ```
 
 When using [cookie-parser](https://www.npmjs.com/package/cookie-parser) middleware, this method also
@@ -63,7 +63,7 @@ supports signed cookies. Simply include the `signed` option set to `true`.
 Then `res.cookie()` will use the secret passed to `cookieParser(secret)` to sign the value.
 
 ```js
-res.cookie('name', 'tobi', { signed: true });
+res.cookie('name', 'tobi', { signed: true })
 ```
 
 Later you may access this value through the [req.signedCookie](#req.signedCookies) object.

--- a/_includes/api/en/5x/res-download.md
+++ b/_includes/api/en/5x/res-download.md
@@ -15,16 +15,16 @@ The optional `options` argument passes through to the underlying [res.sendFile()
 call, and takes the exact same parameters.
 
 ```js
-res.download('/report-12345.pdf');
+res.download('/report-12345.pdf')
 
-res.download('/report-12345.pdf', 'report.pdf');
+res.download('/report-12345.pdf', 'report.pdf')
 
-res.download('/report-12345.pdf', 'report.pdf', function(err){
+res.download('/report-12345.pdf', 'report.pdf', function (err) {
   if (err) {
     // Handle error, but keep in mind the response may be partially-sent
     // so check res.headersSent
   } else {
     // decrement a download credit, etc.
   }
-});
+})
 ```

--- a/_includes/api/en/5x/res-download.md
+++ b/_includes/api/en/5x/res-download.md
@@ -1,0 +1,30 @@
+<h3 id='res.download'>res.download(path [, filename] [, options] [, fn])</h3>
+
+<div class="doc-box doc-info" markdown="1">
+The optional `options` argument is supported by Express v4.16.0 onwards.
+</div>
+
+Transfers the file at `path` as an "attachment". Typically, browsers will prompt the user for download.
+By default, the `Content-Disposition` header "filename=" parameter is `path` (this typically appears in the browser dialog).
+Override this default with the `filename` parameter.
+
+When an error occurs or transfer is complete, the method calls the optional callback function `fn`.
+This method uses [res.sendFile()](#res.sendFile) to transfer the file.
+
+The optional `options` argument passes through to the underlying [res.sendFile()](#res.sendFile)
+call, and takes the exact same parameters.
+
+```js
+res.download('/report-12345.pdf');
+
+res.download('/report-12345.pdf', 'report.pdf');
+
+res.download('/report-12345.pdf', 'report.pdf', function(err){
+  if (err) {
+    // Handle error, but keep in mind the response may be partially-sent
+    // so check res.headersSent
+  } else {
+    // decrement a download credit, etc.
+  }
+});
+```

--- a/_includes/api/en/5x/res-end.md
+++ b/_includes/api/en/5x/res-end.md
@@ -1,0 +1,10 @@
+<h3 id='res.end'>res.end([data] [, encoding])</h3>
+
+Ends the response process. This method actually comes from Node core, specifically the [response.end() method of  http.ServerResponse](https://nodejs.org/api/http.html#http_response_end_data_encoding_callback).
+
+Use to quickly end the response without any data. If you need to respond with data, instead use methods such as [res.send()](#res.send) and [res.json()](#res.json).
+
+```js
+res.end();
+res.status(404).end();
+```

--- a/_includes/api/en/5x/res-end.md
+++ b/_includes/api/en/5x/res-end.md
@@ -5,6 +5,6 @@ Ends the response process. This method actually comes from Node core, specifical
 Use to quickly end the response without any data. If you need to respond with data, instead use methods such as [res.send()](#res.send) and [res.json()](#res.json).
 
 ```js
-res.end();
-res.status(404).end();
+res.end()
+res.status(404).end()
 ```

--- a/_includes/api/en/5x/res-format.md
+++ b/_includes/api/en/5x/res-format.md
@@ -1,0 +1,52 @@
+<h3 id='res.format'>res.format(object)</h3>
+
+Performs content-negotiation on the `Accept` HTTP header on the request object, when present.
+It uses [req.accepts()](#req.accepts) to select a handler for the request, based on the acceptable
+types ordered by their quality values. If the header is not specified, the first callback is invoked.
+When no match is found, the server responds with 406 "Not Acceptable", or invokes the `default` callback.
+
+The `Content-Type` response header is set when a callback is selected. However, you may alter
+this within the callback using methods such as `res.set()` or `res.type()`.
+
+The following example would respond with `{ "message": "hey" }` when the `Accept` header field is set
+to "application/json" or "\*/json" (however if it is "\*/\*", then the response will be "hey").
+
+```js
+res.format({
+  'text/plain': function(){
+    res.send('hey');
+  },
+
+  'text/html': function(){
+    res.send('<p>hey</p>');
+  },
+
+  'application/json': function(){
+    res.send({ message: 'hey' });
+  },
+
+  'default': function() {
+    // log the request and respond with 406
+    res.status(406).send('Not Acceptable');
+  }
+});
+```
+
+In addition to canonicalized MIME types, you may also use extension names mapped
+to these types for a slightly less verbose implementation:
+
+```js
+res.format({
+  text: function(){
+    res.send('hey');
+  },
+
+  html: function(){
+    res.send('<p>hey</p>');
+  },
+
+  json: function(){
+    res.send({ message: 'hey' });
+  }
+});
+```

--- a/_includes/api/en/5x/res-format.md
+++ b/_includes/api/en/5x/res-format.md
@@ -13,23 +13,23 @@ to "application/json" or "\*/json" (however if it is "\*/\*", then the response 
 
 ```js
 res.format({
-  'text/plain': function(){
-    res.send('hey');
+  'text/plain': function () {
+    res.send('hey')
   },
 
-  'text/html': function(){
-    res.send('<p>hey</p>');
+  'text/html': function () {
+    res.send('<p>hey</p>')
   },
 
-  'application/json': function(){
-    res.send({ message: 'hey' });
+  'application/json': function () {
+    res.send({ message: 'hey' })
   },
 
-  'default': function() {
+  'default': function () {
     // log the request and respond with 406
-    res.status(406).send('Not Acceptable');
+    res.status(406).send('Not Acceptable')
   }
-});
+})
 ```
 
 In addition to canonicalized MIME types, you may also use extension names mapped
@@ -37,16 +37,16 @@ to these types for a slightly less verbose implementation:
 
 ```js
 res.format({
-  text: function(){
-    res.send('hey');
+  text: function () {
+    res.send('hey')
   },
 
-  html: function(){
-    res.send('<p>hey</p>');
+  html: function () {
+    res.send('<p>hey</p>')
   },
 
-  json: function(){
-    res.send({ message: 'hey' });
+  json: function () {
+    res.send({ message: 'hey' })
   }
-});
+})
 ```

--- a/_includes/api/en/5x/res-get.md
+++ b/_includes/api/en/5x/res-get.md
@@ -1,0 +1,9 @@
+<h3 id='res.get'>res.get(field)</h3>
+
+Returns the HTTP response header specified by `field`.
+The match is case-insensitive.
+
+```js
+res.get('Content-Type');
+// => "text/plain"
+```

--- a/_includes/api/en/5x/res-get.md
+++ b/_includes/api/en/5x/res-get.md
@@ -4,6 +4,6 @@ Returns the HTTP response header specified by `field`.
 The match is case-insensitive.
 
 ```js
-res.get('Content-Type');
+res.get('Content-Type')
 // => "text/plain"
 ```

--- a/_includes/api/en/5x/res-headersSent.md
+++ b/_includes/api/en/5x/res-headersSent.md
@@ -1,0 +1,11 @@
+<h3 id='res.headersSent'>res.headersSent</h3>
+
+Boolean property that indicates if the app sent HTTP headers for the response.
+
+```js
+app.get('/', function (req, res) {
+  console.log(res.headersSent); // false
+  res.send('OK');
+  console.log(res.headersSent); // true
+});
+```

--- a/_includes/api/en/5x/res-headersSent.md
+++ b/_includes/api/en/5x/res-headersSent.md
@@ -4,8 +4,8 @@ Boolean property that indicates if the app sent HTTP headers for the response.
 
 ```js
 app.get('/', function (req, res) {
-  console.log(res.headersSent); // false
-  res.send('OK');
-  console.log(res.headersSent); // true
-});
+  console.log(res.headersSent) // false
+  res.send('OK')
+  console.log(res.headersSent) // true
+})
 ```

--- a/_includes/api/en/5x/res-json.md
+++ b/_includes/api/en/5x/res-json.md
@@ -7,7 +7,7 @@ The parameter can be any JSON type, including object, array, string, Boolean, nu
 and you can also use it to convert other values to JSON.
 
 ```js
-res.json(null);
-res.json({ user: 'tobi' });
-res.status(500).json({ error: 'message' });
+res.json(null)
+res.json({ user: 'tobi' })
+res.status(500).json({ error: 'message' })
 ```

--- a/_includes/api/en/5x/res-json.md
+++ b/_includes/api/en/5x/res-json.md
@@ -1,0 +1,13 @@
+<h3 id='res.json'>res.json([body])</h3>
+
+Sends a JSON response. This method sends a response (with the correct content-type) that is the parameter converted to a 
+JSON string using [JSON.stringify()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify).
+
+The parameter can be any JSON type, including object, array, string, Boolean, number, or null,
+and you can also use it to convert other values to JSON.
+
+```js
+res.json(null);
+res.json({ user: 'tobi' });
+res.status(500).json({ error: 'message' });
+```

--- a/_includes/api/en/5x/res-jsonp.md
+++ b/_includes/api/en/5x/res-jsonp.md
@@ -1,0 +1,32 @@
+<h3 id='res.jsonp'>res.jsonp([body])</h3>
+
+Sends a JSON response with JSONP support. This method is identical to `res.json()`,
+except that it opts-in to JSONP callback support.
+
+```js
+res.jsonp(null);
+// => callback(null)
+
+res.jsonp({ user: 'tobi' });
+// => callback({ "user": "tobi" })
+
+res.status(500).jsonp({ error: 'message' });
+// => callback({ "error": "message" })
+```
+
+By default, the JSONP callback name is simply `callback`. Override this with the
+<a href="#app.settings.table">jsonp callback name</a> setting.
+
+The following are some examples of JSONP responses using the same code:
+
+```js
+// ?callback=foo
+res.jsonp({ user: 'tobi' });
+// => foo({ "user": "tobi" })
+
+app.set('jsonp callback name', 'cb');
+
+// ?cb=foo
+res.status(500).jsonp({ error: 'message' });
+// => foo({ "error": "message" })
+```

--- a/_includes/api/en/5x/res-jsonp.md
+++ b/_includes/api/en/5x/res-jsonp.md
@@ -4,13 +4,13 @@ Sends a JSON response with JSONP support. This method is identical to `res.json(
 except that it opts-in to JSONP callback support.
 
 ```js
-res.jsonp(null);
+res.jsonp(null)
 // => callback(null)
 
-res.jsonp({ user: 'tobi' });
+res.jsonp({ user: 'tobi' })
 // => callback({ "user": "tobi" })
 
-res.status(500).jsonp({ error: 'message' });
+res.status(500).jsonp({ error: 'message' })
 // => callback({ "error": "message" })
 ```
 
@@ -21,12 +21,12 @@ The following are some examples of JSONP responses using the same code:
 
 ```js
 // ?callback=foo
-res.jsonp({ user: 'tobi' });
+res.jsonp({ user: 'tobi' })
 // => foo({ "user": "tobi" })
 
-app.set('jsonp callback name', 'cb');
+app.set('jsonp callback name', 'cb')
 
 // ?cb=foo
-res.status(500).jsonp({ error: 'message' });
+res.status(500).jsonp({ error: 'message' })
 // => foo({ "error": "message" })
 ```

--- a/_includes/api/en/5x/res-links.md
+++ b/_includes/api/en/5x/res-links.md
@@ -1,0 +1,20 @@
+<h3 id='res.links'>res.links(links)</h3>
+
+Joins the `links` provided as properties of the parameter to populate the response's
+`Link` HTTP header field.
+
+For example, the following call:
+
+```js
+res.links({
+  next: 'http://api.example.com/users?page=2',
+  last: 'http://api.example.com/users?page=5'
+});
+```
+
+Yields the following results:
+
+```js
+Link: <http://api.example.com/users?page=2>; rel="next",
+      <http://api.example.com/users?page=5>; rel="last"
+```

--- a/_includes/api/en/5x/res-links.md
+++ b/_includes/api/en/5x/res-links.md
@@ -9,7 +9,7 @@ For example, the following call:
 res.links({
   next: 'http://api.example.com/users?page=2',
   last: 'http://api.example.com/users?page=5'
-});
+})
 ```
 
 Yields the following results:

--- a/_includes/api/en/5x/res-links.md
+++ b/_includes/api/en/5x/res-links.md
@@ -14,7 +14,7 @@ res.links({
 
 Yields the following results:
 
-```js
+```
 Link: <http://api.example.com/users?page=2>; rel="next",
       <http://api.example.com/users?page=5>; rel="last"
 ```

--- a/_includes/api/en/5x/res-locals.md
+++ b/_includes/api/en/5x/res-locals.md
@@ -1,0 +1,16 @@
+<h3 id='res.locals'>res.locals</h3>
+
+An object that contains response local variables scoped to the request, and therefore available only to
+the view(s) rendered during that request / response cycle (if any). Otherwise,
+this property is identical to [app.locals](#app.locals).
+
+This property is useful for exposing request-level information such as the request path name,
+authenticated user, user settings, and so on.
+
+```js
+app.use(function(req, res, next){
+  res.locals.user = req.user;
+  res.locals.authenticated = ! req.user.anonymous;
+  next();
+});
+```

--- a/_includes/api/en/5x/res-locals.md
+++ b/_includes/api/en/5x/res-locals.md
@@ -8,9 +8,9 @@ This property is useful for exposing request-level information such as the reque
 authenticated user, user settings, and so on.
 
 ```js
-app.use(function(req, res, next){
-  res.locals.user = req.user;
-  res.locals.authenticated = ! req.user.anonymous;
-  next();
-});
+app.use(function (req, res, next) {
+  res.locals.user = req.user
+  res.locals.authenticated = !req.user.anonymous
+  next()
+})
 ```

--- a/_includes/api/en/5x/res-location.md
+++ b/_includes/api/en/5x/res-location.md
@@ -1,0 +1,19 @@
+<h3 id='res.location'>res.location(path)</h3>
+
+Sets the response `Location` HTTP header to the specified `path` parameter.
+
+```js
+res.location('/foo/bar');
+res.location('http://example.com');
+res.location('back');
+```
+
+A `path` value of "back" has a special meaning, it refers to the URL specified in the `Referer` header of the request. If the `Referer` header was not specified, it refers to "/".
+
+<div class='doc-box doc-warn' markdown="1">
+After encoding the URL, if not encoded already, Express passes the specified URL to the browser in the `Location` header,
+without any validation.
+
+Browsers take the responsibility of deriving the intended URL from the current URL
+or the referring URL, and the URL specified in the `Location` header; and redirect the user accordingly.
+</div>

--- a/_includes/api/en/5x/res-location.md
+++ b/_includes/api/en/5x/res-location.md
@@ -3,9 +3,9 @@
 Sets the response `Location` HTTP header to the specified `path` parameter.
 
 ```js
-res.location('/foo/bar');
-res.location('http://example.com');
-res.location('back');
+res.location('/foo/bar')
+res.location('http://example.com')
+res.location('back')
 ```
 
 A `path` value of "back" has a special meaning, it refers to the URL specified in the `Referer` header of the request. If the `Referer` header was not specified, it refers to "/".

--- a/_includes/api/en/5x/res-redirect.md
+++ b/_includes/api/en/5x/res-redirect.md
@@ -1,0 +1,53 @@
+<h3 id='res.redirect'>res.redirect([status,] path)</h3>
+
+Redirects to the URL derived from the specified `path`, with specified `status`, a positive integer
+that corresponds to an [HTTP status code](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html) .
+If not specified, `status` defaults to "302 "Found".
+
+```js
+res.redirect('/foo/bar');
+res.redirect('http://example.com');
+res.redirect(301, 'http://example.com');
+res.redirect('../login');
+```
+Redirects can be a fully-qualified URL for redirecting to a different site:
+
+```js
+res.redirect('http://google.com');
+```
+Redirects can be relative to the root of the host name. For example, if the
+application is on `http://example.com/admin/post/new`, the following
+would redirect to the URL `http://example.com/admin`:
+
+```js
+res.redirect('/admin');
+```
+
+Redirects can be relative to the current URL. For example,
+from `http://example.com/blog/admin/` (notice the trailing slash), the following
+would redirect to the URL `http://example.com/blog/admin/post/new`.
+
+```js
+res.redirect('post/new');
+```
+
+Redirecting to `post/new` from `http://example.com/blog/admin` (no trailing slash),
+will redirect to `http://example.com/blog/post/new`.
+
+If you found the above behavior confusing, think of path segments as directories
+(with trailing slashes) and files, it will start to make sense.
+
+Path-relative redirects are also possible. If you were on
+`http://example.com/admin/post/new`, the following would redirect to
+`http://example.com/admin/post`:
+
+```js
+res.redirect('..');
+```
+
+A `back` redirection redirects the request back to the [referer](http://en.wikipedia.org/wiki/HTTP_referer),
+defaulting to `/` when the referer is missing.
+
+```js
+res.redirect('back');
+```

--- a/_includes/api/en/5x/res-redirect.md
+++ b/_includes/api/en/5x/res-redirect.md
@@ -5,22 +5,22 @@ that corresponds to an [HTTP status code](http://www.w3.org/Protocols/rfc2616/rf
 If not specified, `status` defaults to "302 "Found".
 
 ```js
-res.redirect('/foo/bar');
-res.redirect('http://example.com');
-res.redirect(301, 'http://example.com');
-res.redirect('../login');
+res.redirect('/foo/bar')
+res.redirect('http://example.com')
+res.redirect(301, 'http://example.com')
+res.redirect('../login')
 ```
 Redirects can be a fully-qualified URL for redirecting to a different site:
 
 ```js
-res.redirect('http://google.com');
+res.redirect('http://google.com')
 ```
 Redirects can be relative to the root of the host name. For example, if the
 application is on `http://example.com/admin/post/new`, the following
 would redirect to the URL `http://example.com/admin`:
 
 ```js
-res.redirect('/admin');
+res.redirect('/admin')
 ```
 
 Redirects can be relative to the current URL. For example,
@@ -28,7 +28,7 @@ from `http://example.com/blog/admin/` (notice the trailing slash), the following
 would redirect to the URL `http://example.com/blog/admin/post/new`.
 
 ```js
-res.redirect('post/new');
+res.redirect('post/new')
 ```
 
 Redirecting to `post/new` from `http://example.com/blog/admin` (no trailing slash),
@@ -42,12 +42,12 @@ Path-relative redirects are also possible. If you were on
 `http://example.com/admin/post`:
 
 ```js
-res.redirect('..');
+res.redirect('..')
 ```
 
 A `back` redirection redirects the request back to the [referer](http://en.wikipedia.org/wiki/HTTP_referer),
 defaulting to `/` when the referer is missing.
 
 ```js
-res.redirect('back');
+res.redirect('back')
 ```

--- a/_includes/api/en/5x/res-render.md
+++ b/_includes/api/en/5x/res-render.md
@@ -1,0 +1,33 @@
+<h3 id='res.render'>res.render(view [, locals] [, callback])</h3>
+
+Renders a `view` and sends the rendered HTML string to the client.
+Optional parameters:
+
+- `locals`, an object whose properties define local variables for the view.
+- `callback`, a callback function. If provided, the method returns both the possible error and rendered string, but does not perform an automated response. When an error occurs, the method invokes `next(err)` internally.
+
+The `view` argument is a string that is the file path of the view file to render. This can be an absolute path, or a path relative to the `views` setting. If the path does not contain a file extension, then the `view engine` setting determines the file extension. If the path does contain a file extension, then Express will load the module for the specified template engine (via `require()`) and render it using the loaded module's `__express` function.
+
+For more information, see [Using template engines with Express](/guide/using-template-engines.html).
+
+**NOTE:** The `view` argument performs file system operations like reading a file from disk and evaluating Node.js modules, and as so for security reasons should not contain input from the end-user.
+
+<div class="doc-box doc-notice" markdown="1">
+The local variable `cache` enables view caching. Set it to `true`,
+to cache the view during development; view caching is enabled in production by default.
+</div>
+
+```js
+// send the rendered view to the client
+res.render('index');
+
+// if a callback is specified, the rendered HTML string has to be sent explicitly
+res.render('index', function(err, html) {
+  res.send(html);
+});
+
+// pass a local variable to the view
+res.render('user', { name: 'Tobi' }, function(err, html) {
+  // ...
+});
+```

--- a/_includes/api/en/5x/res-render.md
+++ b/_includes/api/en/5x/res-render.md
@@ -19,15 +19,15 @@ to cache the view during development; view caching is enabled in production by d
 
 ```js
 // send the rendered view to the client
-res.render('index');
+res.render('index')
 
 // if a callback is specified, the rendered HTML string has to be sent explicitly
-res.render('index', function(err, html) {
-  res.send(html);
-});
+res.render('index', function (err, html) {
+  res.send(html)
+})
 
 // pass a local variable to the view
-res.render('user', { name: 'Tobi' }, function(err, html) {
+res.render('user', { name: 'Tobi' }, function (err, html) {
   // ...
-});
+})
 ```

--- a/_includes/api/en/5x/res-send.md
+++ b/_includes/api/en/5x/res-send.md
@@ -1,0 +1,39 @@
+<h3 id='res.send'>res.send([body])</h3>
+
+Sends the HTTP response.
+
+The `body` parameter can be a `Buffer` object, a `String`, an object, or an `Array`.
+For example:
+
+```js
+res.send(new Buffer('whoop'));
+res.send({ some: 'json' });
+res.send('<p>some html</p>');
+res.status(404).send('Sorry, we cannot find that!');
+res.status(500).send({ error: 'something blew up' });
+```
+
+This method performs many useful tasks for simple non-streaming responses:
+For example, it automatically assigns the `Content-Length` HTTP response header field
+(unless previously defined) and provides automatic HEAD and HTTP cache freshness support.
+
+When the parameter is a `Buffer` object, the method sets the `Content-Type`
+response header field  to "application/octet-stream", unless previously defined as shown below:
+
+```js
+res.set('Content-Type', 'text/html');
+res.send(new Buffer('<p>some html</p>'));
+```
+
+When the parameter is a `String`, the method sets the `Content-Type` to "text/html":
+
+```js
+res.send('<p>some html</p>');
+```
+
+When the parameter is an `Array` or `Object`, Express responds with the JSON representation:
+
+```js
+res.send({ user: 'tobi' });
+res.send([1,2,3]);
+```

--- a/_includes/api/en/5x/res-send.md
+++ b/_includes/api/en/5x/res-send.md
@@ -6,7 +6,7 @@ The `body` parameter can be a `Buffer` object, a `String`, an object, or an `Arr
 For example:
 
 ```js
-res.send(new Buffer('whoop'))
+res.send(Buffer.from('whoop'))
 res.send({ some: 'json' })
 res.send('<p>some html</p>')
 res.status(404).send('Sorry, we cannot find that!')
@@ -22,7 +22,7 @@ response header field  to "application/octet-stream", unless previously defined 
 
 ```js
 res.set('Content-Type', 'text/html')
-res.send(new Buffer('<p>some html</p>'))
+res.send(Buffer.from('<p>some html</p>'))
 ```
 
 When the parameter is a `String`, the method sets the `Content-Type` to "text/html":

--- a/_includes/api/en/5x/res-send.md
+++ b/_includes/api/en/5x/res-send.md
@@ -6,11 +6,11 @@ The `body` parameter can be a `Buffer` object, a `String`, an object, or an `Arr
 For example:
 
 ```js
-res.send(new Buffer('whoop'));
-res.send({ some: 'json' });
-res.send('<p>some html</p>');
-res.status(404).send('Sorry, we cannot find that!');
-res.status(500).send({ error: 'something blew up' });
+res.send(new Buffer('whoop'))
+res.send({ some: 'json' })
+res.send('<p>some html</p>')
+res.status(404).send('Sorry, we cannot find that!')
+res.status(500).send({ error: 'something blew up' })
 ```
 
 This method performs many useful tasks for simple non-streaming responses:
@@ -21,19 +21,19 @@ When the parameter is a `Buffer` object, the method sets the `Content-Type`
 response header field  to "application/octet-stream", unless previously defined as shown below:
 
 ```js
-res.set('Content-Type', 'text/html');
-res.send(new Buffer('<p>some html</p>'));
+res.set('Content-Type', 'text/html')
+res.send(new Buffer('<p>some html</p>'))
 ```
 
 When the parameter is a `String`, the method sets the `Content-Type` to "text/html":
 
 ```js
-res.send('<p>some html</p>');
+res.send('<p>some html</p>')
 ```
 
 When the parameter is an `Array` or `Object`, Express responds with the JSON representation:
 
 ```js
-res.send({ user: 'tobi' });
-res.send([1,2,3]);
+res.send({ user: 'tobi' })
+res.send([1, 2, 3])
 ```

--- a/_includes/api/en/5x/res-sendFile.md
+++ b/_includes/api/en/5x/res-sendFile.md
@@ -1,0 +1,86 @@
+<h3 id='res.sendFile'>res.sendFile(path [, options] [, fn])</h3>
+
+<div class="doc-box doc-info" markdown="1">
+`res.sendFile()` is supported by Express v4.8.0 onwards.
+</div>
+
+Transfers the file at the given `path`. Sets the `Content-Type` response HTTP header field
+based on the filename's extension. Unless the `root` option is set in
+the options object, `path` must be an absolute path to the file.
+
+<div class="doc-box doc-warn" markdown="1">
+This API provides access to data on the running file system. Ensure that either (a) the way in
+which the `path` argument was constructed into an absolute path is secure if it contains user
+input or (b) set the `root` option to the absolute path of a directory to contain access within.
+
+When the `root` option is provided, the `path` argument is allowed to be a relative path,
+including containing `..`. Express will validate that the relative path provided as `path` will
+resolve within the given `root` option.
+</div>
+
+The following table provides details on the `options` parameter.
+
+<div class="table-scroller" markdown="1">
+
+| Property        | Description                                     | Default     | Availability |
+|-----------------|-------------------------------------------------|-------------|--------------|
+|`maxAge`         | Sets the max-age property of the `Cache-Control` header in milliseconds or a string in [ms format](https://www.npmjs.org/package/ms)| 0 |  |
+| `root`          | Root directory for relative filenames.|  |  |
+| `lastModified`  | Sets the `Last-Modified` header to the last modified date of the file on the OS. Set `false` to disable it.| Enabled | 4.9.0+ |
+| `headers`       | Object containing HTTP headers to serve with the file.|  |  |
+| `dotfiles`      | Option for serving dotfiles. Possible values are "allow", "deny", "ignore".| "ignore" | &nbsp; |
+| `acceptRanges`  | Enable or disable accepting ranged requests. | `true` | 4.14+ |
+| `cacheControl`  | Enable or disable setting `Cache-Control` response header.| `true` | 4.14+ |
+| `immutable`   | Enable or disable the `immutable` directive in the `Cache-Control` response header. If enabled, the `maxAge` option should also be specified to enable caching. The `immutable` directive will prevent supported clients from making conditional requests during the life of the `maxAge` option to check if the file has changed. | `false` | 4.16+ |
+
+</div>
+
+The method invokes the callback function `fn(err)` when the transfer is complete
+or when an error occurs. If the callback function is specified and an error occurs,
+the callback function must explicitly handle the response process either by
+ending the request-response cycle, or by passing control to the next route.
+
+Here is an example of using `res.sendFile` with all its arguments.
+
+```js
+app.get('/file/:name', function (req, res, next) {
+
+  var options = {
+    root: __dirname + '/public/',
+    dotfiles: 'deny',
+    headers: {
+        'x-timestamp': Date.now(),
+        'x-sent': true
+    }
+  };
+
+  var fileName = req.params.name;
+  res.sendFile(fileName, options, function (err) {
+    if (err) {
+      next(err);
+    } else {
+      console.log('Sent:', fileName);
+    }
+  });
+
+});
+```
+
+The following example illustrates using
+`res.sendFile` to provide fine-grained support for serving files:
+
+```js
+app.get('/user/:uid/photos/:file', function(req, res){
+  var uid = req.params.uid
+    , file = req.params.file;
+
+  req.user.mayViewFilesFrom(uid, function(yes){
+    if (yes) {
+      res.sendFile('/uploads/' + uid + '/' + file);
+    } else {
+      res.status(403).send("Sorry! You can't see that.");
+    }
+  });
+});
+```
+For more information, or if you have issues or concerns, see [send](https://github.com/pillarjs/send).

--- a/_includes/api/en/5x/res-sendFile.md
+++ b/_includes/api/en/5x/res-sendFile.md
@@ -45,7 +45,7 @@ Here is an example of using `res.sendFile` with all its arguments.
 ```js
 app.get('/file/:name', function (req, res, next) {
   var options = {
-    root: __dirname + '/public/',
+    root: path.join(__dirname, 'public'),
     dotfiles: 'deny',
     headers: {
       'x-timestamp': Date.now(),

--- a/_includes/api/en/5x/res-sendFile.md
+++ b/_includes/api/en/5x/res-sendFile.md
@@ -44,43 +44,41 @@ Here is an example of using `res.sendFile` with all its arguments.
 
 ```js
 app.get('/file/:name', function (req, res, next) {
-
   var options = {
     root: __dirname + '/public/',
     dotfiles: 'deny',
     headers: {
-        'x-timestamp': Date.now(),
-        'x-sent': true
+      'x-timestamp': Date.now(),
+      'x-sent': true
     }
-  };
+  }
 
-  var fileName = req.params.name;
+  var fileName = req.params.name
   res.sendFile(fileName, options, function (err) {
     if (err) {
-      next(err);
+      next(err)
     } else {
-      console.log('Sent:', fileName);
+      console.log('Sent:', fileName)
     }
-  });
-
-});
+  })
+})
 ```
 
 The following example illustrates using
 `res.sendFile` to provide fine-grained support for serving files:
 
 ```js
-app.get('/user/:uid/photos/:file', function(req, res){
+app.get('/user/:uid/photos/:file', function (req, res) {
   var uid = req.params.uid
-    , file = req.params.file;
+  var file = req.params.file
 
-  req.user.mayViewFilesFrom(uid, function(yes){
+  req.user.mayViewFilesFrom(uid, function (yes) {
     if (yes) {
-      res.sendFile('/uploads/' + uid + '/' + file);
+      res.sendFile('/uploads/' + uid + '/' + file)
     } else {
-      res.status(403).send("Sorry! You can't see that.");
+      res.status(403).send("Sorry! You can't see that.")
     }
-  });
-});
+  })
+})
 ```
 For more information, or if you have issues or concerns, see [send](https://github.com/pillarjs/send).

--- a/_includes/api/en/5x/res-sendStatus.md
+++ b/_includes/api/en/5x/res-sendStatus.md
@@ -3,10 +3,10 @@
 Sets the response HTTP status code to `statusCode` and send its string representation as the response body.
 
 ```js
-res.sendStatus(200); // equivalent to res.status(200).send('OK')
-res.sendStatus(403); // equivalent to res.status(403).send('Forbidden')
-res.sendStatus(404); // equivalent to res.status(404).send('Not Found')
-res.sendStatus(500); // equivalent to res.status(500).send('Internal Server Error')
+res.sendStatus(200) // equivalent to res.status(200).send('OK')
+res.sendStatus(403) // equivalent to res.status(403).send('Forbidden')
+res.sendStatus(404) // equivalent to res.status(404).send('Not Found')
+res.sendStatus(500) // equivalent to res.status(500).send('Internal Server Error')
 ```
 
 If an unsupported status code is specified, the HTTP status is still set to `statusCode` and the string version of the code is sent as the response body.
@@ -18,7 +18,7 @@ the HTTP server documentation for the Node.js version being used.
 </div>
 
 ```js
-res.sendStatus(9999); // equivalent to res.status(9999).send('9999')
+res.sendStatus(9999) // equivalent to res.status(9999).send('9999')
 ```
 
 [More about HTTP Status Codes](http://en.wikipedia.org/wiki/List_of_HTTP_status_codes)

--- a/_includes/api/en/5x/res-sendStatus.md
+++ b/_includes/api/en/5x/res-sendStatus.md
@@ -1,0 +1,24 @@
+<h3 id='res.sendStatus'>res.sendStatus(statusCode)</h3>
+
+Sets the response HTTP status code to `statusCode` and send its string representation as the response body.
+
+```js
+res.sendStatus(200); // equivalent to res.status(200).send('OK')
+res.sendStatus(403); // equivalent to res.status(403).send('Forbidden')
+res.sendStatus(404); // equivalent to res.status(404).send('Not Found')
+res.sendStatus(500); // equivalent to res.status(500).send('Internal Server Error')
+```
+
+If an unsupported status code is specified, the HTTP status is still set to `statusCode` and the string version of the code is sent as the response body.
+
+<div class="doc-box doc-notice" markdown="1">
+Some versions of Node.js will throw when `res.statusCode` is set to an
+invalid HTTP status code (outside of the range `100` to `599`). Consult
+the HTTP server documentation for the Node.js version being used.
+</div>
+
+```js
+res.sendStatus(9999); // equivalent to res.status(9999).send('9999')
+```
+
+[More about HTTP Status Codes](http://en.wikipedia.org/wiki/List_of_HTTP_status_codes)

--- a/_includes/api/en/5x/res-set.md
+++ b/_includes/api/en/5x/res-set.md
@@ -1,0 +1,16 @@
+<h3 id='res.set'>res.set(field [, value])</h3>
+
+Sets the response's HTTP header `field` to `value`.
+To set multiple fields at once, pass an object as the parameter.
+
+```js
+res.set('Content-Type', 'text/plain');
+
+res.set({
+  'Content-Type': 'text/plain',
+  'Content-Length': '123',
+  'ETag': '12345'
+});
+```
+
+Aliased as `res.header(field [, value])`.

--- a/_includes/api/en/5x/res-set.md
+++ b/_includes/api/en/5x/res-set.md
@@ -4,13 +4,13 @@ Sets the response's HTTP header `field` to `value`.
 To set multiple fields at once, pass an object as the parameter.
 
 ```js
-res.set('Content-Type', 'text/plain');
+res.set('Content-Type', 'text/plain')
 
 res.set({
   'Content-Type': 'text/plain',
   'Content-Length': '123',
   'ETag': '12345'
-});
+})
 ```
 
 Aliased as `res.header(field [, value])`.

--- a/_includes/api/en/5x/res-status.md
+++ b/_includes/api/en/5x/res-status.md
@@ -1,0 +1,10 @@
+<h3 id='res.status'>res.status(code)</h3>
+
+Sets the HTTP status for the response.
+It is a chainable alias of Node's [response.statusCode](http://nodejs.org/api/http.html#http_response_statuscode).
+
+```js
+res.status(403).end();
+res.status(400).send('Bad Request');
+res.status(404).sendFile('/absolute/path/to/404.png');
+```

--- a/_includes/api/en/5x/res-status.md
+++ b/_includes/api/en/5x/res-status.md
@@ -4,7 +4,7 @@ Sets the HTTP status for the response.
 It is a chainable alias of Node's [response.statusCode](http://nodejs.org/api/http.html#http_response_statuscode).
 
 ```js
-res.status(403).end();
-res.status(400).send('Bad Request');
-res.status(404).sendFile('/absolute/path/to/404.png');
+res.status(403).end()
+res.status(400).send('Bad Request')
+res.status(404).sendFile('/absolute/path/to/404.png')
 ```

--- a/_includes/api/en/5x/res-type.md
+++ b/_includes/api/en/5x/res-type.md
@@ -1,0 +1,13 @@
+<h3 id='res.type'>res.type(type)</h3>
+
+Sets the `Content-Type` HTTP header to the MIME type as determined by
+[mime.lookup()](https://github.com/broofa/node-mime#mimelookuppath) for the specified `type`.
+If `type` contains the "/" character, then it sets the `Content-Type` to `type`.
+
+```js
+res.type('.html');              // => 'text/html'
+res.type('html');               // => 'text/html'
+res.type('json');               // => 'application/json'
+res.type('application/json');   // => 'application/json'
+res.type('png');                // => image/png:
+```

--- a/_includes/api/en/5x/res-type.md
+++ b/_includes/api/en/5x/res-type.md
@@ -5,9 +5,9 @@ Sets the `Content-Type` HTTP header to the MIME type as determined by
 If `type` contains the "/" character, then it sets the `Content-Type` to `type`.
 
 ```js
-res.type('.html');              // => 'text/html'
-res.type('html');               // => 'text/html'
-res.type('json');               // => 'application/json'
-res.type('application/json');   // => 'application/json'
-res.type('png');                // => image/png:
+res.type('.html') // => 'text/html'
+res.type('html') // => 'text/html'
+res.type('json') // => 'application/json'
+res.type('application/json') // => 'application/json'
+res.type('png') // => image/png:
 ```

--- a/_includes/api/en/5x/res-vary.md
+++ b/_includes/api/en/5x/res-vary.md
@@ -1,0 +1,7 @@
+<h3 id='res.vary'>res.vary(field)</h3>
+
+Adds the field to the `Vary` response header, if it is not there already.
+
+```js
+res.vary('User-Agent').render('docs');
+```

--- a/_includes/api/en/5x/res-vary.md
+++ b/_includes/api/en/5x/res-vary.md
@@ -3,5 +3,5 @@
 Adds the field to the `Vary` response header, if it is not there already.
 
 ```js
-res.vary('User-Agent').render('docs');
+res.vary('User-Agent').render('docs')
 ```

--- a/_includes/api/en/5x/res.md
+++ b/_includes/api/en/5x/res.md
@@ -1,0 +1,126 @@
+<h2 id="res">Response</h2>
+
+The `res` object represents the HTTP response that an Express app sends when it gets an HTTP request.
+
+In this documentation and by convention,
+the object is always referred to as `res` (and the HTTP request is `req`) but its actual name is determined
+by the parameters to the callback function in which you're working.
+
+For example:
+
+```js
+app.get('/user/:id', function(req, res){
+  res.send('user ' + req.params.id);
+});
+```
+
+But you could just as well have:
+
+```js
+app.get('/user/:id', function(request, response){
+  response.send('user ' + request.params.id);
+});
+```
+
+The `res` object is an enhanced version of Node's own response object
+and supports all [built-in fields and methods](https://nodejs.org/api/http.html#http_class_http_serverresponse).
+
+<h3 id='res.properties'>Properties</h3>
+
+<section markdown="1">
+  {% include api/en/4x/res-app.md %}
+</section>
+
+<section markdown="1">
+  {% include api/en/4x/res-headersSent.md %}
+</section>
+
+<section markdown="1">
+  {% include api/en/4x/res-locals.md %}
+</section>
+
+<h3 id='res.methods'>Methods</h3>
+
+<section markdown="1">
+  {% include api/en/4x/res-append.md %}
+</section>
+
+<section markdown="1">
+  {% include api/en/4x/res-attachment.md %}
+</section>
+
+<section markdown="1">
+  {% include api/en/4x/res-cookie.md %}
+</section>
+
+<section markdown="1">
+  {% include api/en/4x/res-clearCookie.md %}
+</section>
+
+<section markdown="1">
+  {% include api/en/4x/res-download.md %}
+</section>
+
+<section markdown="1">
+  {% include api/en/4x/res-end.md %}
+</section>
+
+<section markdown="1">
+  {% include api/en/4x/res-format.md %}
+</section>
+
+<section markdown="1">
+  {% include api/en/4x/res-get.md %}
+</section>
+
+<section markdown="1">
+  {% include api/en/4x/res-json.md %}
+</section>
+
+<section markdown="1">
+  {% include api/en/4x/res-jsonp.md %}
+</section>
+
+<section markdown="1">
+  {% include api/en/4x/res-links.md %}
+</section>
+
+<section markdown="1">
+  {% include api/en/4x/res-location.md %}
+</section>
+
+<section markdown="1">
+  {% include api/en/4x/res-redirect.md %}
+</section>
+
+<section markdown="1">
+  {% include api/en/4x/res-render.md %}
+</section>
+
+<section markdown="1">
+  {% include api/en/4x/res-send.md %}
+</section>
+
+<section markdown="1">
+  {% include api/en/4x/res-sendFile.md %}
+</section>
+
+<section markdown="1">
+  {% include api/en/4x/res-sendStatus.md %}
+</section>
+
+<section markdown="1">
+  {% include api/en/4x/res-set.md %}
+</section>
+
+<section markdown="1">
+  {% include api/en/4x/res-status.md %}
+</section>
+
+<section markdown="1">
+  {% include api/en/4x/res-type.md %}
+</section>
+
+<section markdown="1">
+  {% include api/en/4x/res-vary.md %}
+</section>

--- a/_includes/api/en/5x/res.md
+++ b/_includes/api/en/5x/res.md
@@ -9,17 +9,17 @@ by the parameters to the callback function in which you're working.
 For example:
 
 ```js
-app.get('/user/:id', function(req, res){
-  res.send('user ' + req.params.id);
-});
+app.get('/user/:id', function (req, res) {
+  res.send('user ' + req.params.id)
+})
 ```
 
 But you could just as well have:
 
 ```js
-app.get('/user/:id', function(request, response){
-  response.send('user ' + request.params.id);
-});
+app.get('/user/:id', function (request, response) {
+  response.send('user ' + request.params.id)
+})
 ```
 
 The `res` object is an enhanced version of Node's own response object

--- a/_includes/api/en/5x/router-METHOD.md
+++ b/_includes/api/en/5x/router-METHOD.md
@@ -1,0 +1,42 @@
+<h3 id='router.METHOD'>router.METHOD(path, [callback, ...] callback)</h3>
+
+The `router.METHOD()` methods provide the routing functionality in Express,
+where METHOD is one of the HTTP methods, such as GET, PUT, POST, and so on,
+in lowercase.  Thus, the actual methods are `router.get()`, `router.post()`,
+`router.put()`, and so on.
+
+<div class="doc-box doc-info" markdown="1">
+  The `router.get()` function is automatically called for the HTTP `HEAD` method in
+  addition to the `GET` method if `router.head()` was not called for the
+  path before `router.get()`.
+</div>
+
+You can provide multiple callbacks, and all are treated equally, and behave just
+like middleware, except that these callbacks may invoke `next('route')`
+to bypass the remaining route callback(s).  You can use this mechanism to perform
+pre-conditions on a route then pass control to subsequent routes when there is no
+reason to proceed with the route matched.
+
+The following snippet illustrates the most simple route definition possible.
+Express translates the path strings to regular expressions, used internally
+to match incoming requests. Query strings are _not_ considered when performing
+these matches, for example "GET /" would match the following route, as would
+"GET /?name=tobi".
+
+```js
+router.get('/', function(req, res){
+  res.send('hello world');
+});
+```
+
+You can also use regular expressions&mdash;useful if you have very specific
+constraints, for example the following would match "GET /commits/71dbb9c" as well
+as "GET /commits/71dbb9c..4c084f9".
+
+```js
+router.get(/^\/commits\/(\w+)(?:\.\.(\w+))?$/, function(req, res){
+  var from = req.params[0];
+  var to = req.params[1] || 'HEAD';
+  res.send('commit range ' + from + '..' + to);
+});
+```

--- a/_includes/api/en/5x/router-METHOD.md
+++ b/_includes/api/en/5x/router-METHOD.md
@@ -24,9 +24,9 @@ these matches, for example "GET /" would match the following route, as would
 "GET /?name=tobi".
 
 ```js
-router.get('/', function(req, res){
-  res.send('hello world');
-});
+router.get('/', function (req, res) {
+  res.send('hello world')
+})
 ```
 
 You can also use regular expressions&mdash;useful if you have very specific
@@ -34,9 +34,9 @@ constraints, for example the following would match "GET /commits/71dbb9c" as wel
 as "GET /commits/71dbb9c..4c084f9".
 
 ```js
-router.get(/^\/commits\/(\w+)(?:\.\.(\w+))?$/, function(req, res){
-  var from = req.params[0];
-  var to = req.params[1] || 'HEAD';
-  res.send('commit range ' + from + '..' + to);
-});
+router.get(/^\/commits\/(\w+)(?:\.\.(\w+))?$/, function (req, res) {
+  var from = req.params[0]
+  var to = req.params[1] || 'HEAD'
+  res.send('commit range ' + from + '..' + to)
+})
 ```

--- a/_includes/api/en/5x/router-Router.md
+++ b/_includes/api/en/5x/router-Router.md
@@ -1,0 +1,2 @@
+<h3 id='router'>Router([options])</h3>
+

--- a/_includes/api/en/5x/router-all.md
+++ b/_includes/api/en/5x/router-all.md
@@ -1,0 +1,31 @@
+<h3 id='router.all'>router.all(path, [callback, ...] callback)</h3>
+
+This method is just like the `router.METHOD()` methods, except that it matches all HTTP methods (verbs).
+
+This method is extremely useful for
+mapping "global" logic for specific path prefixes or arbitrary matches.
+For example, if you placed the following route at the top of all other
+route definitions, it would require that all routes from that point on
+would require authentication, and automatically load a user. Keep in mind
+that these callbacks do not have to act as end points; `loadUser`
+can perform a task, then call `next()` to continue matching subsequent
+routes.
+
+```js
+router.all('*', requireAuthentication, loadUser);
+```
+
+Or the equivalent:
+
+```js
+router.all('*', requireAuthentication)
+router.all('*', loadUser);
+```
+
+Another example of this is white-listed "global" functionality. Here
+the example is much like before, but it only restricts paths prefixed with
+"/api":
+
+```js
+router.all('/api/*', requireAuthentication);
+```

--- a/_includes/api/en/5x/router-all.md
+++ b/_includes/api/en/5x/router-all.md
@@ -12,14 +12,14 @@ can perform a task, then call `next()` to continue matching subsequent
 routes.
 
 ```js
-router.all('*', requireAuthentication, loadUser);
+router.all('*', requireAuthentication, loadUser)
 ```
 
 Or the equivalent:
 
 ```js
 router.all('*', requireAuthentication)
-router.all('*', loadUser);
+router.all('*', loadUser)
 ```
 
 Another example of this is white-listed "global" functionality. Here
@@ -27,5 +27,5 @@ the example is much like before, but it only restricts paths prefixed with
 "/api":
 
 ```js
-router.all('/api/*', requireAuthentication);
+router.all('/api/*', requireAuthentication)
 ```

--- a/_includes/api/en/5x/router-param.md
+++ b/_includes/api/en/5x/router-param.md
@@ -1,0 +1,126 @@
+<h3 id='router.param'>router.param(name, callback)</h3>
+
+Adds callback triggers to route parameters, where `name` is the name of the parameter and `callback` is the callback function. Although `name` is technically optional, using this method without it is deprecated starting with Express v4.11.0 (see below).
+
+The parameters of the callback function are:
+
+- `req`, the request object.
+- `res`, the response object.
+- `next`, indicating the next middleware function.
+- The value of the `name` parameter.
+- The name of the parameter.
+
+<div class="doc-box doc-info" markdown="1">
+Unlike `app.param()`, `router.param()` does not accept an array of route parameters.
+</div>
+
+For example, when `:user` is present in a route path, you may map user loading logic to automatically provide `req.user` to the route, or perform validations on the parameter input.
+
+```js
+router.param('user', function(req, res, next, id) {
+
+  // try to get the user details from the User model and attach it to the request object
+  User.find(id, function(err, user) {
+    if (err) {
+      next(err);
+    } else if (user) {
+      req.user = user;
+      next();
+    } else {
+      next(new Error('failed to load user'));
+    }
+  });
+});
+```
+
+Param callback functions are local to the router on which they are defined. They are not inherited by mounted apps or routers. Hence, param callbacks defined on `router` will be triggered only by route parameters defined on `router` routes.
+
+A param callback will be called only once in a request-response cycle, even if the parameter is matched in multiple routes, as shown in the following examples.
+
+```js
+router.param('id', function (req, res, next, id) {
+  console.log('CALLED ONLY ONCE');
+  next();
+});
+
+router.get('/user/:id', function (req, res, next) {
+  console.log('although this matches');
+  next();
+});
+
+router.get('/user/:id', function (req, res) {
+  console.log('and this matches too');
+  res.end();
+});
+```
+
+On `GET /user/42`, the following is printed:
+
+```sh
+CALLED ONLY ONCE
+although this matches
+and this matches too
+```
+
+<div class="doc-box doc-warn" markdown="1">
+The following section describes `router.param(callback)`, which is deprecated as of v4.11.0.
+</div>
+
+The behavior of the `router.param(name, callback)` method can be altered entirely by passing only a function to `router.param()`. This function is a custom implementation of how `router.param(name, callback)` should behave - it accepts two parameters and must return a middleware.
+
+The first parameter of this function is the name of the URL parameter that should be captured, the second parameter can be any JavaScript object which might be used for returning the middleware implementation.
+
+The middleware returned by the function decides the behavior of what happens when a URL parameter is captured.
+
+In this example, the `router.param(name, callback)` signature is modified to `router.param(name, accessId)`. Instead of accepting a name and a callback, `router.param()` will now accept a name and a number.
+
+```js
+var express = require('express');
+var app = express();
+var router = express.Router();
+
+// customizing the behavior of router.param()
+router.param(function(param, option) {
+  return function (req, res, next, val) {
+    if (val == option) {
+      next();
+    }
+    else {
+      res.sendStatus(403);
+    }
+  }
+});
+
+// using the customized router.param()
+router.param('id', 1337);
+
+// route to trigger the capture
+router.get('/user/:id', function (req, res) {
+  res.send('OK');
+});
+
+app.use(router);
+
+app.listen(3000, function () {
+  console.log('Ready');
+});
+```
+
+In this example, the `router.param(name, callback)` signature remains the same, but instead of a middleware callback, a custom data type checking function has been defined to validate the data type of the user id.
+
+```js
+router.param(function(param, validator) {
+  return function (req, res, next, val) {
+    if (validator(val)) {
+      next();
+    }
+    else {
+      res.sendStatus(403);
+    }
+  }
+});
+
+router.param('id', function (candidate) {
+  return !isNaN(parseFloat(candidate)) && isFinite(candidate);
+});
+```

--- a/_includes/api/en/5x/router-param.md
+++ b/_includes/api/en/5x/router-param.md
@@ -81,7 +81,7 @@ var router = express.Router()
 // customizing the behavior of router.param()
 router.param(function (param, option) {
   return function (req, res, next, val) {
-    if (val == option) {
+    if (val === option) {
       next()
     } else {
       res.sendStatus(403)

--- a/_includes/api/en/5x/router-param.md
+++ b/_includes/api/en/5x/router-param.md
@@ -17,20 +17,19 @@ Unlike `app.param()`, `router.param()` does not accept an array of route paramet
 For example, when `:user` is present in a route path, you may map user loading logic to automatically provide `req.user` to the route, or perform validations on the parameter input.
 
 ```js
-router.param('user', function(req, res, next, id) {
-
+router.param('user', function (req, res, next, id) {
   // try to get the user details from the User model and attach it to the request object
-  User.find(id, function(err, user) {
+  User.find(id, function (err, user) {
     if (err) {
-      next(err);
+      next(err)
     } else if (user) {
-      req.user = user;
-      next();
+      req.user = user
+      next()
     } else {
-      next(new Error('failed to load user'));
+      next(new Error('failed to load user'))
     }
-  });
-});
+  })
+})
 ```
 
 Param callback functions are local to the router on which they are defined. They are not inherited by mounted apps or routers. Hence, param callbacks defined on `router` will be triggered only by route parameters defined on `router` routes.
@@ -39,19 +38,19 @@ A param callback will be called only once in a request-response cycle, even if t
 
 ```js
 router.param('id', function (req, res, next, id) {
-  console.log('CALLED ONLY ONCE');
-  next();
-});
+  console.log('CALLED ONLY ONCE')
+  next()
+})
 
 router.get('/user/:id', function (req, res, next) {
-  console.log('although this matches');
-  next();
-});
+  console.log('although this matches')
+  next()
+})
 
 router.get('/user/:id', function (req, res) {
-  console.log('and this matches too');
-  res.end();
-});
+  console.log('and this matches too')
+  res.end()
+})
 ```
 
 On `GET /user/42`, the following is printed:
@@ -75,52 +74,50 @@ The middleware returned by the function decides the behavior of what happens whe
 In this example, the `router.param(name, callback)` signature is modified to `router.param(name, accessId)`. Instead of accepting a name and a callback, `router.param()` will now accept a name and a number.
 
 ```js
-var express = require('express');
-var app = express();
-var router = express.Router();
+var express = require('express')
+var app = express()
+var router = express.Router()
 
 // customizing the behavior of router.param()
-router.param(function(param, option) {
+router.param(function (param, option) {
   return function (req, res, next, val) {
     if (val == option) {
-      next();
-    }
-    else {
-      res.sendStatus(403);
+      next()
+    } else {
+      res.sendStatus(403)
     }
   }
-});
+})
 
 // using the customized router.param()
-router.param('id', 1337);
+router.param('id', 1337)
 
 // route to trigger the capture
 router.get('/user/:id', function (req, res) {
-  res.send('OK');
-});
+  res.send('OK')
+})
 
-app.use(router);
+app.use(router)
 
 app.listen(3000, function () {
-  console.log('Ready');
-});
+  console.log('Ready')
+})
 ```
 
 In this example, the `router.param(name, callback)` signature remains the same, but instead of a middleware callback, a custom data type checking function has been defined to validate the data type of the user id.
 
 ```js
-router.param(function(param, validator) {
+router.param(function (param, validator) {
   return function (req, res, next, val) {
     if (validator(val)) {
-      next();
-    }
-    else {
-      res.sendStatus(403);
+      next()
+    } else {
+      res.sendStatus(403)
     }
   }
-});
+})
 
 router.param('id', function (candidate) {
-  return !isNaN(parseFloat(candidate)) && isFinite(candidate);
-});
+  return !isNaN(parseFloat(candidate)) && isFinite(candidate)
+})
 ```

--- a/_includes/api/en/5x/router-route.md
+++ b/_includes/api/en/5x/router-route.md
@@ -1,0 +1,50 @@
+<h3 id='router.route'>router.route(path)</h3>
+
+Returns an instance of a single route which you can then use to handle HTTP verbs
+with optional middleware. Use `router.route()` to avoid duplicate route naming and
+thus typing errors.
+
+Building on the `router.param()` example above, the following code shows how to use
+`router.route()` to specify various HTTP method handlers.
+
+```js
+var router = express.Router();
+
+router.param('user_id', function(req, res, next, id) {
+  // sample user, would actually fetch from DB, etc...
+  req.user = {
+    id: id,
+    name: 'TJ'
+  };
+  next();
+});
+
+router.route('/users/:user_id')
+.all(function(req, res, next) {
+  // runs for all HTTP verbs first
+  // think of it as route specific middleware!
+  next();
+})
+.get(function(req, res, next) {
+  res.json(req.user);
+})
+.put(function(req, res, next) {
+  // just an example of maybe updating the user
+  req.user.name = req.params.name;
+  // save user ... etc
+  res.json(req.user);
+})
+.post(function(req, res, next) {
+  next(new Error('not implemented'));
+})
+.delete(function(req, res, next) {
+  next(new Error('not implemented'));
+});
+```
+
+This approach re-uses the single `/users/:user_id` path and adds handlers for
+various HTTP methods.
+
+<div class="doc-box doc-info" markdown="1">
+NOTE: When you use `router.route()`, middleware ordering is based on when the _route_ is created, not when method handlers are added to the route.  For this purpose, you can consider method handlers to belong to the route to which they were added.
+</div>

--- a/_includes/api/en/5x/router-route.md
+++ b/_includes/api/en/5x/router-route.md
@@ -8,38 +8,38 @@ Building on the `router.param()` example above, the following code shows how to 
 `router.route()` to specify various HTTP method handlers.
 
 ```js
-var router = express.Router();
+var router = express.Router()
 
-router.param('user_id', function(req, res, next, id) {
+router.param('user_id', function (req, res, next, id) {
   // sample user, would actually fetch from DB, etc...
   req.user = {
     id: id,
     name: 'TJ'
-  };
-  next();
-});
+  }
+  next()
+})
 
 router.route('/users/:user_id')
-.all(function(req, res, next) {
+  .all(function (req, res, next) {
   // runs for all HTTP verbs first
   // think of it as route specific middleware!
-  next();
-})
-.get(function(req, res, next) {
-  res.json(req.user);
-})
-.put(function(req, res, next) {
+    next()
+  })
+  .get(function (req, res, next) {
+    res.json(req.user)
+  })
+  .put(function (req, res, next) {
   // just an example of maybe updating the user
-  req.user.name = req.params.name;
-  // save user ... etc
-  res.json(req.user);
-})
-.post(function(req, res, next) {
-  next(new Error('not implemented'));
-})
-.delete(function(req, res, next) {
-  next(new Error('not implemented'));
-});
+    req.user.name = req.params.name
+    // save user ... etc
+    res.json(req.user)
+  })
+  .post(function (req, res, next) {
+    next(new Error('not implemented'))
+  })
+  .delete(function (req, res, next) {
+    next(new Error('not implemented'))
+  })
 ```
 
 This approach re-uses the single `/users/:user_id` path and adds handlers for

--- a/_includes/api/en/5x/router-use.md
+++ b/_includes/api/en/5x/router-use.md
@@ -1,0 +1,106 @@
+<h3 id='router.use'>router.use([path], [function, ...] function)</h3>
+
+Uses the specified middleware function or functions, with optional mount path `path`, that defaults to "/".
+
+This method is similar to [app.use()](#app.use). A simple example and use case is described below.
+See [app.use()](#app.use) for more information.
+
+Middleware is like a plumbing pipe: requests start at the first middleware function defined
+and work their way "down" the middleware stack processing for each path they match.
+
+```js
+var express = require('express');
+var app = express();
+var router = express.Router();
+
+// simple logger for this router's requests
+// all requests to this router will first hit this middleware
+router.use(function(req, res, next) {
+  console.log('%s %s %s', req.method, req.url, req.path);
+  next();
+});
+
+// this will only be invoked if the path starts with /bar from the mount point
+router.use('/bar', function(req, res, next) {
+  // ... maybe some additional /bar logging ...
+  next();
+});
+
+// always invoked
+router.use(function(req, res, next) {
+  res.send('Hello World');
+});
+
+app.use('/foo', router);
+
+app.listen(3000);
+```
+
+The "mount" path is stripped and is _not_ visible to the middleware function.
+The main effect of this feature is that a mounted middleware function may operate without
+code changes regardless of its "prefix" pathname.
+
+The order in which you define middleware with `router.use()` is very important.
+They are invoked sequentially, thus the order defines middleware precedence. For example,
+usually a logger is the very first middleware you would use, so that every request gets logged.
+
+```js
+var logger = require('morgan');
+
+router.use(logger());
+router.use(express.static(__dirname + '/public'));
+router.use(function(req, res){
+  res.send('Hello');
+});
+```
+
+Now suppose you wanted to ignore logging requests for static files, but to continue
+logging routes and middleware defined after `logger()`.  You would simply move the call to `express.static()` to the top,
+before adding the logger middleware:
+
+```js
+router.use(express.static(__dirname + '/public'));
+router.use(logger());
+router.use(function(req, res){
+  res.send('Hello');
+});
+```
+
+Another example is serving files from multiple directories,
+giving precedence to "./public" over the others:
+
+```js
+app.use(express.static(__dirname + '/public'));
+app.use(express.static(__dirname + '/files'));
+app.use(express.static(__dirname + '/uploads'));
+```
+
+The `router.use()` method also supports named parameters so that your mount points
+for other routers can benefit from preloading using named parameters.
+
+__NOTE__: Although these middleware functions are added via a particular router, _when_
+they run is defined by the path they are attached to (not the router). Therefore,
+middleware added via one router may run for other routers if its routes
+match. For example, this code shows two different routers mounted on the same path:
+
+```js
+var authRouter = express.Router();
+var openRouter = express.Router();
+
+authRouter.use(require('./authenticate').basic(usersdb));
+
+authRouter.get('/:user_id/edit', function(req, res, next) { 
+  // ... Edit user UI ...  
+});
+openRouter.get('/', function(req, res, next) { 
+  // ... List users ... 
+})
+openRouter.get('/:user_id', function(req, res, next) { 
+  // ... View user ... 
+})
+
+app.use('/users', authRouter);
+app.use('/users', openRouter);
+```
+
+Even though the authentication middleware was added via the `authRouter` it will run on the routes defined by the `openRouter` as well since both routers were mounted on `/users`.  To avoid this behavior, use different paths for each router.

--- a/_includes/api/en/5x/router-use.md
+++ b/_includes/api/en/5x/router-use.md
@@ -9,31 +9,31 @@ Middleware is like a plumbing pipe: requests start at the first middleware funct
 and work their way "down" the middleware stack processing for each path they match.
 
 ```js
-var express = require('express');
-var app = express();
-var router = express.Router();
+var express = require('express')
+var app = express()
+var router = express.Router()
 
 // simple logger for this router's requests
 // all requests to this router will first hit this middleware
-router.use(function(req, res, next) {
-  console.log('%s %s %s', req.method, req.url, req.path);
-  next();
-});
+router.use(function (req, res, next) {
+  console.log('%s %s %s', req.method, req.url, req.path)
+  next()
+})
 
 // this will only be invoked if the path starts with /bar from the mount point
-router.use('/bar', function(req, res, next) {
+router.use('/bar', function (req, res, next) {
   // ... maybe some additional /bar logging ...
-  next();
-});
+  next()
+})
 
 // always invoked
-router.use(function(req, res, next) {
-  res.send('Hello World');
-});
+router.use(function (req, res, next) {
+  res.send('Hello World')
+})
 
-app.use('/foo', router);
+app.use('/foo', router)
 
-app.listen(3000);
+app.listen(3000)
 ```
 
 The "mount" path is stripped and is _not_ visible to the middleware function.
@@ -45,13 +45,13 @@ They are invoked sequentially, thus the order defines middleware precedence. For
 usually a logger is the very first middleware you would use, so that every request gets logged.
 
 ```js
-var logger = require('morgan');
+var logger = require('morgan')
 
-router.use(logger());
-router.use(express.static(__dirname + '/public'));
-router.use(function(req, res){
-  res.send('Hello');
-});
+router.use(logger())
+router.use(express.static(__dirname + '/public'))
+router.use(function (req, res) {
+  res.send('Hello')
+})
 ```
 
 Now suppose you wanted to ignore logging requests for static files, but to continue
@@ -59,20 +59,20 @@ logging routes and middleware defined after `logger()`.  You would simply move t
 before adding the logger middleware:
 
 ```js
-router.use(express.static(__dirname + '/public'));
-router.use(logger());
-router.use(function(req, res){
-  res.send('Hello');
-});
+router.use(express.static(__dirname + '/public'))
+router.use(logger())
+router.use(function (req, res) {
+  res.send('Hello')
+})
 ```
 
 Another example is serving files from multiple directories,
 giving precedence to "./public" over the others:
 
 ```js
-app.use(express.static(__dirname + '/public'));
-app.use(express.static(__dirname + '/files'));
-app.use(express.static(__dirname + '/uploads'));
+app.use(express.static(__dirname + '/public'))
+app.use(express.static(__dirname + '/files'))
+app.use(express.static(__dirname + '/uploads'))
 ```
 
 The `router.use()` method also supports named parameters so that your mount points
@@ -84,23 +84,23 @@ middleware added via one router may run for other routers if its routes
 match. For example, this code shows two different routers mounted on the same path:
 
 ```js
-var authRouter = express.Router();
-var openRouter = express.Router();
+var authRouter = express.Router()
+var openRouter = express.Router()
 
-authRouter.use(require('./authenticate').basic(usersdb));
+authRouter.use(require('./authenticate').basic(usersdb))
 
-authRouter.get('/:user_id/edit', function(req, res, next) { 
-  // ... Edit user UI ...  
-});
-openRouter.get('/', function(req, res, next) { 
-  // ... List users ... 
+authRouter.get('/:user_id/edit', function (req, res, next) {
+  // ... Edit user UI ...
 })
-openRouter.get('/:user_id', function(req, res, next) { 
-  // ... View user ... 
+openRouter.get('/', function (req, res, next) {
+  // ... List users ...
+})
+openRouter.get('/:user_id', function (req, res, next) {
+  // ... View user ...
 })
 
-app.use('/users', authRouter);
-app.use('/users', openRouter);
+app.use('/users', authRouter)
+app.use('/users', openRouter)
 ```
 
 Even though the authentication middleware was added via the `authRouter` it will run on the routes defined by the `openRouter` as well since both routers were mounted on `/users`.  To avoid this behavior, use different paths for each router.

--- a/_includes/api/en/5x/router-use.md
+++ b/_includes/api/en/5x/router-use.md
@@ -48,7 +48,7 @@ usually a logger is the very first middleware you would use, so that every reque
 var logger = require('morgan')
 
 router.use(logger())
-router.use(express.static(__dirname + '/public'))
+router.use(express.static(path.join(__dirname, 'public')))
 router.use(function (req, res) {
   res.send('Hello')
 })
@@ -59,7 +59,7 @@ logging routes and middleware defined after `logger()`.  You would simply move t
 before adding the logger middleware:
 
 ```js
-router.use(express.static(__dirname + '/public'))
+router.use(express.static(path.join(__dirname, 'public')))
 router.use(logger())
 router.use(function (req, res) {
   res.send('Hello')
@@ -70,9 +70,9 @@ Another example is serving files from multiple directories,
 giving precedence to "./public" over the others:
 
 ```js
-app.use(express.static(__dirname + '/public'))
-app.use(express.static(__dirname + '/files'))
-app.use(express.static(__dirname + '/uploads'))
+app.use(express.static(path.join(__dirname, 'public')))
+app.use(express.static(path.join(__dirname, 'files')))
+app.use(express.static(path.join(__dirname, 'uploads')))
 ```
 
 The `router.use()` method also supports named parameters so that your mount points

--- a/_includes/api/en/5x/router.md
+++ b/_includes/api/en/5x/router.md
@@ -1,0 +1,60 @@
+<h2 id="router">Router</h2>
+
+<section markdown="1">
+A `router` object is an isolated instance of middleware and routes. You can think of it
+as a "mini-application," capable only of performing middleware and routing
+functions. Every Express application has a built-in app router.
+
+A router behaves like middleware itself, so you can use it as an argument to
+[app.use()](#app.use) or as the argument to another router's  [use()](#router.use) method.
+
+The top-level `express` object has a [Router()](#express.router) method that creates a new `router` object.
+
+Once you've created a router object, you can add middleware and HTTP method routes (such as `get`, `put`, `post`,
+and so on) to it just like an application.  For example:
+
+```js
+// invoked for any requests passed to this router
+router.use(function(req, res, next) {
+  // .. some logic here .. like any other middleware
+  next();
+});
+
+// will handle any request that ends in /events
+// depends on where the router is "use()'d"
+router.get('/events', function(req, res, next) {
+  // ..
+});
+```
+
+You can then use a router for a particular root URL in this way separating your routes into files or even mini-apps.
+
+```js
+// only requests to /calendar/* will be sent to our "router"
+app.use('/calendar', router);
+```
+
+
+</section>
+
+<h3 id='router.methods'>Methods</h3>
+
+<section markdown="1">
+  {% include api/en/4x/router-all.md %}
+</section>
+
+<section markdown="1">
+  {% include api/en/4x/router-METHOD.md %}
+</section>
+
+<section markdown="1">
+  {% include api/en/4x/router-param.md %}
+</section>
+
+<section markdown="1">
+  {% include api/en/4x/router-route.md %}
+</section>
+
+<section markdown="1">
+  {% include api/en/4x/router-use.md %}
+</section>

--- a/_includes/api/en/5x/router.md
+++ b/_includes/api/en/5x/router.md
@@ -15,23 +15,23 @@ and so on) to it just like an application.  For example:
 
 ```js
 // invoked for any requests passed to this router
-router.use(function(req, res, next) {
+router.use(function (req, res, next) {
   // .. some logic here .. like any other middleware
-  next();
-});
+  next()
+})
 
 // will handle any request that ends in /events
 // depends on where the router is "use()'d"
-router.get('/events', function(req, res, next) {
+router.get('/events', function (req, res, next) {
   // ..
-});
+})
 ```
 
 You can then use a router for a particular root URL in this way separating your routes into files or even mini-apps.
 
 ```js
 // only requests to /calendar/* will be sent to our "router"
-app.use('/calendar', router);
+app.use('/calendar', router)
 ```
 
 

--- a/_includes/api/en/5x/routing-args.html
+++ b/_includes/api/en/5x/routing-args.html
@@ -1,0 +1,49 @@
+<h4> Arguments</h4>
+
+<table class="doctable" border="1" style="padding-left: 20px;">
+<tr>
+<th>Argument </th>
+<th> Description </th>
+<th style="width: 100px;"> Default </th>
+</tr>
+
+<tr>
+<td><code>path</code></td>
+<td>
+The path for which the middleware function is invoked; can be any of:
+<ul>
+<li>A string representing a path.</li>
+<li>A path pattern.</li>
+<li>A regular expression pattern to match paths.</li>
+<li>An array of combinations of any of the above.</li>
+</ul>
+
+For examples, see <a href="#path-examples">Path examples</a>.
+</td>
+<td>'/' (root path)</td>
+</tr>
+
+<tr>
+<td> <code>callback</code></td>
+<td>
+Callback functions; can be:
+<ul>
+<li>A middleware function.</li>
+<li>A series of middleware functions (separated by commas).</li>
+<li>An array of middleware functions.</li>
+<li>A combination of all of the above.</li>
+</ul>
+<p>
+You can provide multiple callback functions that behave just like middleware, except
+that these callbacks can invoke <code>next('route')</code> to bypass
+the remaining route callback(s). You can use this mechanism to impose pre-conditions
+on a route, then pass control to subsequent routes if there is no reason to proceed with the current route.
+</p><p>
+Since <a href="#router">router</a> and <a href="#application">app</a> implement the middleware interface,
+you can use them as you would any other middleware function.
+</p><p>
+For examples, see <a href="#middleware-callback-function-examples">Middleware callback function examples</a>.
+</p>
+</td>
+<td> None </td>
+</tr></table>

--- a/_includes/header/header-en.html
+++ b/_includes/header/header-en.html
@@ -78,6 +78,8 @@
               <ul id="application-menu" class="menu">
                   <li><a href="/{{ page.lang }}/4x/api.html"{% if page.menu == 'api' %} class="active"{% endif %}>API reference</a>
                       <ul>
+                          <li><a href="/{{ page.lang }}/5x/api.html">5.x (alpha)</a>
+                          </li>
                           <li><a href="/{{ page.lang }}/4x/api.html">4.x</a>
                           </li>
                           <li><a href="/{{ page.lang }}/3x/api.html">3.x (deprecated)</a>

--- a/_layouts/5x-api.html
+++ b/_layouts/5x-api.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<!---
+ Copyright (c) 2016 StrongLoop, IBM, and Express Contributors
+ License: MIT
+-->
+<html lang="{{ page.lang }}">
+
+  {% include head.html %}
+
+  <body>
+
+    <section class="content">
+
+      {% include header/header-{{ page.lang }}.html %}
+
+      {% include api/en/5x/menu.md %}
+
+      <div id="overlay"></div>
+
+      {{ content }}
+
+    </section>
+
+    {% include footer/footer-{{ page.lang }}.html %}
+
+  </body>
+
+</html>

--- a/en/5x/api.md
+++ b/en/5x/api.md
@@ -1,0 +1,18 @@
+---
+layout: 5x-api
+title: Express 5.x - API Reference
+menu: api
+lang: en
+redirect_from: "/5x/api.html"
+---
+<div id="api-doc" markdown="1">
+
+  <h1>5.x API</h1>
+
+  {% include api/{{ page.lang }}/5x/express.md %}
+  {% include api/{{ page.lang }}/5x/app.md %}
+  {% include api/{{ page.lang }}/5x/req.md %}
+  {% include api/{{ page.lang }}/5x/res.md %}
+  {% include api/{{ page.lang }}/5x/router.md %}
+
+</div>


### PR DESCRIPTION
This is related to: https://github.com/expressjs/express/issues/3913

Includes: 
* copy `en/4x` --> `en/5x`
* copy `_includes/api/4x` --> `_includes/api/5x`
* copy `_layouts/4x-api.html` --> `_layouts/5x-api.html`
* add link in `header/header-en.html` to 5.x (RC) documentation

@dougwilson Could you please review and also provide me with more information or examples of what should edit on the entries related to the change log (https://github.com/expressjs/express/blob/5.0/History.md) ? Thank you.