### PR TITLE
Replacing next(err) with next("route")

### DIFF
--- a/en/guide/error-handling.md
+++ b/en/guide/error-handling.md
@@ -294,5 +294,5 @@ app.get('/a_route_behind_paywall',
 In this example, the `getPaidContent` handler will be skipped but any remaining handlers in `app` for `/a_route_behind_paywall` would continue to be executed.
 
 <div class="doc-box doc-info" markdown="1">
-Calls to `next()` and `next(err)` indicate that the current handler is complete and in what state.  `next(err)` will skip all remaining handlers in the chain except for those that are set up to handle errors as described above.
+Calls to `next()` and `next("route")` indicate that the current handler is complete and in what state.  `next(err)` will skip all remaining handlers in the chain except for those that are set up to handle errors as described above.
 </div>


### PR DESCRIPTION
Calls to `next()` and `next("route")` indicate that the current handler is complete and in what state. I think this is the correct definition. Previously it was "Calls to `next()` and `next(err)` indicate that the current handler is complete and in what state",