### PR TITLE
Update code samples in 5.x docs to use const

### DIFF
--- a/_includes/api/en/5x/app-engine.md
+++ b/_includes/api/en/5x/app-engine.md
@@ -30,7 +30,7 @@ Some template engines do not follow this convention.  The
 so they work seamlessly with Express.
 
 ```js
-var engines = require('consolidate')
+const engines = require('consolidate')
 app.engine('haml', engines.haml)
 app.engine('html', engines.hogan)
 ```

--- a/_includes/api/en/5x/app-listen.md
+++ b/_includes/api/en/5x/app-listen.md
@@ -4,8 +4,8 @@ Starts a UNIX socket and listens for connections on the given path.
 This method is identical to Node's [http.Server.listen()](https://nodejs.org/api/http.html#http_server_listen).
 
 ```js
-var express = require('express')
-var app = express()
+const express = require('express')
+const app = express()
 app.listen('/tmp/sock')
 ```
 
@@ -18,8 +18,8 @@ If port is omitted or is 0, the operating system will assign an arbitrary unused
 port, which is useful for cases like automated tasks (tests, etc.).
 
 ```js
-var express = require('express')
-var app = express()
+const express = require('express')
+const app = express()
 app.listen(3000)
 ```
 
@@ -30,10 +30,10 @@ your app with the same code base, as the app does not inherit from these
 (it is simply a callback):
 
 ```js
-var express = require('express')
-var https = require('https')
-var http = require('http')
-var app = express()
+const express = require('express')
+const https = require('https')
+const http = require('http')
+const app = express()
 
 http.createServer(app).listen(80)
 https.createServer(options, app).listen(443)

--- a/_includes/api/en/5x/app-mountpath.md
+++ b/_includes/api/en/5x/app-mountpath.md
@@ -7,10 +7,10 @@ The `app.mountpath` property contains one or more path patterns on which a sub-a
 </div>
 
 ```js
-var express = require('express')
+const express = require('express')
 
-var app = express() // the main app
-var admin = express() // the sub app
+const app = express() // the main app
+const admin = express() // the sub app
 
 admin.get('/', function (req, res) {
   console.log(admin.mountpath) // /admin
@@ -27,14 +27,14 @@ If a sub-app is mounted on multiple path patterns, `app.mountpath` returns the l
 patterns it is mounted on, as shown in the following example.
 
 ```js
-var admin = express()
+const admin = express()
 
 admin.get('/', function (req, res) {
   console.log(admin.mountpath) // [ '/adm*n', '/manager' ]
   res.send('Admin Homepage')
 })
 
-var secret = express()
+const secret = express()
 secret.get('/', function (req, res) {
   console.log(secret.mountpath) // /secr*t
   res.send('Admin Secret')

--- a/_includes/api/en/5x/app-onmount.md
+++ b/_includes/api/en/5x/app-onmount.md
@@ -14,7 +14,7 @@ For details, see [Application settings](/en/5x/api.html#app.settings.table).
 </div>
 
 ```js
-var admin = express()
+const admin = express()
 
 admin.on('mount', function (parent) {
   console.log('Admin Mounted')

--- a/_includes/api/en/5x/app-param.md
+++ b/_includes/api/en/5x/app-param.md
@@ -90,8 +90,8 @@ The middleware returned by the function decides the behavior of what happens whe
 In this example, the `app.param(name, callback)` signature is modified to `app.param(name, accessId)`. Instead of accepting a name and a callback, `app.param()` will now accept a name and a number.
 
 ```js
-var express = require('express')
-var app = express()
+const express = require('express')
+const app = express()
 
 // customizing the behavior of app.param()
 app.param(function (param, option) {

--- a/_includes/api/en/5x/app-path.md
+++ b/_includes/api/en/5x/app-path.md
@@ -3,9 +3,9 @@
 Returns the canonical path of the app, a string.
 
 ```js
-var app = express()
-var blog = express()
-var blogAdmin = express()
+const app = express()
+const blog = express()
+const blogAdmin = express()
 
 app.use('/blog', blog)
 blog.use('/admin', blogAdmin)

--- a/_includes/api/en/5x/app-route.md
+++ b/_includes/api/en/5x/app-route.md
@@ -4,7 +4,7 @@ Returns an instance of a single route, which you can then use to handle HTTP ver
 Use `app.route()` to avoid duplicate route names (and thus typo errors).
 
 ```js
-var app = express()
+const app = express()
 
 app.route('/events')
   .all(function (req, res, next) {

--- a/_includes/api/en/5x/app-use.md
+++ b/_includes/api/en/5x/app-use.md
@@ -163,7 +163,7 @@ Even though the examples are for `app.use()`, they are also valid for `app.use()
 </code></pre>
 A router is valid middleware.
 
-<pre><code class="language-js">var router = express.Router();
+<pre><code class="language-js">const router = express.Router();
 router.get('/', function (req, res, next) {
   next();
 });
@@ -171,7 +171,7 @@ app.use(router);
 </code></pre>
 
 An Express app is valid middleware.
-<pre><code class="language-js">var subApp = express();
+<pre><code class="language-js">const subApp = express();
 subApp.get('/', function (req, res, next) {
   next();
 });
@@ -184,12 +184,12 @@ app.use(subApp);
       <td>Series of Middleware</td>
       <td>
         You can specify more than one middleware function at the same mount path.
-<pre><code class="language-js">var r1 = express.Router();
+<pre><code class="language-js">const r1 = express.Router();
 r1.get('/', function (req, res, next) {
   next();
 });
 
-var r2 = express.Router();
+const r2 = express.Router();
 r2.get('/', function (req, res, next) {
   next();
 });
@@ -205,12 +205,12 @@ app.use(r1, r2);
       Use an array to group middleware logically.
       If you pass an array of middleware as the first or only middleware parameters,
       then you <em>must</em> specify the mount path.
-<pre><code class="language-js">var r1 = express.Router();
+<pre><code class="language-js">const r1 = express.Router();
 r1.get('/', function (req, res, next) {
   next();
 });
 
-var r2 = express.Router();
+const r2 = express.Router();
 r2.get('/', function (req, res, next) {
   next();
 });
@@ -227,13 +227,13 @@ app.use('/', [r1, r2]);
 <pre><code class="language-js">function mw1(req, res, next) { next(); }
 function mw2(req, res, next) { next(); }
 
-var r1 = express.Router();
+const r1 = express.Router();
 r1.get('/', function (req, res, next) { next(); });
 
-var r2 = express.Router();
+const r2 = express.Router();
 r2.get('/', function (req, res, next) { next(); });
 
-var subApp = express();
+const subApp = express();
 subApp.get('/', function (req, res, next) { next(); });
 
 app.use(mw1, [mw2, r1, r2], subApp);

--- a/_includes/api/en/5x/app.md
+++ b/_includes/api/en/5x/app.md
@@ -4,8 +4,8 @@ The `app` object conventionally denotes the Express application.
 Create it by calling the top-level `express()` function exported by the Express module:
 
 ```js
-var express = require('express')
-var app = express()
+const express = require('express')
+const app = express()
 
 app.get('/', function (req, res) {
   res.send('hello world')

--- a/_includes/api/en/5x/express.md
+++ b/_includes/api/en/5x/express.md
@@ -3,8 +3,8 @@
 Creates an Express application. The `express()` function is a top-level function exported by the `express` module.
 
 ```js
-var express = require('express')
-var app = express()
+const express = require('express')
+const app = express()
 ```
 
 <h3 id='express.methods'>Methods</h3>

--- a/_includes/api/en/5x/express.router.md
+++ b/_includes/api/en/5x/express.router.md
@@ -3,7 +3,7 @@
 Creates a new [router](#router) object.
 
 ```js
-var router = express.Router([options])
+const router = express.Router([options])
 ```
 
 The optional `options` parameter specifies the behavior of the router.

--- a/_includes/api/en/5x/express.static.md
+++ b/_includes/api/en/5x/express.static.md
@@ -74,7 +74,7 @@ Arguments:
 Here is an example of using the `express.static` middleware function with an elaborate options object:
 
 ```js
-var options = {
+const options = {
   dotfiles: 'ignore',
   etag: false,
   extensions: ['htm', 'html'],

--- a/_includes/api/en/5x/req-baseUrl.md
+++ b/_includes/api/en/5x/req-baseUrl.md
@@ -8,7 +8,7 @@ except `app.mountpath` returns the matched path pattern(s).
 For example:
 
 ```js
-var greet = express.Router()
+const greet = express.Router()
 
 greet.get('/jp', function (req, res) {
   console.log(req.baseUrl) // /greet

--- a/_includes/api/en/5x/req-body.md
+++ b/_includes/api/en/5x/req-body.md
@@ -7,10 +7,10 @@ as [body-parser](https://www.npmjs.org/package/body-parser) and [multer](https:/
 The following example shows how to use body-parsing middleware to populate `req.body`.
 
 ```js
-var app = require('express')()
-var bodyParser = require('body-parser')
-var multer = require('multer') // v1.0.5
-var upload = multer() // for parsing multipart/form-data
+const app = require('express')()
+const bodyParser = require('body-parser')
+const multer = require('multer') // v1.0.5
+const upload = multer() // for parsing multipart/form-data
 
 app.use(bodyParser.json()) // for parsing application/json
 app.use(bodyParser.urlencoded({ extended: true })) // for parsing application/x-www-form-urlencoded

--- a/_includes/api/en/5x/req-range.md
+++ b/_includes/api/en/5x/req-range.md
@@ -17,7 +17,7 @@ An array of ranges will be returned or negative numbers indicating an error pars
 
 ```js
 // parse header from request
-var range = req.range(1000)
+const range = req.range(1000)
 
 // the type of the range
 if (range.type === 'bytes') {

--- a/_includes/api/en/5x/res-sendFile.md
+++ b/_includes/api/en/5x/res-sendFile.md
@@ -44,7 +44,7 @@ Here is an example of using `res.sendFile` with all its arguments.
 
 ```js
 app.get('/file/:name', function (req, res, next) {
-  var options = {
+  const options = {
     root: path.join(__dirname, 'public'),
     dotfiles: 'deny',
     headers: {
@@ -53,7 +53,7 @@ app.get('/file/:name', function (req, res, next) {
     }
   }
 
-  var fileName = req.params.name
+  const fileName = req.params.name
   res.sendFile(fileName, options, function (err) {
     if (err) {
       next(err)
@@ -69,8 +69,8 @@ The following example illustrates using
 
 ```js
 app.get('/user/:uid/photos/:file', function (req, res) {
-  var uid = req.params.uid
-  var file = req.params.file
+  const uid = req.params.uid
+  const file = req.params.file
 
   req.user.mayViewFilesFrom(uid, function (yes) {
     if (yes) {

--- a/_includes/api/en/5x/router-METHOD.md
+++ b/_includes/api/en/5x/router-METHOD.md
@@ -35,8 +35,8 @@ as "GET /commits/71dbb9c..4c084f9".
 
 ```js
 router.get(/^\/commits\/(\w+)(?:\.\.(\w+))?$/, function (req, res) {
-  var from = req.params[0]
-  var to = req.params[1] || 'HEAD'
+  const from = req.params[0]
+  const to = req.params[1] || 'HEAD'
   res.send('commit range ' + from + '..' + to)
 })
 ```

--- a/_includes/api/en/5x/router-param.md
+++ b/_includes/api/en/5x/router-param.md
@@ -74,9 +74,9 @@ The middleware returned by the function decides the behavior of what happens whe
 In this example, the `router.param(name, callback)` signature is modified to `router.param(name, accessId)`. Instead of accepting a name and a callback, `router.param()` will now accept a name and a number.
 
 ```js
-var express = require('express')
-var app = express()
-var router = express.Router()
+const express = require('express')
+const app = express()
+const router = express.Router()
 
 // customizing the behavior of router.param()
 router.param(function (param, option) {

--- a/_includes/api/en/5x/router-route.md
+++ b/_includes/api/en/5x/router-route.md
@@ -8,7 +8,7 @@ Building on the `router.param()` example above, the following code shows how to 
 `router.route()` to specify various HTTP method handlers.
 
 ```js
-var router = express.Router()
+const router = express.Router()
 
 router.param('user_id', function (req, res, next, id) {
   // sample user, would actually fetch from DB, etc...

--- a/_includes/api/en/5x/router-use.md
+++ b/_includes/api/en/5x/router-use.md
@@ -9,9 +9,9 @@ Middleware is like a plumbing pipe: requests start at the first middleware funct
 and work their way "down" the middleware stack processing for each path they match.
 
 ```js
-var express = require('express')
-var app = express()
-var router = express.Router()
+const express = require('express')
+const app = express()
+const router = express.Router()
 
 // simple logger for this router's requests
 // all requests to this router will first hit this middleware
@@ -45,7 +45,7 @@ They are invoked sequentially, thus the order defines middleware precedence. For
 usually a logger is the very first middleware you would use, so that every request gets logged.
 
 ```js
-var logger = require('morgan')
+const logger = require('morgan')
 
 router.use(logger())
 router.use(express.static(path.join(__dirname, 'public')))
@@ -84,8 +84,8 @@ middleware added via one router may run for other routers if its routes
 match. For example, this code shows two different routers mounted on the same path:
 
 ```js
-var authRouter = express.Router()
-var openRouter = express.Router()
+const authRouter = express.Router()
+const openRouter = express.Router()
 
 authRouter.use(require('./authenticate').basic(usersdb))
 


### PR DESCRIPTION
This update the code samples in 5.x alpha documentation to use the modern keyword `const` instead of `var`

Please review @crandmck @dougwilson :)