### PR TITLE
Added security advisory on setting trust proxy to true on production.

### DIFF
--- a/en/guide/behind-proxies.md
+++ b/en/guide/behind-proxies.md
@@ -20,6 +20,8 @@ Although the app will not fail to run if the application variable `trust proxy` 
       <td>Boolean</td>
 <td markdown="1">
 If `true`, the client's IP address is understood as the left-most entry in the `X-Forwarded-*` header.
+  
+Note that setting it to `true` on production environment might cause security issue as it would allow the client to spoof IP address. It is recommended to set it specifically to the number of hops instead _(see Number type)_.
 
 If `false`, the app is understood as directly facing the Internet and the client's IP address is derived from `req.connection.remoteAddress`. This is the default setting.
 </td>


### PR DESCRIPTION
As the default is `false`, it is often tempted to simply set it to `true` on production when an express server is operating behind a proxy. This causes a common security issue where a client is now able to pass in arbitrary IPs in `X-Forwarded-For` and trick Express into accepting it as the client IP.