### PR TITLE
fix table style to block so as not to overflow into surrounding text

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1149,7 +1149,7 @@ h2 a {
 
 .callout {position: relative;}
 
-#mw-fig { padding: 0; border: 0; width: 960px; margin-bottom: 20px;}
+#mw-fig { border-collapse: separate; padding: 0; border: 0; width: 960px; margin-bottom: 20px;}
 #mw-fig-imgcell {margin: 0; padding: 0px; border: 0; width: 410px;}
 #mw-fig-img {margin: 0px; padding: 0px; width: 410px; height: 308px;}
 .mw-fig-callouts {margin: 0; padding: 0 0 0 5px; border: 0; width: 550px;}


### PR DESCRIPTION
Had a hard time reading the Overview section at http://expressjs.com/en/guide/writing-middleware.html#mw-fig because the diagram was overflowing and hiding the preceding paragraphs.

**This is what it currently looks like:**
<img width="977" alt="Screen Shot 2020-04-09 at 9 57 10 PM" src="https://user-images.githubusercontent.com/35355900/78956442-4a716680-7ab0-11ea-85df-923f132e2428.png">
**And this is what the change affects:**
<img width="1085" alt="Screen Shot 2020-04-09 at 9 57 26 PM" src="https://user-images.githubusercontent.com/35355900/78956451-5a894600-7ab0-11ea-8bd6-1290a194163c.png">

Notice: the diagram no longer overflows or obfuscates the two preceding lines of text.