### PR TITLE
Remove "Add your company" copy

### DIFF
--- a/en/resources/companies-using-express.md
+++ b/en/resources/companies-using-express.md
@@ -76,6 +76,3 @@ redirect_from: "/resources/companies-using-express.html"
       <img alt="kuali" class="memberlogo" src="/images/companies/kuali-logo.png" />
     </a>
 </div>
-<p style="margin-top: 30px;">
-To add your logo to this page, please <a href="https://github.com/expressjs/expressjs.com/blob/gh-pages/en/resources/companies-using-express.md">open a pull request</a>.
-</p>

--- a/sk/resources/companies-using-express.md
+++ b/sk/resources/companies-using-express.md
@@ -58,6 +58,3 @@ lang: sk
       <img alt="kuali" class="memberlogo" src="/images/companies/kuali-logo.png" />
     </a>
 </div>
-
-Ak vaša firma používa Express, dajte nám vedieť:
-[callback@us.ibm.com](mailto:callback@us.ibm.com).

--- a/th/resources/companies-using-express.md
+++ b/th/resources/companies-using-express.md
@@ -75,6 +75,3 @@ lang: th
       <img alt="kuali" class="memberlogo" src="/images/companies/kuali-logo.png" />
     </a>
 </div>
-<p style="margin-top: 30px;">
-To add your logo to this page, please <a href="https://github.com/expressjs/expressjs.com/blob/gh-pages/en/resources/companies-using-express.md">open a pull request</a>.
-</p>

--- a/tr/resources/companies-using-express.md
+++ b/tr/resources/companies-using-express.md
@@ -60,7 +60,4 @@ lang: tr
       <img alt="kuali" class="memberlogo" src="/images/companies/kuali-logo.png" />
     </a>
 </div>
-<p style="margin-top: 30px;">
-To add your logo to this page, please <a href="https://github.com/expressjs/expressjs.com/blob/gh-pages/en/resources/companies-using-express.md">open a pull request</a>.
-</p>
 </div>


### PR DESCRIPTION
Removes the copy inviting folks to add their company to the "Companies using Express" page.

Related #1112 expressjs/discussions#105