### PR TITLE
fix: reduce navbar overflow, fix anchor positioning

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -204,8 +204,8 @@ a {
 }
 
 #api-doc *:target, #page-doc *:target {
- margin-top: -60px;
- padding-top: 60px;
+ margin-top: -120px;
+ padding-top: 120px;
  z-index: -1;
 }
 
@@ -674,7 +674,6 @@ footer {
 #navbar {
   padding-left: 5%;
   max-width: 1000px;
-  height: 100%;
   position: relative;
   display: flex;
   justify-content: flex-end;


### PR DESCRIPTION
This PR addresses two issues I noticed:

* The navbar's div on desktop invisibly covers some of the page content. You can test this by going to [this anchor](https://expressjs.com/en/advanced/best-practice-performance.html#in-code) and mouse over the first few links in the bullet list. The links aren't clickable.
* The second issue is also demonstrated by that link, the sticky header is obscuring the anchor that was linked to.

