### PR TITLE
Rephrase Russian top menu items to free-up space for search field

### DIFF
--- a/_includes/header/header-ru.html
+++ b/_includes/header/header-ru.html
@@ -11,7 +11,7 @@
   <div id="navbar">
       <input id="q" placeholder="🔎 search">
       <ul id="navmenu">
-          <li><a href="/{{ page.lang }}/" id="home-menu"{% if page.menu == 'home' %} class="active"{% endif %}>Начальная страница</a></li>
+          <li><a href="/{{ page.lang }}/" id="home-menu"{% if page.menu == 'home' %} class="active"{% endif %}>Главная</a></li>
           <li>
               <ul id="getting-started-menu" class="menu">
                   <li><a href="/{{ page.lang }}/starter/installing.html"{% if page.menu == 'starter' %} class="active"{% endif %}>Начало работы</a>
@@ -80,7 +80,7 @@
           </li>
           <li>
               <ul id="application-menu" class="menu">
-                  <li><a href="/{{ page.lang }}/4x/api.html"{% if page.menu == 'api' %} class="active"{% endif %}>Справочник по API</a>
+                  <li><a href="/{{ page.lang }}/4x/api.html"{% if page.menu == 'api' %} class="active"{% endif %}>API</a>
                       <ul>
                           <li><a href="/{{ page.lang }}/4x/api.html">4.x</a>
                           </li>


### PR DESCRIPTION
Fixes #1175 by rephrasing and reducing amount of words in top menu items in Russian translation.