### PR TITLE
tweak #i18n-notice-box margin

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -562,7 +562,7 @@ html[xmlns] .clearfix {
 }
 
 #i18n-notice-box {
-  margin-top: 100px;
+  margin-top: 150px;
   position: relative;
 }
 


### PR DESCRIPTION
As `#i18n-notice-box margin` is depending on the header's height, I just made a minor tweak.

Before
<img width="1145" alt="Screen Shot 2020-06-04 at 15 00 37" src="https://user-images.githubusercontent.com/1716463/83720605-5292f000-a674-11ea-90cd-064932a4e8ff.png">

After
<img width="1139" alt="Screen Shot 2020-06-04 at 15 00 45" src="https://user-images.githubusercontent.com/1716463/83720612-54f54a00-a674-11ea-9712-dcc675ee68db.png">
