### PR TITLE
doc: when 'trust proxy' = true, req.ip stays a single ip

### DIFF
--- a/en/guide/behind-proxies.md
+++ b/en/guide/behind-proxies.md
@@ -84,7 +84,7 @@ Enabling `trust proxy` will have the following impact:
   </li>
   <li markdown="1">`X-Forwarded-Proto` can be set by the reverse proxy to tell the app whether it is `https` or  `http` or even an invalid name. This value is reflected by [req.protocol](/{{ page.lang }}/api.html#req.protocol).
   </li>
-  <li markdown="1">The [req.ip](/{{ page.lang }}/api.html#req.ip) and [req.ips](/{{ page.lang }}/api.html#req.ips) values are populated with the list of addresses from `X-Forwarded-For`.
+  <li markdown="1">The [req.ip](/{{ page.lang }}/api.html#req.ip) and [req.ips](/{{ page.lang }}/api.html#req.ips) values are populated based on the socket address and `X-Forwarded-For` header, starting at the first untrusted address.
   </li>
 </ul>
 


### PR DESCRIPTION
Before this change, the documentation stated that with 'trust proxy' set, both
req.ip and req.ips would be populated with the list of addresses from
X-Forwarded-For header.

This is true only for req.ips, while req.ip will only get the left-most entry.