### PR TITLE
Remove link that points to inactive/malicious domain

### DIFF
--- a/de/resources/books-blogs.md
+++ b/de/resources/books-blogs.md
@@ -40,7 +40,6 @@ texxtoor, September 2015. In deutscher Sprache / in German language
 - [StrongLoop Blog: Express category](http://strongloop.com/strongblog/category/express/)
 - [Hage Yaapa's Blog: Express category](http://www.hacksparrow.com/category/express-js)
 - [Codeforgeek Blog: Express category](http://codeforgeek.com/code/nodejs/express/)
-- [Node-tricks Blog: Express category](http://node-tricks.com/category/express/)
 
 ### Add your blog here!
 

--- a/en/resources/books-blogs.md
+++ b/en/resources/books-blogs.md
@@ -49,7 +49,6 @@ self-published, February 2018.
 - [StrongLoop Blog: Express category](https://strongloop.com/strongblog/tag_Express.html)
 - [Hage Yaapa's Blog: Express category](http://www.hacksparrow.com/category/express-js)
 - [Codeforgeek Blog: Express category](http://codeforgeek.com/code/nodejs/express/)
-- [Node-tricks Blog: Express category](http://node-tricks.com/category/express/)
 - [Baboon Blog: Express category](http://www.baboon.ir/tutorials/expressjs/) (Persian language)
 - [Techforgeek Blog: Express category](http://techforgeek.com/expressjs/)
 - [RoseHosting.com Blog: Express tag](https://www.rosehosting.com/blog/tag/express/)

--- a/es/resources/books-blogs.md
+++ b/es/resources/books-blogs.md
@@ -40,7 +40,6 @@ texxtoor, September 2015. In deutscher Sprache / in German language
 - [StrongLoop Blog: Express category](http://strongloop.com/strongblog/category/express/)
 - [Hage Yaapa's Blog: Express category](http://www.hacksparrow.com/category/express-js)
 - [Codeforgeek Blog: Express category](http://codeforgeek.com/code/nodejs/express/)
-- [Node-tricks Blog: Express category](http://node-tricks.com/category/express/)
 
 ### Add your blog here!
 

--- a/fr/resources/books-blogs.md
+++ b/fr/resources/books-blogs.md
@@ -40,7 +40,6 @@ texxtoor, September 2015. In deutscher Sprache / in German language
 - [StrongLoop Blog: Express category](http://strongloop.com/strongblog/category/express/)
 - [Hage Yaapa's Blog: Express category](http://www.hacksparrow.com/category/express-js)
 - [Codeforgeek Blog: Express category](http://codeforgeek.com/code/nodejs/express/)
-- [Node-tricks Blog: Express category](http://node-tricks.com/category/express/)
 
 ### Add your blog here!
 

--- a/ko/resources/books-blogs.md
+++ b/ko/resources/books-blogs.md
@@ -40,7 +40,6 @@ texxtoor, September 2015. In deutscher Sprache / in German language
 - [StrongLoop Blog: Express category](http://strongloop.com/strongblog/category/express/)
 - [Hage Yaapa's Blog: Express category](http://www.hacksparrow.com/category/express-js)
 - [Codeforgeek Blog: Express category](http://codeforgeek.com/code/nodejs/express/)
-- [Node-tricks Blog: Express category](http://node-tricks.com/category/express/)
 
 ### Add your blog here!
 

--- a/pt-br/resources/books-blogs.md
+++ b/pt-br/resources/books-blogs.md
@@ -32,7 +32,6 @@ Aqui estão alguns dos vários livros sobre Express:
 - [StrongLoop Blog: Express category](http://strongloop.com/strongblog/category/express/)
 - [Hage Yaapa's Blog: Express category](http://www.hacksparrow.com/category/express-js)
 - [Codeforgeek Blog: Express category](http://codeforgeek.com/code/nodejs/express/)
-- [Node-tricks Blog: Express category](http://node-tricks.com/category/express/)
 
 ### Adicione seu blog aqui!
 

--- a/ru/resources/books-blogs.md
+++ b/ru/resources/books-blogs.md
@@ -40,7 +40,6 @@ texxtoor, September 2015. In deutscher Sprache / in German language
 - [StrongLoop Blog: Express category](http://strongloop.com/strongblog/category/express/)
 - [Hage Yaapa's Blog: Express category](http://www.hacksparrow.com/category/express-js)
 - [Codeforgeek Blog: Express category](http://codeforgeek.com/code/nodejs/express/)
-- [Node-tricks Blog: Express category](http://node-tricks.com/category/express/)
 
 ### Add your blog here!
 

--- a/sk/resources/books-blogs.md
+++ b/sk/resources/books-blogs.md
@@ -44,7 +44,6 @@ texxtoor, September 2015. In deutscher Sprache / in German language
 - [StrongLoop Blog: Express category](http://strongloop.com/strongblog/category/express/)
 - [Hage Yaapa's Blog: Express category](http://www.hacksparrow.com/category/express-js)
 - [Codeforgeek Blog: Express category](http://codeforgeek.com/code/nodejs/express/)
-- [Node-tricks Blog: Express category](http://node-tricks.com/category/express/)
 - [Baboon Blog: Express category](http://www.baboon.ir/tutorials/expressjs/) (Persian language)
 
 ### Pridajte váš blog!

--- a/uk/resources/books-blogs.md
+++ b/uk/resources/books-blogs.md
@@ -40,7 +40,6 @@ texxtoor, September 2015. In deutscher Sprache / in German language
 - [StrongLoop Blog: Express category](http://strongloop.com/strongblog/category/express/)
 - [Hage Yaapa's Blog: Express category](http://www.hacksparrow.com/category/express-js)
 - [Codeforgeek Blog: Express category](http://codeforgeek.com/code/nodejs/express/)
-- [Node-tricks Blog: Express category](http://node-tricks.com/category/express/)
 - [Baboon Blog: Express category](http://www.baboon.ir/tutorials/expressjs/) (Persian language)
 
 ### Add your blog here!

--- a/uz/resources/books-blogs.md
+++ b/uz/resources/books-blogs.md
@@ -35,7 +35,6 @@ Pack Publishing, June 2013.
 - [StrongLoop Blog: Express category](http://strongloop.com/strongblog/category/express/)
 - [Hage Yaapa's Blog: Express category](http://www.hacksparrow.com/category/express-js)
 - [Codeforgeek Blog: Express category](http://codeforgeek.com/code/nodejs/express/)
-- [Node-tricks Blog: Express category](http://node-tricks.com/category/express/)
 
 ### Add your blog here!
 

--- a/zh-cn/resources/books-blogs.md
+++ b/zh-cn/resources/books-blogs.md
@@ -40,7 +40,6 @@ texxtoor, September 2015. In deutscher Sprache / in German language
 - [StrongLoop Blog: Express category](http://strongloop.com/strongblog/category/express/)
 - [Hage Yaapa's Blog: Express category](http://www.hacksparrow.com/category/express-js)
 - [Codeforgeek Blog: Express category](http://codeforgeek.com/code/nodejs/express/)
-- [Node-tricks Blog: Express category](http://node-tricks.com/category/express/)
 
 ### Add your blog here!
 

--- a/zh-tw/resources/books-blogs.md
+++ b/zh-tw/resources/books-blogs.md
@@ -40,7 +40,6 @@ texxtoor, September 2015. In deutscher Sprache / in German language
 - [StrongLoop Blog: Express category](http://strongloop.com/strongblog/category/express/)
 - [Hage Yaapa's Blog: Express category](http://www.hacksparrow.com/category/express-js)
 - [Codeforgeek Blog: Express category](http://codeforgeek.com/code/nodejs/express/)
-- [Node-tricks Blog: Express category](http://node-tricks.com/category/express/)
 
 ### Add your blog here!
 


### PR DESCRIPTION
This removes links in all translations (and all occurrences on the site so far as `sed` could tell) to a now defunct `node-tricks.com` URL which was serving up some phishing content.

I discussed this at #1100 