### PR TITLE
Add husky and configure pre-push hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "eslint-plugin-markdown": "^1.0.2",
     "eslint-plugin-node": "^11.0.0",
     "eslint-plugin-promise": "^4.2.1",
-    "eslint-plugin-standard": "^4.0.1"
+    "eslint-plugin-standard": "^4.0.1",
+    "husky": "^4.2.5"
   },
   "eslintConfig": {
     "extends": "standard",
@@ -23,6 +24,11 @@
       "handle-callback-err": 0,
       "no-undef": 0,
       "no-unused-vars": 0
+    }
+  },
+  "husky": {
+    "hooks": {
+      "pre-push": "npm test"
     }
   }
 }


### PR DESCRIPTION
Currently, it's easy for new contributors to accidentally miss the
`eslint` configuration and incorrectly format their code examples when
first creating a pull request. Adding git hooks gives contributors
immediate feedback of mismatched styling before they are able to
create the PR minimizing "re-work" by contributors and back and forth
for maintainers.