### PR TITLE
Fixed a typo in router.md

### DIFF
--- a/_includes/api/en/4x/router.md
+++ b/_includes/api/en/4x/router.md
@@ -2,7 +2,7 @@
 
 <section markdown="1">
 A `router` object is an isolated instance of middleware and routes. You can think of it
-as a "mini-application," capable only of performing middleware and routing
+as a "mini-application", capable only of performing middleware and routing
 functions. Every Express application has a built-in app router.
 
 A router behaves like middleware itself, so you can use it as an argument to


### PR DESCRIPTION
There's a small change proposed by me: the comma after "mini-application" was in the quotes.
I've fixed that.