### PR TITLE
Correcting path example to be consistent w/h description

### DIFF
--- a/en/guide/using-middleware.md
+++ b/en/guide/using-middleware.md
@@ -204,7 +204,7 @@ router.use(function (req, res, next) {
   next()
 })
 
-router.get('/', function (req, res) {
+router.get('/user/:id', function (req, res) {
   res.send('hello, user!')
 })
 


### PR DESCRIPTION
Description (line 195) mentions GET fetching `user/:id`, yet code example  shows  GET fetching `/`. 
Adding in  `user/:id` to code example.