### PR TITLE
Updates to community page

### DIFF
--- a/en/resources/community.md
+++ b/en/resources/community.md
@@ -8,60 +8,67 @@ redirect_from: "/resources/community.html"
 
 # Community
 
-## Mailing List
-
-Join over 2000 Express users or browse over 5000
-discussions in the [Google Group](https://groups.google.com/group/express-js).
-
-## Gitter
-
-The [expressjs/express chatroom](https://gitter.im/expressjs/express) is great place
-for developers interested in the everyday discussions related to Express.
-
-## IRC channel
-
-Hundreds of developers idle in #express on freenode every day.
-If you have questions about the framework, jump in for quick
-feedback.
-
-## Issues
-
-If you've come across what you think is a bug, or just want to make
-a feature request open a ticket in the [issue queue](https://github.com/expressjs/express/issues).
-
 ## Technical committee
 
-The Express technical committee meets online every two weeks to discuss development and maintenance of Express, and other issues relevant to the Express project.
-Each meeting is typically announced in an [expressjs/discussions issue](https://github.com/expressjs/discussions/issues) with a link to the Google Hangout, which is
+The Express technical committee meets online every two weeks (as needed) to discuss development and maintenance of Express,
+and other issues relevant to the Express project. Each meeting is typically announced in an
+[expressjs/discussions issue](https://github.com/expressjs/discussions/issues) with a link to join or view the meeting, which is
 open to all observers.
 
 The meetings are recorded; for a list of the recordings, see the [Express.js YouTube channel](https://www.youtube.com/channel/UCYjxjAeH6TRik9Iwy5nXw7g).
 
 Members of the Express technical committee are:
 
+**Active:**
+
 - [@blakeembrey](https://github.com/blakeembrey) - Blake Embrey
 - [@crandmck](https://github.com/crandmck) - Rand McKinney
 - [@dougwilson](https://github.com/dougwilson) - Douglas Wilson
+- [@LinusU](https://github.com/LinusU) - Linus Unnebäck
+- [@wesleytodd](https://github.com/wesleytodd) - Wes Todd
+
+**Inactive:**
+
 - [@hacksparrow](https://github.com/hacksparrow) - Hage Yaapa
 - [@jonathanong](https://github.com/jonathanong) - jongleberry
-- [@LinusU](https://github.com/LinusU) - Linus Unnebäck
 - [@niftylettuce](https://github.com/niftylettuce) - niftylettuce
 - [@troygoode](https://github.com/troygoode) - Troy Goode
 
-## Examples
-
-View dozens of Express application [examples](https://github.com/expressjs/express/tree/master/examples)
-in the repository covering everything from API design and authentication to template engine integration.
-
-## Other modules
+## Express is made of many modules
 
 Our vibrant community has created a large variety of extensions,
 [middleware modules](/{{ page.lang }}/resources/middleware.html) and
-[higher-level frameworks](frameworks.html).  
+[higher-level frameworks](frameworks.html).
 
 Additionally, the Express community maintains modules in these two GitHub orgs:
 
 - [jshttp](https://jshttp.github.io/) modules providing useful utility functions; see [Utility modules](/{{ page.lang }}/resources/utils.html).
 - [pillarjs](https://pillarjs.github.io/): low-level modules that Express uses internally.
 
-See also the [Express wiki](https://github.com/expressjs/express/wiki).
+To keep up with what is going on in the whole community, check out the [ExpressJS StatusBoard](https://expressjs.github.com/statusboard).
+
+## Gitter
+
+The [expressjs/express chatroom](https://gitter.im/expressjs/express) is great place
+for developers interested in the everyday discussions related to Express.
+
+## Issues
+
+If you've come across what you think is a bug, or just want to make
+a feature request open a ticket in the [issue queue](https://github.com/expressjs/express/issues).
+
+## Examples
+
+View dozens of Express application [examples](https://github.com/expressjs/express/tree/master/examples)
+in the repository covering everything from API design and authentication to template engine integration.
+
+## Mailing List
+
+Join over 2000 Express users or browse over 5000
+discussions in the [Google Group](https://groups.google.com/group/express-js).
+
+## IRC channel
+
+Hundreds of developers idle in #express on freenode every day.
+If you have questions about the framework, jump in for quick
+feedback.


### PR DESCRIPTION
The community page was pretty out of date.  I did a few things:

1. Moved the older and less active community sections to the bottom
2. Moved the TC section to the top as that is the most active part
3. Broke the TC into active and inactive members (adding myself)
4. Added a link to the StatusBoard

The idea behind the `inactive` and `active` sections was more about participation in the TC meetings, not necessarily their "activity" on the repos.  Do people think this is a reasonable change?