### PR TITLE
Update the footers to point at the OpenJS Foundation.

### DIFF
--- a/_includes/footer/footer-de.html
+++ b/_includes/footer/footer-de.html
@@ -5,8 +5,8 @@
         <div id="github">
             <iframe src="//ghbtns.com/github-btn.html?user=expressjs&amp;repo=express&amp;type=watch&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe>
         </div>
-        <div id="sponsor"><a href="https://github.com/expressjs/express">Express</a> ist ein Projekt der Stiftung Node.js.</div>
-        <div id="fork"><a href="https://github.com/expressjs/expressjs.com">Website auf GitHub forken</a>. </div>
+        <div id="sponsor"><a href="https://expressjs.com">Express</a> ist ein Projekt der <a href="https://openjsf.org">Stiftung OpenJS</a>.</div>
+        <div id="fork"><a href="https://github.com/expressjs/expressjs.com">Website auf GitHub forken</a>.</div>
         <div>Copyright &copy; StrongLoop, Inc. und andere Mitwirkende an expressjs.com.</div>
     </div>
     <div id="license">

--- a/_includes/footer/footer-en.html
+++ b/_includes/footer/footer-en.html
@@ -1,4 +1,5 @@
 <a id="top" href="#"><img src="/images/arrow.png"></a>
+
 <footer>
   <section id="doc-langs">
   Documentation translations provided by <a href="http://strongloop.com">StrongLoop/IBM</a>:
@@ -6,15 +7,12 @@
   <br>
   Community translation available for: <a href="/sk/">Slovak</a>, <a href="/uk/">Ukrainian</a>, <a href="/uz/">Uzbek</a>, <a href="/tr/">Turkish</a> and <a href="/th/">Thai</a>.
   </section>
-
   <div id="footer-content">
       <div id="github">
         <a class="github-button" href="https://github.com/expressjs/expressjs.com" data-icon="octicon-star" aria-label="Star expressjs/expressjs.com on GitHub">Star</a>
       </div>
-      <div id="sponsor"><a href="https://github.com/expressjs/express/">Express</a>
-          is a project of the <a href="http://nodejs.org/foundation"></a>Node.js Foundation</a>.</div>
-      <div id="fork"><a href="https://github.com/expressjs/expressjs.com">Fork the website on GitHub</a>.
-      </div>
+      <div id="sponsor"><a href="https://expressjs.com">Express</a> is a project of the <a href="https://openjsf.org">OpenJS Foundation</a>.</div>
+      <div id="fork"><a href="https://github.com/expressjs/expressjs.com">Fork the website on GitHub</a>.</div>
       <div>Copyright &copy; 2017 StrongLoop, IBM, and other expressjs.com contributors.</div>
   </div>
   <div id="license">

--- a/_includes/footer/footer-es.html
+++ b/_includes/footer/footer-es.html
@@ -5,10 +5,8 @@
         <div id="github">
             <iframe src="//ghbtns.com/github-btn.html?user=expressjs&amp;repo=express&amp;type=watch&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe>
         </div>
-        <div id="sponsor"><a href="https://github.com/expressjs/express">Express</a> es un proyecto de la Fundación Node.js.</div>
-
-        <div id="fork"><a href="https://github.com/expressjs/expressjs.com">Bifurque el sitio web en GitHub</a>.
-        </div>
+        <div id="sponsor"><a href="https://expressjs.com">Express</a> es un proyecto de la <a href="https://openjsf.org">Fundación OpenJS</a>.</div>
+        <div id="fork"><a href="https://github.com/expressjs/expressjs.com">Bifurque el sitio web en GitHub</a>.</div>
         <div>Copyright &copy; StrongLoop, Inc. y otros colaboradores de expressjs.com.</div>
     </div>
     <div id="license">

--- a/_includes/footer/footer-fr.html
+++ b/_includes/footer/footer-fr.html
@@ -5,9 +5,8 @@
         <div id="github">
             <iframe src="//ghbtns.com/github-btn.html?user=expressjs&amp;repo=express&amp;type=watch&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe>
         </div>
-        <div id="sponsor"><a href="https://github.com/expressjs/express">Express</a> est un projet de la Fondation Node.js. </div>
-        <div id="fork"><a href="https://github.com/expressjs/expressjs.com">Consultez le site Web GitHub</a>.
-        </div>
+        <div id="sponsor"><a href="https://expressjs.com">Express</a> est un projet de la <a href="https://openjsf.org">Fondation OpenJS</a>.</div>
+        <div id="fork"><a href="https://github.com/expressjs/expressjs.com">Consultez le site Web GitHub</a>.</div>
         <div>Copyright &copy; StrongLoop, Inc., et autres contributeurs expressjs.com.</div>
     </div>
     <div id="license">

--- a/_includes/footer/footer-it.html
+++ b/_includes/footer/footer-it.html
@@ -5,9 +5,8 @@
         <div id="github">
             <iframe src="//ghbtns.com/github-btn.html?user=expressjs&amp;repo=express&amp;type=watch&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe>
         </div>
-        <div id="sponsor"><a href="https://github.com/expressjs/express">Express</a> è un progetto della Fondazione Node.js.</div>
-        <div id="fork"><a href="https://github.com/expressjs/expressjs.com">Avviare il sito web su GitHub</a>.
-        </div>
+        <div id="sponsor"><a href="https://expressjs.com">Express</a> è un progetto della <a href="https://openjsf.org">Fondazione OpenJS</a>.</div>
+        <div id="fork"><a href="https://github.com/expressjs/expressjs.com">Avviare il sito web su GitHub</a>.</div>
         <div>Copyright &copy; StrongLoop, Inc. e altri contributor di expressjs.com.</div>
     </div>
     <div id="license">

--- a/_includes/footer/footer-ja.html
+++ b/_includes/footer/footer-ja.html
@@ -5,7 +5,7 @@
         <div id="github">
             <iframe src="//ghbtns.com/github-btn.html?user=expressjs&amp;repo=express&amp;type=watch&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe>
         </div>
-        <div id="sponsor"><a href="https://github.com/expressjs/express">Express</a>は、Node.jsの財団のプロジェクトです</div>
+        <div id="sponsor"><a href="https://expressjs.com">Express</a>は、<a href="https://openjsf.org">OpenJSの財団</a>のプロジェクトです。</div>
         <div id="fork"><a href="https://github.com/expressjs/expressjs.com">GitHub で Web サイトを fork します</a>。</div>
         <div>Copyright &copy; StrongLoop, Inc.、およびその他の expressjs.com コントリビューター。</div>
     </div>

--- a/_includes/footer/footer-ko.html
+++ b/_includes/footer/footer-ko.html
@@ -5,13 +5,12 @@
         <div id="github">
             <iframe src="//ghbtns.com/github-btn.html?user=expressjs&amp;repo=express&amp;type=watch&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe>
         </div>
-        <div id="sponsor"><a href="https://github.com/expressjs/express">Express</a>는 Node.js 기반의 프로젝트입니다.</div>
-        <div id="fork"><a href="https://github.com/expressjs/expressjs.com">GitHub에서 웹사이트의 포크를 작성하십시오</a>.
-        </div>
+        <div id="sponsor"><a href="https://expressjs.com">Express</a>는 <a href="https://openjsf.org">OpenJS 기반의</a> 프로젝트입니다.</div>
+        <div id="fork"><a href="https://github.com/expressjs/expressjs.com">GitHub에서 웹사이트의 포크를 작성하십시오</a>.</div>
         <div>Copyright &copy; StrongLoop, Inc., and other expressjs.com contributors.</div>
     </div>
     <div id="license">
-<a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/"><img alt="크리에이티브 커먼즈 라이선스" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/3.0/us/80x15.png" /></a> 이 저작물은 <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/">크리에이티브 커먼즈 저작자표시-동일조건변경허락 3.0 미국 라이선스</a>에 따라 이용할 수 있습니다.
+        <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/"><img alt="크리에이티브 커먼즈 라이선스" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/3.0/us/80x15.png" /></a> 이 저작물은 <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/">크리에이티브 커먼즈 저작자표시-동일조건변경허락 3.0 미국 라이선스</a>에 따라 이용할 수 있습니다.
     </div>
 </footer>
 

--- a/_includes/footer/footer-pt-br.html
+++ b/_includes/footer/footer-pt-br.html
@@ -5,15 +5,12 @@
         <div id="github">
             <iframe src="//ghbtns.com/github-btn.html?user=expressjs&amp;repo=express&amp;type=watch&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe>
         </div>
-        <div id="sponsor"><a href="https://github.com/expressjs/express">Express</a> é um projeto da Fundação Node.js.</div>
-        <div id="fork">
-<a href="https://github.com/expressjs/expressjs.com">Crie um Fork do website no GitHub</a>.
-        </div>
-        <div>Copyright &copy; StrongLoop, Inc., e outros
-contribuidores do expressjs.com.</div>
+        <div id="sponsor"><a href="https://expressjs.com">Express</a> é um projeto da <a href="https://openjsf.org">Fundação Node.js</a>.</div>
+        <div id="fork"><a href="https://github.com/expressjs/expressjs.com">Crie um Fork do website no GitHub</a>.</div>
+        <div>Copyright &copy; StrongLoop, Inc., e outros contribuidores do expressjs.com.</div>
+    </div>
     <div id="license">
         <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/"><img alt="Licença Creative Commons" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/3.0/us/80x15.png" /></a> Este obra está licenciado com uma Licença <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/">Creative Commons Atribuição-CompartilhaIgual 3.0 Estados Unidos</a>.
-    </div>
     </div>
 </footer>
 

--- a/_includes/footer/footer-ru.html
+++ b/_includes/footer/footer-ru.html
@@ -5,13 +5,12 @@
         <div id="github">
             <iframe src="//ghbtns.com/github-btn.html?user=expressjs&amp;repo=express&amp;type=watch&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe>
         </div>
-        <div id="sponsor"><a href="https://github.com/expressjs/express">Express</a> проект Фонда Node.js.</div>
-        <div id="fork"><a href="https://github.com/expressjs/expressjs.com">Создайте клон веб-сайта на GitHub</a>.
-        </div>
+        <div id="sponsor"><a href="https://expressjs.com">Express</a> проект <a href="https://openjsf.org">фонда OpenJS</a>.</div>
+        <div id="fork"><a href="https://github.com/expressjs/expressjs.com">Создайте клон веб-сайта на GitHub</a>.</div>
         <div>Copyright &copy; StrongLoop, Inc. и других участников expressjs.com.</div>
     </div>
     <div id="license">
-<a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/"><img alt="Лицензия Creative Commons" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/3.0/us/80x15.png" /></a> Это произведение доступно по <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/">лицензии Creative Commons «Attribution-ShareAlike» («Атрибуция — На тех же условиях») 3.0 США</a>.
+        <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/"><img alt="Лицензия Creative Commons" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/3.0/us/80x15.png" /></a> Это произведение доступно по <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/">лицензии Creative Commons «Attribution-ShareAlike» («Атрибуция — На тех же условиях») 3.0 США</a>.
     </div>
 </footer>
 

--- a/_includes/footer/footer-sk.html
+++ b/_includes/footer/footer-sk.html
@@ -1,20 +1,17 @@
 <a id="top" href="#"><img src="/images/arrow.png"></a>
+
 <footer>
     <div id="footer-content">
         <div id="github">
             <iframe src="https://ghbtns.com/github-btn.html?user=expressjs&repo=express&type=star&count=true" frameborder="0" scrolling="0" width="200px" height="20px"></iframe>
         </div>
-        <div id="sponsor">
-            <a href="https://github.com/expressjs/express/">Express</a> je projekt patriaci pod <a href="http://nodejs.org/foundation"></a>Node.js Foundation</a>.
-        </div>
-        <div id="fork">
-            <a href="https://github.com/expressjs/expressjs.com">Editovať stránku na GitHub-e</a>.
-        </div>
+        <div id="sponsor"><a href="https://expressjs.com">Express</a> je projekt patriaci pod <a href="https://openjsf.org">Nadácie OpenJS</a>.</div>
+        <div id="fork"><a href="https://github.com/expressjs/expressjs.com">Editovať stránku na GitHub-e</a>.</div>
         <div>Copyright &copy; 2016 StrongLoop, IBM a ostatní expressjs.com prispievatelia.</div>
     </div>
     <div id="license">
         <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/3.0/us/80x15.png" /></a> This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/">Creative Commons Attribution-ShareAlike 3.0 United States License</a>.
-    </div>     
+    </div>
 </footer>
 
 {% include footer/_docsearch.html %}

--- a/_includes/footer/footer-th.html
+++ b/_includes/footer/footer-th.html
@@ -1,14 +1,12 @@
 <a id="top" href="#"><img src="/images/arrow.png"></a>
-<footer>
 
+<footer>
   <div id="footer-content">
       <div id="github">
         <a class="github-button" href="https://github.com/expressjs/expressjs.com" data-icon="octicon-star" aria-label="Star expressjs/expressjs.com on GitHub">Star</a>
       </div>
-      <div id="sponsor"><a href="https://github.com/expressjs/express/">Express</a>
-          เป็นโครงการของ <a href="http://nodejs.org/foundation"></a>มูลนิธิ Node.js</a>.</div>
-      <div id="fork"><a href="https://github.com/expressjs/expressjs.com">Fork เว็บไซต์บน GitHub</a>.
-      </div>
+      <div id="sponsor"><a href="https://expressjs.com">Express</a> เป็นโครงการของ <a href="https://openjsf.org">มูลนิธิ OpenJS</a>.</div>
+      <div id="fork"><a href="https://github.com/expressjs/expressjs.com">Fork เว็บไซต์บน GitHub</a>.</div>
       <div>Copyright &copy; 2017 StrongLoop, IBM, และผู้มีส่วนร่วมอื่นๆ ของ expressjs.com.</div>
   </div>
   <div id="license">

--- a/_includes/footer/footer-tr.html
+++ b/_includes/footer/footer-tr.html
@@ -1,4 +1,5 @@
 <a id="top" href="#"><img src="/images/arrow.png"></a>
+
 <footer>
   <section id="doc-langs">
    <a href="http://strongloop.com">StrongLoop/IBM</a> tarafından sağlanan belge çevirileri:
@@ -6,14 +7,12 @@
   <br>
   Topluluk çevirisi için: <a href="/sk/">Slovakça</a>, <a href="/uk/">Ukraynaca</a> and <a href="/uz/">Özbekçe</a>.
   </section>
-
   <div id="footer-content">
       <div id="github">
         <a class="github-button" href="https://github.com/expressjs/expressjs.com" data-icon="octicon-star" aria-label="Star expressjs/expressjs.com on GitHub">Star</a>
       </div>
-      <div id="sponsor"><a href="https://github.com/expressjs/express/">Express</a> bir <a href="http://nodejs.org/foundation"></a>Node.js Vakfı</a> projesidir.</div>
-      <div id="fork"><a href="https://github.com/expressjs/expressjs.com">Github'da Forkla</a>.
-      </div>
+      <div id="sponsor"><a href="https://expressjs.com">Express</a> bir <a href="https://openjsf.org">OpenJS Vakfı</a> projesidir.</div>
+      <div id="fork"><a href="https://github.com/expressjs/expressjs.com">Github'da Forkla</a>.</div>
       <div>Telif Hakkı &copy; 2017 StrongLoop, IBM, ve diğer expressjs.com katkıda bulunanlar.</div>
   </div>
   <div id="license">

--- a/_includes/footer/footer-uk.html
+++ b/_includes/footer/footer-uk.html
@@ -5,10 +5,9 @@
         <div id="github">
             <iframe src="//ghbtns.com/github-btn.html?user=expressjs&amp;repo=express&amp;type=watch&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe>
         </div>
-        <div id="sponsor"><a href="https://github.com/expressjs/express">Express</a> is a project of the Node.js Foundation.</div>
-        <div id="fork"><a href="https://github.com/expressjs/expressjs.com">Fork the website on GitHub</a>.
-        </div>
-        <div>Copyright &copy; StrongLoop, Inc., and other expressjs.com contributors.</div>
+        <div id="sponsor"><a href="https://expressjs.com">Express</a> проект <a href="https://openjsf.org">фонду OpenJS</a>.</div>
+        <div id="fork"><a href="https://github.com/expressjs/expressjs.com">Розмістіть веб-сайт на GitHub</a>.</div>
+        <div>Copyright &copy; StrongLoop, Inc. та інших учасників expressjs.com.</div>
     </div>
     <div id="license">
         <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/"><img alt="Ліцензія Creative Commons" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/3.0/us/80x15.png" /></a> Цей твір ліцензовано за <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/">ліцензією Creative Commons Із Зазначенням Авторства - Поширення На Тих Самих Умовах 3.0 Сполучені Штати</a>.

--- a/_includes/footer/footer-uz.html
+++ b/_includes/footer/footer-uz.html
@@ -5,9 +5,8 @@
         <div id="github">
             <iframe src="//ghbtns.com/github-btn.html?user=expressjs&amp;repo=express&amp;type=watch&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe>
         </div>
-        <div id="sponsor"><a href="https://github.com/expressjs/express">Express</a> is a project of the Node.js Foundation.</div>
-        <div id="fork"><a href="https://github.com/expressjs/expressjs.com">Fork the website on GitHub</a>.
-        </div>
+        <div id="sponsor"><a href="https://expressjs.com">Express</a> bu <a href="https://openjsf.org">OpenJS fondining</a> loyihasi.</div>
+        <div id="fork"><a href="https://github.com/expressjs/expressjs.com">Fork the website on GitHub</a>.</div>
         <div>Copyright &copy; StrongLoop, Inc., and other expressjs.com contributors.</div>
     </div>
     <div id="license">

--- a/_includes/footer/footer-zh-cn.html
+++ b/_includes/footer/footer-zh-cn.html
@@ -5,12 +5,12 @@
         <div id="github">
             <iframe src="//ghbtns.com/github-btn.html?user=expressjs&amp;repo=express&amp;type=watch&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe>
         </div>
-        <div id="sponsor"><a href="https://github.com/expressjs/express">Express</a>是Node.js的基金会的一个项目</div>
+        <div id="sponsor"><a href="https://expressjs.com">Express</a>是<a href="https://openjsf.org">OpenJS的基金会的</a>一个项目。</div>
         <div id="fork"><a href="https://github.com/expressjs/expressjs.com">在 GitHub 上派生出网站</a>。</div>
         <div>Copyright &copy; StrongLoop, Inc., and other expressjs.com contributors.</div>
     </div>
     <div id="license">
-<a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/"><img alt="知识共享许可协议" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/3.0/us/80x15.png" /></a> 本作品采用<a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/">知识共享署名-相同方式共享 3.0 美国许可协议</a>进行许可。
+        <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/"><img alt="知识共享许可协议" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/3.0/us/80x15.png" /></a> 本作品采用<a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/">知识共享署名-相同方式共享 3.0 美国许可协议</a>进行许可。
     </div>
 </footer>
 

--- a/_includes/footer/footer-zh-tw.html
+++ b/_includes/footer/footer-zh-tw.html
@@ -5,13 +5,12 @@
         <div id="github">
             <iframe src="//ghbtns.com/github-btn.html?user=expressjs&amp;repo=express&amp;type=watch&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe>
         </div>
-        <div id="sponsor"><a href="https://github.com/expressjs/express">Express</a>是Node.js的基金會的一個項目。</div>
-        <div id="fork"><a href="https://github.com/expressjs/expressjs.com">GitHub 上的網站分支</a>。
-        </div>
+        <div id="sponsor"><a href="https://expressjs.com">Express</a>是<a href="https://openjsf.org">OpenJS的基金會的</a>一個項目。</div>
+        <div id="fork"><a href="https://github.com/expressjs/expressjs.com">GitHub 上的網站分支</a>。</div>
         <div>Copyright &copy; StrongLoop, Inc. 與其他 expressjs.com 貢獻者。</div>
     </div>
-       <div id="license">
-            <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/"><img alt="創用 CC 授權條款" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/3.0/us/80x15.png" /></a> 本著作係採用<a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/">創用 CC 姓名標示-相同方式分享 3.0 美國 授權條款</a>授權.
+    <div id="license">
+        <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/"><img alt="創用 CC 授權條款" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/3.0/us/80x15.png" /></a> 本著作係採用<a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/">創用 CC 姓名標示-相同方式分享 3.0 美國 授權條款</a>授權.
     </div>
 </footer>
 


### PR DESCRIPTION
Update the `#sponsor` tag in the footer to point at https://expressjs.com and https://openjsf.org.

- Most languages weren't linking to Node.js Foundation correctly or at all to begin with.
- http://nodejs.org/foundation currently 301s to https://openjsf.org/
- Translations were not modified. 
  - One exception with Ukrainian which was mostly English (I used Google Translate).