### PR TITLE
Initial cleanup of 5.x alpha doc

### DIFF
--- a/_includes/announcement/announcement-en.md
+++ b/_includes/announcement/announcement-en.md
@@ -1,8 +1,8 @@
 <ul>
   <li>
-    <p class="announcement-title">Express 4.16.0 contains important security updates.</p>
+    <p class="announcement-title">Express 5.0 alpha documentation is now available.</p>
     <p markdown="1">
-     For more information on what was added in this release, see the [4.16.0 changelog](/{{ page.lang }}/changelog/4x.html#4.16.0).
+     The alpha <a href="{{ page.lang }}/5x/api.html">API documentation</a> is a work in progress.  For information on what's in the release, see the Express <a href="https://github.com/expressjs/express/blob/5.0/History.md">release history</a>.
     </p>
   </li>
 </ul>

--- a/_includes/api/en/5x/app-METHOD.md
+++ b/_includes/api/en/5x/app-METHOD.md
@@ -4,7 +4,7 @@ Routes an HTTP request, where METHOD is the HTTP method of the request, such as 
 PUT, POST, and so on, in lowercase. Thus, the actual methods are `app.get()`,
 `app.post()`, `app.put()`, and so on.  See [Routing methods](#routing-methods) below for the complete list.
 
-{% include api/en/4x/routing-args.html %}
+{% include api/en/5x/routing-args.html %}
 
 #### Routing methods
 

--- a/_includes/api/en/5x/app-all.md
+++ b/_includes/api/en/5x/app-all.md
@@ -3,7 +3,7 @@
 This method is like the standard [app.METHOD()](#app.METHOD) methods,
 except it matches all HTTP verbs.
 
-{% include api/en/4x/routing-args.html %}
+{% include api/en/5x/routing-args.html %}
 
 #### Examples
 

--- a/_includes/api/en/5x/app-delete-method.md
+++ b/_includes/api/en/5x/app-delete-method.md
@@ -3,7 +3,7 @@
 Routes HTTP DELETE requests to the specified path with the specified callback functions.
 For more information, see the [routing guide](/guide/routing.html).
 
-{% include api/en/4x/routing-args.html %}
+{% include api/en/5x/routing-args.html %}
 
 #### Example
 

--- a/_includes/api/en/5x/app-get-method.md
+++ b/_includes/api/en/5x/app-get-method.md
@@ -2,7 +2,7 @@
 
 Routes HTTP GET requests to the specified path with the specified callback functions.
 
-{% include api/en/4x/routing-args.html %}
+{% include api/en/5x/routing-args.html %}
 
 For more information, see the [routing guide](/guide/routing.html).
 

--- a/_includes/api/en/5x/app-onmount.md
+++ b/_includes/api/en/5x/app-onmount.md
@@ -10,7 +10,7 @@ Sub-apps will:
 * Not inherit the value of settings that have a default value.  You must set the value in the sub-app.
 * Inherit the value of settings with no default value.
 
-For details, see [Application settings](/en/4x/api.html#app.settings.table).
+For details, see [Application settings](/en/5x/api.html#app.settings.table).
 </div>
 
 ```js

--- a/_includes/api/en/5x/app-post-method.md
+++ b/_includes/api/en/5x/app-post-method.md
@@ -3,7 +3,7 @@
 Routes HTTP POST requests to the specified path with the specified callback functions.
 For more information, see the [routing guide](/guide/routing.html).
 
-{% include api/en/4x/routing-args.html %}
+{% include api/en/5x/routing-args.html %}
 
 #### Example
 

--- a/_includes/api/en/5x/app-put-method.md
+++ b/_includes/api/en/5x/app-put-method.md
@@ -2,7 +2,7 @@
 
 Routes HTTP PUT requests to the specified path with the specified callback functions.
 
-{% include api/en/4x/routing-args.html %}
+{% include api/en/5x/routing-args.html %}
 
 #### Example
 

--- a/_includes/api/en/5x/app-set.md
+++ b/_includes/api/en/5x/app-set.md
@@ -17,4 +17,4 @@ app.get('title') // "My Site"
 
 <h4 id='app.settings.table'>Application Settings</h4>
 
-{% include api/en/4x/app-settings.md %}
+{% include api/en/5x/app-settings.md %}

--- a/_includes/api/en/5x/app-use.md
+++ b/_includes/api/en/5x/app-use.md
@@ -4,7 +4,7 @@ Mounts the specified [middleware](/guide/using-middleware.html) function or func
 at the specified path:
 the middleware function is executed when the base of the requested path matches `path`.
 
-{% include api/en/4x/routing-args.html %}
+{% include api/en/5x/routing-args.html %}
 
 #### Description
 
@@ -30,7 +30,7 @@ Sub-apps will:
 * Not inherit the value of settings that have a default value.  You must set the value in the sub-app.
 * Inherit the value of settings with no default value.
 
-For details, see [Application settings](/en/4x/api.html#app.settings.table).
+For details, see [Application settings](/en/5x/api.html#app.settings.table).
 </div>
 
 Middleware functions are executed sequentially, therefore the order of middleware inclusion is important.

--- a/_includes/api/en/5x/app.md
+++ b/_includes/api/en/5x/app.md
@@ -31,93 +31,93 @@ The Express application object can be referred from the [request object](#req) a
 <h3 id='app.properties'>Properties</h3>
 
 <section markdown="1">
-  {% include api/en/4x/app-locals.md %}
+  {% include api/en/5x/app-locals.md %}
 </section>
 
 <section markdown="1">
-  {% include api/en/4x/app-mountpath.md %}
+  {% include api/en/5x/app-mountpath.md %}
 </section>
 
 <h3 id='app.events'>Events</h3>
 
 <section markdown="1">
-  {% include api/en/4x/app-onmount.md %}
+  {% include api/en/5x/app-onmount.md %}
 </section>
 
 <h3 id='app.methods'>Methods</h3>
 
 <section markdown="1">
-  {% include api/en/4x/app-all.md %}
+  {% include api/en/5x/app-all.md %}
 </section>
 
 <section markdown="1">
-  {% include api/en/4x/app-delete-method.md %}
+  {% include api/en/5x/app-delete-method.md %}
 </section>
 
 <section markdown="1">
-  {% include api/en/4x/app-disable.md %}
+  {% include api/en/5x/app-disable.md %}
 </section>
 
 <section markdown="1">
-  {% include api/en/4x/app-disabled.md %}
+  {% include api/en/5x/app-disabled.md %}
 </section>
 
 <section markdown="1">
-  {% include api/en/4x/app-enable.md %}
+  {% include api/en/5x/app-enable.md %}
 </section>
 
 <section markdown="1">
-  {% include api/en/4x/app-enabled.md %}
+  {% include api/en/5x/app-enabled.md %}
 </section>
 
 <section markdown="1">
-  {% include api/en/4x/app-engine.md %}
+  {% include api/en/5x/app-engine.md %}
 </section>
 
 <section markdown="1">
-  {% include api/en/4x/app-get.md %}
+  {% include api/en/5x/app-get.md %}
 </section>
 
 <section markdown="1">
-  {% include api/en/4x/app-get-method.md %}
+  {% include api/en/5x/app-get-method.md %}
 </section>
 
 <section markdown="1">
-  {% include api/en/4x/app-listen.md %}
+  {% include api/en/5x/app-listen.md %}
 </section>
 
 <section markdown="1">
-  {% include api/en/4x/app-METHOD.md %}
+  {% include api/en/5x/app-METHOD.md %}
 </section>
 
 <section markdown="1">
-  {% include api/en/4x/app-param.md %}
+  {% include api/en/5x/app-param.md %}
 </section>
 
 <section markdown="1">
-  {% include api/en/4x/app-path.md %}
+  {% include api/en/5x/app-path.md %}
 </section>
 
 <section markdown="1">
-  {% include api/en/4x/app-post-method.md %}
+  {% include api/en/5x/app-post-method.md %}
 </section>
 
 <section markdown="1">
-  {% include api/en/4x/app-put-method.md %}
+  {% include api/en/5x/app-put-method.md %}
 </section>
 
 <section markdown="1">
-  {% include api/en/4x/app-render.md %}
+  {% include api/en/5x/app-render.md %}
 </section>
 
 <section markdown="1">
-  {% include api/en/4x/app-route.md %}
+  {% include api/en/5x/app-route.md %}
 </section>
 
 <section markdown="1">
-  {% include api/en/4x/app-set.md %}
+  {% include api/en/5x/app-set.md %}
 </section>
 
 <section markdown="1">
-  {% include api/en/4x/app-use.md %}
+  {% include api/en/5x/app-use.md %}
 </section>

--- a/_includes/api/en/5x/express.json.md
+++ b/_includes/api/en/5x/express.json.md
@@ -1,9 +1,5 @@
 <h3 id='express.json' class='h2'>express.json([options])</h3>
 
-<div class="doc-box doc-info" markdown="1">
-This middleware is available in Express v4.16.0 onwards.
-</div>
-
 This is a built-in middleware function in Express. It parses incoming requests
 with JSON payloads and is based on
 [body-parser](/{{ page.lang }}/resources/middleware/body-parser.html).

--- a/_includes/api/en/5x/express.md
+++ b/_includes/api/en/5x/express.md
@@ -10,17 +10,17 @@ var app = express()
 <h3 id='express.methods'>Methods</h3>
 
 <section markdown="1">
-  {% include api/en/4x/express.json.md %}
+  {% include api/en/5x/express.json.md %}
 </section>
 
 <section markdown="1">
-  {% include api/en/4x/express.static.md %}
+  {% include api/en/5x/express.static.md %}
 </section>
 
 <section markdown="1">
-  {% include api/en/4x/express.router.md %}
+  {% include api/en/5x/express.router.md %}
 </section>
 
 <section markdown="1">
-  {% include api/en/4x/express.urlencoded.md %}
+  {% include api/en/5x/express.urlencoded.md %}
 </section>

--- a/_includes/api/en/5x/express.raw.md
+++ b/_includes/api/en/5x/express.raw.md
@@ -1,0 +1,32 @@
+<h3 id='express.raw' class='h2'>express.raw([options])</h3>
+
+This is a built-in middleware function in Express. It parses incoming request
+payloads into a `Buffer` and is based on
+[body-parser](/{{ page.lang }}/resources/middleware/body-parser.html).
+
+Returns middleware that parses all bodies as a `Buffer` and only looks at requests
+where the `Content-Type` header matches the `type` option. This parser accepts
+any Unicode encoding of the body and supports automatic inflation of `gzip` and
+`deflate` encodings.
+
+A new `body` `Buffer` containing the parsed data is populated on the `request`
+object after the middleware (i.e. `req.body`), or an empty object (`{}`) if
+there was no body to parse, the `Content-Type` was not matched, or an error
+occurred.
+
+<div class="doc-box doc-warn" markdown="1">
+As `req.body`'s shape is based on user-controlled input, all properties and
+values in this object are untrusted and should be validated before trusting.
+For example, `req.body.toString()` may fail in multiple ways, for example
+stacking multiple parsers `req.body` may be from a different parser. Testing
+that `req.body` is a `Buffer` before calling buffer methods is recommended.
+</div>
+
+The following table describes the properties of the optional `options` object.
+
+| Property  | Description                                                           |   Type      | Default         |
+|-----------|-----------------------------------------------------------------------|-------------|-----------------|
+| `inflate` | Enables or disables handling deflated (compressed) bodies; when disabled, deflated bodies are rejected. | Boolean | `true` |
+| `limit`   | Controls the maximum request body size. If this is a number, then the value specifies the number of bytes; if it is a string, the value is passed to the [bytes](https://www.npmjs.com/package/bytes) library for parsing. | Mixed | `"100kb"` |
+| `type`    | This is used to determine what media type the middleware will parse. This option can be a string, array of strings, or a function. If not a function, `type` option is passed directly to the [type-is](https://www.npmjs.org/package/type-is#readme) library and this can be an extension name (like `bin`), a mime type (like `application/octet-stream`), or a mime type with a wildcard (like `*/*` or `application/*`). If a function, the `type` option is called as `fn(req)` and the request is parsed if it returns a truthy value. | Mixed | `"application/octet-stream"` |
+| `verify`  | This option, if supplied, is called as `verify(req, res, buf, encoding)`, where `buf` is a `Buffer` of the raw request body and `encoding` is the encoding of the request. The parsing can be aborted by throwing an error. | Function | `undefined` |

--- a/_includes/api/en/5x/express.text.md
+++ b/_includes/api/en/5x/express.text.md
@@ -1,0 +1,33 @@
+<h3 id='express.text' class='h2'>express.text([options])</h3>
+
+This is a built-in middleware function in Express. It parses incoming request
+payloads into a string and is based on
+[body-parser](/{{ page.lang }}/resources/middleware/body-parser.html).
+
+Returns middleware that parses all bodies as a string and only looks at requests
+where the `Content-Type` header matches the `type` option. This parser accepts
+any Unicode encoding of the body and supports automatic inflation of `gzip` and
+`deflate` encodings.
+
+A new `body` string containing the parsed data is populated on the `request`
+object after the middleware (i.e. `req.body`), or an empty object (`{}`) if
+there was no body to parse, the `Content-Type` was not matched, or an error
+occurred.
+
+<div class="doc-box doc-warn" markdown="1">
+As `req.body`'s shape is based on user-controlled input, all properties and
+values in this object are untrusted and should be validated before trusting.
+For example, `req.body.trim()` may fail in multiple ways, for example
+stacking multiple parsers `req.body` may be from a different parser. Testing
+that `req.body` is a string before calling string methods is recommended.
+</div>
+
+The following table describes the properties of the optional `options` object.
+
+| Property         | Description                                                           |   Type      | Default         |
+|------------------|-----------------------------------------------------------------------|-------------|-----------------|
+| `defaultCharset` | Specify the default character set for the text content if the charset is not specified in the `Content-Type` header of the request. | String | `"utf-8"` |
+| `inflate`        | Enables or disables handling deflated (compressed) bodies; when disabled, deflated bodies are rejected. | Boolean | `true` |
+| `limit`          | Controls the maximum request body size. If this is a number, then the value specifies the number of bytes; if it is a string, the value is passed to the [bytes](https://www.npmjs.com/package/bytes) library for parsing. | Mixed | `"100kb"` |
+| `type`           | This is used to determine what media type the middleware will parse. This option can be a string, array of strings, or a function. If not a function, `type` option is passed directly to the [type-is](https://www.npmjs.org/package/type-is#readme) library and this can be an extension name (like `txt`), a mime type (like `text/plain`), or a mime type with a wildcard (like `*/*` or `text/*`). If a function, the `type` option is called as `fn(req)` and the request is parsed if it returns a truthy value. | Mixed | `"text/plain"` |
+| `verify`         | This option, if supplied, is called as `verify(req, res, buf, encoding)`, where `buf` is a `Buffer` of the raw request body and `encoding` is the encoding of the request. The parsing can be aborted by throwing an error. | Function | `undefined` |

--- a/_includes/api/en/5x/express.urlencoded.md
+++ b/_includes/api/en/5x/express.urlencoded.md
@@ -1,9 +1,5 @@
 <h3 id='express.urlencoded' class='h2'>express.urlencoded([options])</h3>
 
-<div class="doc-box doc-info" markdown="1">
-This middleware is available in Express v4.16.0 onwards.
-</div>
-
 This is a built-in middleware function in Express. It parses incoming requests
 with urlencoded payloads and is based on [body-parser](/{{ page.lang }}/resources/middleware/body-parser.html).
 

--- a/_includes/api/en/5x/req-hostname.md
+++ b/_includes/api/en/5x/req-hostname.md
@@ -2,12 +2,22 @@
 
 Contains the hostname derived from the `Host` HTTP header.
 
-When the [`trust proxy` setting](/4x/api.html#trust.proxy.options.table) does not evaluate to `false`,
-this property will instead have the value of the `X-Forwarded-Host` header field.
-This header can be set by the client or by the proxy.
+When the [`trust proxy` setting](/5x/api.html#trust.proxy.options.table)
+does not evaluate to `false`, this property will instead get the value
+from the `X-Forwarded-Host` header field. This header can be set by
+the client or by the proxy.
+
+If there is more than one `X-Forwarded-Host` header in the request, the
+value of the first header is used. This includes a single header with
+comma-separated values, in which the first value is used.
+
+<div class="doc-box doc-info" markdown="1">
+Prior to Express v4.17.0, the `X-Forwarded-Host` could not contain multiple
+values or be present more than once.
+</div>
 
 ```js
 // Host: "example.com:3000"
 console.dir(req.hostname)
-// => "example.com"
+// => 'example.com'
 ```

--- a/_includes/api/en/5x/req-ip.md
+++ b/_includes/api/en/5x/req-ip.md
@@ -2,7 +2,7 @@
 
 Contains the remote IP address of the request.
 
-When the [`trust proxy` setting](/4x/api.html#trust.proxy.options.table) does not evaluate to `false`,
+When the [`trust proxy` setting](/5x/api.html#trust.proxy.options.table) does not evaluate to `false`,
 the value of this property is derived from the left-most entry in the
 `X-Forwarded-For` header. This header can be set by the client or by the proxy.
 

--- a/_includes/api/en/5x/req-ips.md
+++ b/_includes/api/en/5x/req-ips.md
@@ -1,6 +1,6 @@
 <h3 id='req.ips'>req.ips</h3>
 
-When the [`trust proxy` setting](/4x/api.html#trust.proxy.options.table) does not evaluate to `false`,
+When the [`trust proxy` setting](/5x/api.html#trust.proxy.options.table) does not evaluate to `false`,
 this property contains an array of IP addresses
 specified in the `X-Forwarded-For` request header. Otherwise, it contains an
 empty array. This header can be set by the client or by the proxy.

--- a/_includes/api/en/5x/req-params.md
+++ b/_includes/api/en/5x/req-params.md
@@ -16,7 +16,7 @@ console.dir(req.params[0])
 // => "javascripts/jquery.js"
 ```
 
-If you need to make changes to a key in `req.params`, use the [app.param](/{{ page.lang }}/4x/api.html#app.param) handler. Changes are applicable only to [parameters](/{{ page.lang }}/guide/routing.html#route-parameters) already defined in the route path.
+If you need to make changes to a key in `req.params`, use the [app.param](/{{ page.lang }}/5x/api.html#app.param) handler. Changes are applicable only to [parameters](/{{ page.lang }}/guide/routing.html#route-parameters) already defined in the route path.
 
 Any changes made to the `req.params` object in a middleware or route handler will be reset.
 

--- a/_includes/api/en/5x/req-path.md
+++ b/_includes/api/en/5x/req-path.md
@@ -9,5 +9,5 @@ console.dir(req.path)
 ```
 
 <div class="doc-box doc-info" markdown="1">
-When called from a middleware, the mount point is not included in `req.path`. See [app.use()](/4x/api.html#app.use) for more details.
+When called from a middleware, the mount point is not included in `req.path`. See [app.use()](/5x/api.html#app.use) for more details.
 </div>

--- a/_includes/api/en/5x/req-subdomains.md
+++ b/_includes/api/en/5x/req-subdomains.md
@@ -10,4 +10,4 @@ console.dir(req.subdomains)
 
 The application property `subdomain offset`, which defaults to 2, is used for determining the
 beginning of the subdomain segments. To change this behavior, change its value
-using [app.set](/{{ page.lang }}/4x/api.html#app.set).
+using [app.set](/{{ page.lang }}/5x/api.html#app.set).

--- a/_includes/api/en/5x/req.md
+++ b/_includes/api/en/5x/req.md
@@ -37,116 +37,116 @@ or [pez](https://www.npmjs.com/package/pez).
 </div>
 
 <section markdown="1">
-  {% include api/en/4x/req-app.md %}
+  {% include api/en/5x/req-app.md %}
 </section>
 
 <section markdown="1">
-  {% include api/en/4x/req-baseUrl.md %}
+  {% include api/en/5x/req-baseUrl.md %}
 </section>
 
 <section markdown="1">
-  {% include api/en/4x/req-body.md %}
+  {% include api/en/5x/req-body.md %}
 </section>
 
 <section markdown="1">
-  {% include api/en/4x/req-cookies.md %}
+  {% include api/en/5x/req-cookies.md %}
 </section>
 
 <section markdown="1">
-  {% include api/en/4x/req-fresh.md %}
+  {% include api/en/5x/req-fresh.md %}
 </section>
 
 <section markdown="1">
-  {% include api/en/4x/req-hostname.md %}
+  {% include api/en/5x/req-hostname.md %}
 </section>
 
 <section markdown="1">
-  {% include api/en/4x/req-ip.md %}
+  {% include api/en/5x/req-ip.md %}
 </section>
 
 <section markdown="1">
-  {% include api/en/4x/req-ips.md %}
+  {% include api/en/5x/req-ips.md %}
 </section>
 
 <section markdown="1">
-  {% include api/en/4x/req-method.md %}
+  {% include api/en/5x/req-method.md %}
 </section>
 
 <section markdown="1">
-  {% include api/en/4x/req-originalUrl.md %}
+  {% include api/en/5x/req-originalUrl.md %}
 </section>
 
 <section markdown="1">
-  {% include api/en/4x/req-params.md %}
+  {% include api/en/5x/req-params.md %}
 </section>
 
 <section markdown="1">
-  {% include api/en/4x/req-path.md %}
+  {% include api/en/5x/req-path.md %}
 </section>
 
 <section markdown="1">
-  {% include api/en/4x/req-protocol.md %}
+  {% include api/en/5x/req-protocol.md %}
 </section>
 
 <section markdown="1">
-  {% include api/en/4x/req-query.md %}
+  {% include api/en/5x/req-query.md %}
 </section>
 
 <section markdown="1">
-  {% include api/en/4x/req-route.md %}
+  {% include api/en/5x/req-route.md %}
 </section>
 
 <section markdown="1">
-  {% include api/en/4x/req-secure.md %}
+  {% include api/en/5x/req-secure.md %}
 </section>
 
 <section markdown="1">
-  {% include api/en/4x/req-signedCookies.md %}
+  {% include api/en/5x/req-signedCookies.md %}
 </section>
 
 <section markdown="1">
-  {% include api/en/4x/req-stale.md %}
+  {% include api/en/5x/req-stale.md %}
 </section>
 
 <section markdown="1">
-  {% include api/en/4x/req-subdomains.md %}
+  {% include api/en/5x/req-subdomains.md %}
 </section>
 
 <section markdown="1">
-  {% include api/en/4x/req-xhr.md %}
+  {% include api/en/5x/req-xhr.md %}
 </section>
 
 <h3 id='req.methods'>Methods</h3>
 
 <section markdown="1">
-  {% include api/en/4x/req-accepts.md %}
+  {% include api/en/5x/req-accepts.md %}
 </section>
 
 <section markdown="1">
-  {% include api/en/4x/req-acceptsCharsets.md %}
+  {% include api/en/5x/req-acceptsCharsets.md %}
 </section>
 
 <section markdown="1">
-  {% include api/en/4x/req-acceptsEncodings.md %}
+  {% include api/en/5x/req-acceptsEncodings.md %}
 </section>
 
 <section markdown="1">
-  {% include api/en/4x/req-acceptsLanguages.md %}
+  {% include api/en/5x/req-acceptsLanguages.md %}
 </section>
 
 <section markdown="1">
-  {% include api/en/4x/req-get.md %}
+  {% include api/en/5x/req-get.md %}
 </section>
 
 <section markdown="1">
-  {% include api/en/4x/req-is.md %}
+  {% include api/en/5x/req-is.md %}
 </section>
 
 <section markdown="1">
-  {% include api/en/4x/req-param.md %}
+  {% include api/en/5x/req-param.md %}
 </section>
 
 <section markdown="1">
-  {% include api/en/4x/req-range.md %}
+  {% include api/en/5x/req-range.md %}
 </section>
 

--- a/_includes/api/en/5x/res.md
+++ b/_includes/api/en/5x/res.md
@@ -28,99 +28,99 @@ and supports all [built-in fields and methods](https://nodejs.org/api/http.html#
 <h3 id='res.properties'>Properties</h3>
 
 <section markdown="1">
-  {% include api/en/4x/res-app.md %}
+  {% include api/en/5x/res-app.md %}
 </section>
 
 <section markdown="1">
-  {% include api/en/4x/res-headersSent.md %}
+  {% include api/en/5x/res-headersSent.md %}
 </section>
 
 <section markdown="1">
-  {% include api/en/4x/res-locals.md %}
+  {% include api/en/5x/res-locals.md %}
 </section>
 
 <h3 id='res.methods'>Methods</h3>
 
 <section markdown="1">
-  {% include api/en/4x/res-append.md %}
+  {% include api/en/5x/res-append.md %}
 </section>
 
 <section markdown="1">
-  {% include api/en/4x/res-attachment.md %}
+  {% include api/en/5x/res-attachment.md %}
 </section>
 
 <section markdown="1">
-  {% include api/en/4x/res-cookie.md %}
+  {% include api/en/5x/res-cookie.md %}
 </section>
 
 <section markdown="1">
-  {% include api/en/4x/res-clearCookie.md %}
+  {% include api/en/5x/res-clearCookie.md %}
 </section>
 
 <section markdown="1">
-  {% include api/en/4x/res-download.md %}
+  {% include api/en/5x/res-download.md %}
 </section>
 
 <section markdown="1">
-  {% include api/en/4x/res-end.md %}
+  {% include api/en/5x/res-end.md %}
 </section>
 
 <section markdown="1">
-  {% include api/en/4x/res-format.md %}
+  {% include api/en/5x/res-format.md %}
 </section>
 
 <section markdown="1">
-  {% include api/en/4x/res-get.md %}
+  {% include api/en/5x/res-get.md %}
 </section>
 
 <section markdown="1">
-  {% include api/en/4x/res-json.md %}
+  {% include api/en/5x/res-json.md %}
 </section>
 
 <section markdown="1">
-  {% include api/en/4x/res-jsonp.md %}
+  {% include api/en/5x/res-jsonp.md %}
 </section>
 
 <section markdown="1">
-  {% include api/en/4x/res-links.md %}
+  {% include api/en/5x/res-links.md %}
 </section>
 
 <section markdown="1">
-  {% include api/en/4x/res-location.md %}
+  {% include api/en/5x/res-location.md %}
 </section>
 
 <section markdown="1">
-  {% include api/en/4x/res-redirect.md %}
+  {% include api/en/5x/res-redirect.md %}
 </section>
 
 <section markdown="1">
-  {% include api/en/4x/res-render.md %}
+  {% include api/en/5x/res-render.md %}
 </section>
 
 <section markdown="1">
-  {% include api/en/4x/res-send.md %}
+  {% include api/en/5x/res-send.md %}
 </section>
 
 <section markdown="1">
-  {% include api/en/4x/res-sendFile.md %}
+  {% include api/en/5x/res-sendFile.md %}
 </section>
 
 <section markdown="1">
-  {% include api/en/4x/res-sendStatus.md %}
+  {% include api/en/5x/res-sendStatus.md %}
 </section>
 
 <section markdown="1">
-  {% include api/en/4x/res-set.md %}
+  {% include api/en/5x/res-set.md %}
 </section>
 
 <section markdown="1">
-  {% include api/en/4x/res-status.md %}
+  {% include api/en/5x/res-status.md %}
 </section>
 
 <section markdown="1">
-  {% include api/en/4x/res-type.md %}
+  {% include api/en/5x/res-type.md %}
 </section>
 
 <section markdown="1">
-  {% include api/en/4x/res-vary.md %}
+  {% include api/en/5x/res-vary.md %}
 </section>

--- a/_includes/api/en/5x/router.md
+++ b/_includes/api/en/5x/router.md
@@ -40,21 +40,21 @@ app.use('/calendar', router)
 <h3 id='router.methods'>Methods</h3>
 
 <section markdown="1">
-  {% include api/en/4x/router-all.md %}
+  {% include api/en/5x/router-all.md %}
 </section>
 
 <section markdown="1">
-  {% include api/en/4x/router-METHOD.md %}
+  {% include api/en/5x/router-METHOD.md %}
 </section>
 
 <section markdown="1">
-  {% include api/en/4x/router-param.md %}
+  {% include api/en/5x/router-param.md %}
 </section>
 
 <section markdown="1">
-  {% include api/en/4x/router-route.md %}
+  {% include api/en/5x/router-route.md %}
 </section>
 
 <section markdown="1">
-  {% include api/en/4x/router-use.md %}
+  {% include api/en/5x/router-use.md %}
 </section>

--- a/en/5x/api.md
+++ b/en/5x/api.md
@@ -9,6 +9,8 @@ redirect_from: "/5x/api.html"
 
   <h1>5.x API</h1>
 
+  {% include note.html content="This is early alpha documentation that may be incomplete and is still under development." %}
+
   {% include api/{{ page.lang }}/5x/express.md %}
   {% include api/{{ page.lang }}/5x/app.md %}
   {% include api/{{ page.lang }}/5x/req.md %}

--- a/index.md
+++ b/index.md
@@ -16,11 +16,9 @@ redirect_from: "/en/index.html"
     <div id="install-command">$ npm install express --save</div>
   </div>
 </section>
-<!--
 <section id="announcements">
-  {% include announcement/announcement-{{ page.lang }}.md %}
+  {% include announcement/announcement-en.md %}
 </section>
--->
 
 <section id="intro">
 


### PR DESCRIPTION
After landing #1037 this PR takes care of some housekeeping and clean-up, specifically:
- Add changes for 4.17 release that were in #1043 
- Adds an announcement to the home page about the 5.x alpha docs, as discussed in the last @expressjs/express-tc meeting.
- Adds a short disclaimer to the top of the API page saying the docs are a work in progress.
- Removes several notices stating `This middleware is available in Express v4.xx.0 onwards`; I'm assuming these notes are irrelevant in the 5.x docs (since the middleware will be available in 5.x).  Please correct me if I'm mistaken.
- Changes all the cross-references within the 5.x API docs from 4.x to the new 5.x docs.  In general for a given major release we should keep the cross-references within that release's API doc.  IOW, the links that were to `/en/4x/api.html#xyz` were changed to `/en/5x/api.html#xyz`. 