### PR TITLE
Document other shell variable for debuging express

### DIFF
--- a/en/guide/debugging.md
+++ b/en/guide/debugging.md
@@ -113,4 +113,24 @@ You can specify more than one debug namespace by assigning a comma-separated lis
 $ DEBUG=http,mail,express:* node index.js
 ```
 
+## Advanced options
+
+When running through Node.js, you can set a few environment variables that will change the behavior of the debug logging:
+
+| Name      | Purpose                                         |
+|-----------|-------------------------------------------------|
+| `DEBUG`   | Enables/disables specific debugging namespaces. |
+| `DEBUG_COLORS`| Whether or not to use colors in the debug output. |
+| `DEBUG_DEPTH` | Object inspection depth. |
+| `DEBUG_FD`    | File descriptor to write debug output to. |
+| `DEBUG_SHOW_HIDDEN` | Shows hidden properties on inspected objects. |
+
+__Note:__ The environment variables beginning with `DEBUG_` end up being
+converted into an Options object that gets used with `%o`/`%O` formatters.
+See the Node.js documentation for
+[`util.inspect()`](https://nodejs.org/api/util.html#util_util_inspect_object_options)
+for the complete list.
+
+## Resources
+
 For more information about `debug`, see the [debug](https://www.npmjs.com/package/debug).


### PR DESCRIPTION
Specified `DEBUG_FD` and `DEBUG_COLORS` shell variables to handle redirection of logs to a file and enabling/disabling color output respectively