### PR TITLE
Fix inconsistency in the documentation of req.accepts

### DIFF
--- a/_includes/api/en/4x/req-accepts.md
+++ b/_includes/api/en/4x/req-accepts.md
@@ -26,7 +26,7 @@ req.accepts('application/json')
 // Accept: text/*, application/json
 req.accepts('image/png')
 req.accepts('png')
-// => undefined
+// => false
 
 // Accept: text/*;q=.5, application/json
 req.accepts(['html', 'json'])

--- a/_includes/api/en/5x/req-accepts.md
+++ b/_includes/api/en/5x/req-accepts.md
@@ -26,7 +26,7 @@ req.accepts('application/json')
 // Accept: text/*, application/json
 req.accepts('image/png')
 req.accepts('png')
-// => undefined
+// => false
 
 // Accept: text/*;q=.5, application/json
 req.accepts(['html', 'json'])


### PR DESCRIPTION
According to the description above the example and to the [accepts](https://github.com/jshttp/accepts) documentation, `req.accepts` returns `false` when no types match. This is also the behavior that we observe when running the example.