### PR TITLE
res.send documentation change

### DIFF
--- a/_includes/api/en/4x/res-send.md
+++ b/_includes/api/en/4x/res-send.md
@@ -2,7 +2,7 @@
 
 Sends the HTTP response.
 
-The `body` parameter can be a `Buffer` object, a `String`, an object, or an `Array`.
+The `body` parameter can be a `Buffer` object, a `String`, an object, `Boolean`, or an `Array`.
 For example:
 
 ```js

--- a/_includes/api/en/5x/res-send.md
+++ b/_includes/api/en/5x/res-send.md
@@ -2,7 +2,7 @@
 
 Sends the HTTP response.
 
-The `body` parameter can be a `Buffer` object, a `String`, an object, or an `Array`.
+The `body` parameter can be a `Buffer` object, a `String`, an object, `Boolean`, or an `Array`.
 For example:
 
 ```js


### PR DESCRIPTION
This documentation is incorrect, because res.send also accepts booleans. Example could be even found in express tests: 
```js
it('should return true when the resource is not modified', function(done){
      var app = express();
      var etag = '"12345"';

      app.use(function(req, res){
        res.set('ETag', etag);
        res.send(req.fresh); // <-- req.fresh returns Boolean
      });

      request(app)
      .get('/')
      .set('If-None-Match', etag)
      .expect(304, done);
    })
```