### PR TITLE
Add Eta to list of template engines

### DIFF
--- a/en/resources/template-engines.md
+++ b/en/resources/template-engines.md
@@ -17,6 +17,7 @@ These template engines work "out-of-the-box" with Express:
 - **[EJS](https://github.com/tj/ejs)**: Embedded JavaScript template engine.
 - **[hbs](https://github.com/pillarjs/hbs)**: Adapter for Handlebars.js, an extension of Mustache.js template engine.
 - **[Squirrelly](https://github.com/squirrellyjs/squirrelly)**: Blazing-fast template engine that supports partials, helpers, custom tags, filters, and caching. Not white-space sensitive, works with any language.
+- **[Eta](https://github.com/eta-dev/eta)**: Super-fast lightweight embedded JS template engine. Supports custom delimiters, async, whitespace control, partials, caching, plugins.
 - **[React](https://github.com/reactjs/express-react-views)**: Renders React components on the server. It renders static markup and does not support mounting those views on the client.
 - **[h4e](https://github.com/louischatriot/h4e)**: Adapter for Hogan.js, with support for partials and layouts.
 - **[hulk-hogan](https://github.com/quangv/hulk-hogan)**: Adapter for Twitter's Hogan.js (Mustache syntax), with support for Partials.


### PR DESCRIPTION
I added an embedded JS template engine of mine called Eta. Since Eta is built off the same underlying code as Squirrelly, I figured the positioning made sense?

See #1139