### PR TITLE
Update 4x and 5x docs to include `router(req, res, next)` documentation

### DIFF
--- a/_includes/api/en/4x/menu.md
+++ b/_includes/api/en/4x/menu.md
@@ -190,6 +190,7 @@
         <ul id="router-menu">
             <li><em>Methods</em>
             </li>
+            <li><a href="#router.instance">router(req, res, next)</a>
             <li><a href="#router.all">router.all()</a>
             </li>
             <li><a href="#router.METHOD">router.METHOD()</a>

--- a/_includes/api/en/4x/router-instance.md
+++ b/_includes/api/en/4x/router-instance.md
@@ -1,0 +1,43 @@
+<h3 id='router.instance'>router(req, res, next)</h3>
+
+Once a router instance has been created and all the relevant route handlers have been added
+you can use in a few different ways.
+
+```js
+const userRouter = express.Router()
+
+userRouter.get('/events', (req, res, next) => {
+  const { userId } = req.query
+  // return user specific events
+})
+
+userRouter.get('/tasks', (req, res, next) => {
+  const { userId } = req.query
+  // return user specific tasks
+})
+```
+
+  - Directly pass it to another router's route handler.
+
+```js
+app.use('/calendar', userRouter)
+```
+
+  - Or you can call pass the `req`, `res`, and `next` arguments to the `Router` instance as a function
+  within another router's route handler.
+  
+```js
+app.use('*', (req, res, next) => {
+  if (req.query.userId) {
+    // if a user id is passed in use the user specific router
+    userRouter(req, res, next)
+  } else {
+    next()
+  }
+})
+```
+
+This allows you to have a more fine-grained control over what the router instance is responsible for, 
+while still maintaining a clear separation of concerns between different functionalities. In the example 
+above, the logic is split by whether a user ID is specified in the request query params. This allows
+for easily separating logic for authenticated users versus visitors.

--- a/_includes/api/en/4x/router.md
+++ b/_includes/api/en/4x/router.md
@@ -38,21 +38,21 @@ In this example the `req`, `res` and `next` arguments are imperatively passed to
 explicitly pass them within a callback.
 
 ```js
-const userRouter = express.Router();
+const userRouter = express.Router()
 
 userRouter.get('/calendar', (req, res, next) => {
-  const { user_id } = req.query;
+  const { userId } = req.query
   // return user specific calendar information
-});
+})
 
 app.use('*', (req, res, next) => {
-  if (req.query.user_id) {
+  if (req.query.userId) {
     // if a user id is passed in use the user specific router
-    userRouter(req, res, next);
+    userRouter(req, res, next)
   } else {
-    next();
+    next()
   }
-});
+})
 ```
 
 

--- a/_includes/api/en/4x/router.md
+++ b/_includes/api/en/4x/router.md
@@ -34,6 +34,27 @@ You can then use a router for a particular root URL in this way separating your 
 app.use('/calendar', router)
 ```
 
+In this example the `req`, `res` and `next` arguments are imperatively passed to the `router` instance. You can also 
+explicitly pass them within a callback.
+
+```js
+const userRouter = express.Router();
+
+userRouter.get('/calendar', (req, res, next) => {
+  const { user_id } = req.query;
+  // return user specific calendar information
+});
+
+app.use('*', (req, res, next) => {
+  if (req.query.user_id) {
+    // if a user id is passed in use the user specific router
+    userRouter(req, res, next);
+  } else {
+    next();
+  }
+});
+```
+
 
 </section>
 

--- a/_includes/api/en/4x/router.md
+++ b/_includes/api/en/4x/router.md
@@ -34,8 +34,8 @@ You can then use a router for a particular root URL in this way separating your 
 app.use('/calendar', router)
 ```
 
-In this example the `req`, `res` and `next` arguments are imperatively passed to the `router` instance. You can also 
-explicitly pass them within a callback.
+In this example the `req`, `res` and `next` arguments are being imperatively passed to the `router` instance. You can also 
+explicitly pass them within another route handler.
 
 ```js
 const userRouter = express.Router()
@@ -59,6 +59,10 @@ app.use('*', (req, res, next) => {
 </section>
 
 <h3 id='router.methods'>Methods</h3>
+
+<section markdown="1">
+  {% include api/en/4x/router-instance.md %}
+</section>
 
 <section markdown="1">
   {% include api/en/4x/router-all.md %}

--- a/_includes/api/en/5x/router.md
+++ b/_includes/api/en/5x/router.md
@@ -34,6 +34,26 @@ You can then use a router for a particular root URL in this way separating your 
 app.use('/calendar', router)
 ```
 
+In this example the `req`, `res` and `next` arguments are imperatively passed to the `router` instance. You can also 
+explicitly pass them within a callback.
+
+```js
+const userRouter = express.Router();
+
+userRouter.get('/calendar', (req, res, next) => {
+  const { user_id } = req.query;
+  // return user specific calendar information
+});
+
+app.use('*', (req, res, next) => {
+  if (req.query.user_id) {
+    // if a user id is passed in use the user specific router
+    userRouter(req, res, next);
+  } else {
+    next();
+  }
+});
+```
 
 </section>
 

--- a/_includes/api/en/5x/router.md
+++ b/_includes/api/en/5x/router.md
@@ -38,21 +38,21 @@ In this example the `req`, `res` and `next` arguments are imperatively passed to
 explicitly pass them within a callback.
 
 ```js
-const userRouter = express.Router();
+const userRouter = express.Router()
 
 userRouter.get('/calendar', (req, res, next) => {
-  const { user_id } = req.query;
+  const { userId } = req.query
   // return user specific calendar information
-});
+})
 
 app.use('*', (req, res, next) => {
-  if (req.query.user_id) {
+  if (req.query.userId) {
     // if a user id is passed in use the user specific router
-    userRouter(req, res, next);
+    userRouter(req, res, next)
   } else {
-    next();
+    next()
   }
-});
+})
 ```
 
 </section>


### PR DESCRIPTION
API docs currently provide an example of using the `Router.router()` instance imperatively
as a middleware, but it isn't immediately clear that this can be used as a regular function
within a handler by explicitly passing in the arguments.

Resolves
#1151 