### PR TITLE
Update req-secure header and excerpt

### DIFF
--- a/_includes/api/en/5x/req-secure.md
+++ b/_includes/api/en/5x/req-secure.md
@@ -1,5 +1,8 @@
- A Boolean property that is true if a TLS connection is established. Equivalent to: 
+<h3 id='req.secure'>req.secure</h3>
  
+A Boolean property that is true if a TLS connection is established. Equivalent to the following:
+
+<!-- eslint-disable no-unused-expressions -->
 ```js
-req.protocol == 'https';
+req.protocol === 'https'
 ```


### PR DESCRIPTION
Based on behavior of current site, it looks like req-secure ought to have the header reinstated. Also, es-lint fails with the JS block-style example for a few reasons, most importantly the "unused expression". For this example, I opted to just have a single line instead of the block-style code, which I am not sure could be made acceptable to es-lint without a less attractive option like introducing a variable (e.g. assign the result of the expression to isSecure...)