### PR TITLE
Add new Examples page

### DIFF
--- a/_includes/header/header-en.html
+++ b/_includes/header/header-en.html
@@ -42,6 +42,11 @@
                             </a>
                           </li>
                           <li>
+                            <a href="/{{ page.lang }}/starter/examples.html">
+                              More examples
+                            </a>
+                          </li>
+                          <li>
                             <a href="/{{ page.lang }}/starter/faq.html">
                               FAQ
                             </a>

--- a/_includes/readmes/express-master/examples.md
+++ b/_includes/readmes/express-master/examples.md
@@ -1,0 +1,30 @@
+# Express examples
+
+This page contains list of examples using Express.
+
+- [auth](./auth) - Authentication with login and password
+- [content-negotiation](./content-negotiation) - HTTP content negotiation
+- [cookie-sessions](./cookie-sessions) - Working with cookie-based session
+- [cookies](./cookies) - Working with cookies
+- [downloads](./downloads) - Transferring files to client
+- [ejs](./ejs) - Working with Embedded JavaScript templating (ejs)
+- [error-pages](./error-pages) - Creating error pages
+- [error](./error) - Working with error middleware
+- [hello-world](./hello-world) - Simple request handler
+- [markdown](./markdown) - Markdown as template engine
+- [multi-router](./multi-router) - Working with multiple express routers
+- [multipart](./multipart) - Accepting multipart-encoded forms
+- [mvc](./mvc) - MVC style controllers
+- [online](./online) - Tracking online user activity with `online` and `redis` packages
+- [params](./params) - Working with route parameters
+- [resource](./resource) - Multiple HTTP operations on the same resource
+- [route-map](./route-map) - Organizing routes using map
+- [route-middleware](./route-middleware) - Working with route middleware
+- [route-separation](./route-separation) - Organizing routes per each resource
+- [search](./search) - Search API
+- [session](./session) - User sessions
+- [static-files](./static-files) - Serving static files
+- [vhost](./vhost) - Working with virtual hosts
+- [view-constructor](./view-constructor) - Rendering views dynamically
+- [view-locals](./view-locals) - Saving data in request object between middleware calls
+- [web-service](./web-service) - Simple API service

--- a/_includes/readmes/express-master/examples.md
+++ b/_includes/readmes/express-master/examples.md
@@ -4,7 +4,7 @@ This page contains list of examples using Express.
 
 - [auth](./auth) - Authentication with login and password
 - [content-negotiation](./content-negotiation) - HTTP content negotiation
-- [cookie-sessions](./cookie-sessions) - Working with cookie-based session
+- [cookie-sessions](./cookie-sessions) - Working with cookie-based sessions
 - [cookies](./cookies) - Working with cookies
 - [downloads](./downloads) - Transferring files to client
 - [ejs](./ejs) - Working with Embedded JavaScript templating (ejs)
@@ -12,13 +12,13 @@ This page contains list of examples using Express.
 - [error](./error) - Working with error middleware
 - [hello-world](./hello-world) - Simple request handler
 - [markdown](./markdown) - Markdown as template engine
-- [multi-router](./multi-router) - Working with multiple express routers
+- [multi-router](./multi-router) - Working with multiple Express routers
 - [multipart](./multipart) - Accepting multipart-encoded forms
-- [mvc](./mvc) - MVC style controllers
+- [mvc](./mvc) - MVC-style controllers
 - [online](./online) - Tracking online user activity with `online` and `redis` packages
 - [params](./params) - Working with route parameters
 - [resource](./resource) - Multiple HTTP operations on the same resource
-- [route-map](./route-map) - Organizing routes using map
+- [route-map](./route-map) - Organizing routes using a map
 - [route-middleware](./route-middleware) - Working with route middleware
 - [route-separation](./route-separation) - Organizing routes per each resource
 - [search](./search) - Search API

--- a/en/starter/examples.md
+++ b/en/starter/examples.md
@@ -1,0 +1,12 @@
+---
+layout: page
+title: Express examples
+menu: starter
+lang: en
+redirect_from: "/starter/examples.html"
+---
+
+{% capture examples %}{% include readmes/express-master/examples.md %}{% endcapture %}
+{{ examples | replace: "](.", "](https://github.com/expressjs/express/tree/master/examples" }}
+
+###  [Previous: Static Files ](/{{ page.lang }}/starter/static-files.html)&nbsp;&nbsp;&nbsp;&nbsp;[Next: FAQ ](/{{ page.lang }}/starter/faq.html)

--- a/en/starter/faq.md
+++ b/en/starter/faq.md
@@ -90,4 +90,4 @@ If you have a specific file, use the `res.sendFile()` function.
 If you are serving many assets from a directory, use the `express.static()`
 middleware function.
 
-###  [Previous: Static Files ](/{{ page.lang }}/starter/static-files.html)
+###  [Previous: More examples ](/{{ page.lang }}/starter/examples.html)

--- a/en/starter/static-files.md
+++ b/en/starter/static-files.md
@@ -75,4 +75,4 @@ app.use('/static', express.static(path.join(__dirname, 'public')))
 
 For more details about the `serve-static` function and its options, see  [serve-static](/resources/middleware/serve-static.html).
 
-### [Previous: Basic Routing ](/{{ page.lang }}/starter/basic-routing.html)&nbsp;&nbsp;&nbsp;&nbsp;[Next: FAQ ](/{{ page.lang }}/starter/faq.html)
+### [Previous: Basic Routing ](/{{ page.lang }}/starter/basic-routing.html)&nbsp;&nbsp;&nbsp;&nbsp;[Next: More examples ](/{{ page.lang }}/starter/examples.html)

--- a/get-readmes.sh
+++ b/get-readmes.sh
@@ -26,6 +26,7 @@ expressjs serve-static master
 expressjs session master
 expressjs timeout master
 expressjs vhost master
+expressjs express master/examples
 LIST_END
 ) | while read org repo branch; do
   # Write the README.md to a file named after the repo


### PR DESCRIPTION
Following https://github.com/expressjs/express/issues/4343 - I'd like to present a new page with list of links to examples from main express repo.

<img width="831" alt="Screenshot 2020-07-28 at 13 56 28" src="https://user-images.githubusercontent.com/5843270/88657735-0cd62f00-d0db-11ea-998f-cc41e06830aa.png">

