### PR TITLE
quick fix for #1044

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -802,7 +802,6 @@ h2 a {
 
 .algolia-autocomplete {
   min-width: 12em;
-  max-width: 12em;
   top: -0.2em;
 }
 


### PR DESCRIPTION
This is a quick fix for #1044 .

I am not quite sure what `min-width` and `max-width` is doing good here. By removing the `max-width` the navbar looks okayish in Firefox again.

hth