### PR TITLE
[doc website] Add a nice search experience

### DIFF
--- a/_data/docsearch.yml
+++ b/_data/docsearch.yml
@@ -1,0 +1,3 @@
+# config: https://github.com/algolia/docsearch-configs/blob/master/configs/expressjs.json
+apiKey: 7164e33055faa6ecddefd9e08fc59f5d
+indexName: expressjs

--- a/_includes/footer/_docsearch.html
+++ b/_includes/footer/_docsearch.html
@@ -1,0 +1,6 @@
+<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js" onload="docsearch({
+  apiKey: '{{ site.data.docsearch.apiKey }}',
+  indexName: '{{ site.data.docsearch.indexName }}',
+  inputSelector: '#q',
+  algoliaOptions: { 'facetFilters': ['lang:{{ page.lang }}'] }
+})" async></script>

--- a/_includes/footer/footer-de.html
+++ b/_includes/footer/footer-de.html
@@ -33,3 +33,5 @@
         <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/"><img alt="Creative Commons Lizenzvertrag" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/3.0/us/80x15.png" /></a> Dieses Werk ist lizenziert unter einer <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/">Creative Commons Namensnennung - Weitergabe unter gleichen Bedingungen 3.0 Vereinigte Staaten von Amerika Lizenz</a>.
     </div>
 </footer>
+
+{% include footer/_docsearch.html %}

--- a/_includes/footer/footer-en.html
+++ b/_includes/footer/footer-en.html
@@ -42,3 +42,5 @@
 </footer>
 
 <script async defer src="https://buttons.github.io/buttons.js"></script>
+
+{% include footer/_docsearch.html %}

--- a/_includes/footer/footer-es.html
+++ b/_includes/footer/footer-es.html
@@ -35,3 +35,5 @@
         <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/"><img alt="Licencia Creative Commons" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/3.0/us/80x15.png" /></a> Esta obra está bajo una <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/">Licencia Creative Commons Atribución-CompartirIgual 3.0 Estados Unidos de América</a>.
     </div>
 </footer>
+
+{% include footer/_docsearch.html %}

--- a/_includes/footer/footer-fr.html
+++ b/_includes/footer/footer-fr.html
@@ -34,3 +34,5 @@
         <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/"><img alt="Licence Creative Commons" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/3.0/us/80x15.png" /></a> Ce(tte) œuvre est mise à disposition selon les termes de la <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/">Licence Creative Commons Attribution -  Partage dans les Mêmes Conditions 3.0 États-Unis</a>.
     </div>
 </footer>
+
+{% include footer/_docsearch.html %}

--- a/_includes/footer/footer-it.html
+++ b/_includes/footer/footer-it.html
@@ -34,3 +34,5 @@
         <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/"><img alt="Licenza Creative Commons" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/3.0/us/80x15.png" /></a> Quest'opera è distribuita con Licenza <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/">Creative Commons Attribuzione - Condividi allo stesso modo 3.0 Stati Uniti</a>.
     </div>
 </footer>
+
+{% include footer/_docsearch.html %}

--- a/_includes/footer/footer-ja.html
+++ b/_includes/footer/footer-ja.html
@@ -33,3 +33,5 @@
         <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/"><img alt="クリエイティブ・コモンズ・ライセンス" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/3.0/us/80x15.png" /></a> この 作品 は <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/">クリエイティブ・コモンズ 表示 - 継承 3.0 アメリカ合衆国 ライセンスの下に提供されています。</a>
     </div>
 </footer>
+
+{% include footer/_docsearch.html %}

--- a/_includes/footer/footer-ko.html
+++ b/_includes/footer/footer-ko.html
@@ -34,3 +34,5 @@
 <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/"><img alt="크리에이티브 커먼즈 라이선스" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/3.0/us/80x15.png" /></a> 이 저작물은 <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/">크리에이티브 커먼즈 저작자표시-동일조건변경허락 3.0 미국 라이선스</a>에 따라 이용할 수 있습니다.
     </div>
 </footer>
+
+{% include footer/_docsearch.html %}

--- a/_includes/footer/footer-pt-br.html
+++ b/_includes/footer/footer-pt-br.html
@@ -36,3 +36,5 @@ contribuidores do expressjs.com.</div>
     </div>
     </div>
 </footer>
+
+{% include footer/_docsearch.html %}

--- a/_includes/footer/footer-ru.html
+++ b/_includes/footer/footer-ru.html
@@ -34,3 +34,5 @@
 <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/"><img alt="Лицензия Creative Commons" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/3.0/us/80x15.png" /></a> Это произведение доступно по <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/">лицензии Creative Commons «Attribution-ShareAlike» («Атрибуция — На тех же условиях») 3.0 США</a>.
     </div>
 </footer>
+
+{% include footer/_docsearch.html %}

--- a/_includes/footer/footer-sk.html
+++ b/_includes/footer/footer-sk.html
@@ -35,3 +35,5 @@
         <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/3.0/us/80x15.png" /></a> This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/">Creative Commons Attribution-ShareAlike 3.0 United States License</a>.
     </div>     
 </footer>
+
+{% include footer/_docsearch.html %}

--- a/_includes/footer/footer-th.html
+++ b/_includes/footer/footer-th.html
@@ -36,3 +36,5 @@
 </footer>
 
 <script async defer src="https://buttons.github.io/buttons.js"></script>
+
+{% include footer/_docsearch.html %}

--- a/_includes/footer/footer-tr.html
+++ b/_includes/footer/footer-tr.html
@@ -41,3 +41,5 @@
 </footer>
 
 <script async defer src="https://buttons.github.io/buttons.js"></script>
+
+{% include footer/_docsearch.html %}

--- a/_includes/footer/footer-uk.html
+++ b/_includes/footer/footer-uk.html
@@ -33,3 +33,5 @@
         <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/"><img alt="Ліцензія Creative Commons" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/3.0/us/80x15.png" /></a> Цей твір ліцензовано за <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/">ліцензією Creative Commons Із Зазначенням Авторства - Поширення На Тих Самих Умовах 3.0 Сполучені Штати</a>.
     </div>
 </footer>
+
+{% include footer/_docsearch.html %}

--- a/_includes/footer/footer-uz.html
+++ b/_includes/footer/footer-uz.html
@@ -33,3 +33,5 @@
         <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/3.0/us/80x15.png" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/">Creative Commons Attribution-ShareAlike 3.0 United States License</a>.
     </div>
 </footer>
+
+{% include footer/_docsearch.html %}

--- a/_includes/footer/footer-zh-cn.html
+++ b/_includes/footer/footer-zh-cn.html
@@ -33,3 +33,5 @@
 <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/"><img alt="知识共享许可协议" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/3.0/us/80x15.png" /></a> 本作品采用<a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/">知识共享署名-相同方式共享 3.0 美国许可协议</a>进行许可。
     </div>
 </footer>
+
+{% include footer/_docsearch.html %}

--- a/_includes/footer/footer-zh-tw.html
+++ b/_includes/footer/footer-zh-tw.html
@@ -34,3 +34,5 @@
             <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/"><img alt="創用 CC 授權條款" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/3.0/us/80x15.png" /></a> 本著作係採用<a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/">創用 CC 姓名標示-相同方式分享 3.0 美國 授權條款</a>授權.
     </div>
 </footer>
+
+{% include footer/_docsearch.html %}

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -19,4 +19,7 @@
     <script data-cfasync="false" src="/js/retina.js"></script>
     <script data-cfasync="false" src="/js/dropit.js"></script>
     <script data-cfasync="false" src="/js/prism.js"></script>
+    <link rel="stylesheet" href="/css/search.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
+
 </head>

--- a/_includes/header/header-de.html
+++ b/_includes/header/header-de.html
@@ -5,6 +5,7 @@
   <section id="logo"><a href="/" class="express">Express</a>
   </section>
   <div id="navbar">
+      <input id="q" placeholder="🔎 search">
       <ul id="navmenu">
           <li><a href="/{{ page.lang }}/" id="home-menu"{% if page.menu == 'home' %} class="active"{% endif %}>Home</a></li>
           <li>

--- a/_includes/header/header-en.html
+++ b/_includes/header/header-en.html
@@ -5,6 +5,7 @@
   <section id="logo"><a href="/" class="express">Express</a>
   </section>
   <div id="navbar">
+      <input id="q" placeholder="🔎 search">
       <ul id="navmenu">
           <li><a href="/" id="home-menu"{% if page.menu == 'home' %} class="active"{% endif %}>Home</a></li>
           <li>

--- a/_includes/header/header-es.html
+++ b/_includes/header/header-es.html
@@ -5,6 +5,7 @@
   <section id="logo"><a href="/" class="express">Express</a>
   </section>
   <div id="navbar">
+      <input id="q" placeholder="🔎 search">
       <ul id="navmenu">
           <li><a href="/{{ page.lang }}/" id="home-menu"{% if page.menu == 'home' %} class="active"{% endif %}>Inicio</a></li>
           <li>

--- a/_includes/header/header-fr.html
+++ b/_includes/header/header-fr.html
@@ -6,6 +6,7 @@
   </section>
   <div id="navbar">
       <ul id="navmenu">
+          <input id="q" placeholder="🔎 search">
           <li><a href="/{{ page.lang }}/" id="home-menu"{% if page.menu == 'home' %} class="active"{% endif %}>Accueil</a></li>
           <li>
               <ul id="getting-started-menu" class="menu">

--- a/_includes/header/header-it.html
+++ b/_includes/header/header-it.html
@@ -5,6 +5,7 @@
   <section id="logo"><a href="/" class="express">Express</a>
   </section>
   <div id="navbar">
+      <input id="q" placeholder="🔎 search">
       <ul id="navmenu">
           <li><a href="/{{ page.lang }}/" id="home-menu"{% if page.menu == 'home' %} class="active"{% endif %}>Home</a></li>
           <li>

--- a/_includes/header/header-ja.html
+++ b/_includes/header/header-ja.html
@@ -5,6 +5,7 @@
   <section id="logo"><a href="/" class="express">Express</a>
   </section>
   <div id="navbar">
+      <input id="q" placeholder="🔎 search">
       <ul id="navmenu">
           <li><a href="/{{ page.lang }}/" id="home-menu"{% if page.menu == 'home' %} class="active"{% endif %}>ホーム</a></li>
           <li>

--- a/_includes/header/header-ko.html
+++ b/_includes/header/header-ko.html
@@ -5,6 +5,7 @@
   <section id="logo"><a href="/" class="express">Express</a>
   </section>
   <div id="navbar">
+      <input id="q" placeholder="🔎 search">
       <ul id="navmenu">
           <li><a href="/{{ page.lang }}/" id="home-menu"{% if page.menu == 'home' %} class="active"{% endif %}>홈</a></li>
           <li>

--- a/_includes/header/header-pt-br.html
+++ b/_includes/header/header-pt-br.html
@@ -5,6 +5,7 @@
   <section id="logo"><a href="/" class="express">Express</a>
   </section>
   <div id="navbar">
+      <input id="q" placeholder="🔎 search">
       <ul id="navmenu">
           <li><a href="/{{ page.lang }}/" id="home-menu"{% if page.menu == 'home' %} class="active"{% endif %}>Página Inicial</a></li>
           <li>

--- a/_includes/header/header-ru.html
+++ b/_includes/header/header-ru.html
@@ -5,6 +5,7 @@
   <section id="logo"><a href="/" class="express">Express</a>
   </section>
   <div id="navbar">
+      <input id="q" placeholder="🔎 search">
       <ul id="navmenu">
           <li><a href="/{{ page.lang }}/" id="home-menu"{% if page.menu == 'home' %} class="active"{% endif %}>Начальная страница</a></li>
           <li>

--- a/_includes/header/header-sk.html
+++ b/_includes/header/header-sk.html
@@ -5,6 +5,7 @@
     <section id="logo"><a href="/" class="express">Express</a>
     </section>
     <div id="navbar">
+        <input id="q" placeholder="🔎 search">
         <ul id="navmenu">
             <li><a href="/{{ page.lang }}/" id="home-menu" {% if page.menu == 'home' %} class="active" {% endif %}>Domov</a></li>
             <li>

--- a/_includes/header/header-th.html
+++ b/_includes/header/header-th.html
@@ -5,6 +5,7 @@
   <section id="logo"><a href="/" class="express">Express</a>
   </section>
   <div id="navbar">
+      <input id="q" placeholder="🔎 search">
       <ul id="navmenu">
           <li><a href="/{{ page.lang }}/" id="home-menu"{% if page.menu == 'home' %} class="active"{% endif %}>หน้าแรก</a></li>
           <li>

--- a/_includes/header/header-tr.html
+++ b/_includes/header/header-tr.html
@@ -5,6 +5,7 @@
   <section id="logo"><a href="/" class="express">Express</a>
   </section>
   <div id="navbar">
+      <input id="q" placeholder="🔎 search" />
       <ul id="navmenu">
           <li><a href="/" id="home-menu"{% if page.menu == 'home' %} class="active"{% endif %}>Anasayfa</a></li>
           <li>

--- a/_includes/header/header-uz.html
+++ b/_includes/header/header-uz.html
@@ -4,7 +4,8 @@
   </div>
   <section id="logo"><a href="/" class="express">Express</a>
   </section>
-  <div id="navbar">
+  <div id="navbar">
+      <input id="q" placeholder="🔎 search" />
       <ul id="navmenu">
           <li><a href="/{{ page.lang }}/" id="home-menu"{% if page.menu == 'home' %} class="active"{% endif %}>Bosh sahifa</a></li>
           <li>

--- a/_includes/header/header-zh-cn.html
+++ b/_includes/header/header-zh-cn.html
@@ -5,6 +5,7 @@
   <section id="logo"><a href="/" class="express">Express</a>
   </section>
   <div id="navbar">
+      <input id="q" placeholder="🔎 search">
       <ul id="navmenu">
           <li><a href="/{{ page.lang }}/" id="home-menu"{% if page.menu == 'home' %} class="active"{% endif %}>主页</a></li>
           <li>

--- a/_includes/header/header-zh-tw.html
+++ b/_includes/header/header-zh-tw.html
@@ -5,6 +5,7 @@
   <section id="logo"><a href="/" class="express">Express</a>
   </section>
   <div id="navbar">
+      <input id="q" placeholder="🔎 search">
       <ul id="navmenu">
           <li><a href="/{{ page.lang }}/" id="home-menu"{% if page.menu == 'home' %} class="active"{% endif %}>首頁</a></li>
           <li>

--- a/css/search.css
+++ b/css/search.css
@@ -1,0 +1,16 @@
+#q {
+  display: none;
+  height: 2.5em;
+  min-width: 100%;
+  padding: 5px;
+}
+
+.algolia-autocomplete {
+  min-width: 12em;
+  max-width: 12em;
+  top: -0.2em;
+}
+
+.algolia-autocomplete #q {
+  display: initial
+}


### PR DESCRIPTION
👋 team,

TL;DR: Add a learn-as-you-type search experience to the documentation

I'm working at Algolia on the a project called [DocSearch](https://community.algolia.com/docsearch/) which goal is to enhance documentation websites with exhaustive, fast and relevant search. You might have seen DocSearch live already on websites like [react](https://reactjs.org/), [Bootstrap](https://getbootstrap.com/), [Brew](https://brew.sh/) or [jQuery](https://jquery.com/).

I have created [a preview of this PR](https://docsearch-expressjs.netlify.com/) and what DocSearch on the expressjs website could will look like here. Feel free to try it and let us know what you think. Please note the learn-as-you-type experience and the typo tolerance:

[![demo of DocSearch + expressjs](https://cl.ly/532172fbd10d/download/Screen%20Recording%202019-04-24%20at%2001.47%20PM.gif)](https://docsearch-expressjs.netlify.com/)

The way DocSearch works is by crawling your content, pushing the results into an Algolia index, and then requesting this index directly from the website front-end through JavaScript.

We'll take care of crawling your website and populating the Algolia index with the latest changes every 24h for you. You don't need to change anything to your deployment process. The only thing you need to add are the following CSS and JS snippets that will bind the dropdown to your searchbox.

We built DocSearch with the idea of giving back to the Open-Source community. This is why your [crawling configuration](https://github.com/algolia/docsearch-configs/blob/master/configs/python-expressjs.json) is available on GitHub if you want to change it. We also have our own [documentation](https://community.algolia.com/docsearch/documentation/) to help you tweak the dropdown to your needs. You'll also have access to *analytics on the most searched terms* or those with *no results*. All of this is of course *entirely free*.