### PR TITLE
Update description of xssFilter for helmet in best-practice-security.md

### DIFF
--- a/en/advanced/best-practice-security.md
+++ b/en/advanced/best-practice-security.md
@@ -57,7 +57,7 @@ Helmet is actually just a collection of smaller middleware functions that set se
 * [noCache](https://github.com/helmetjs/nocache) sets `Cache-Control` and Pragma headers to disable client-side caching.
 * [noSniff](https://github.com/helmetjs/dont-sniff-mimetype) sets `X-Content-Type-Options` to prevent browsers from MIME-sniffing a response away from the declared content-type.
 * [frameguard](https://github.com/helmetjs/frameguard) sets the `X-Frame-Options` header to provide [clickjacking](https://www.owasp.org/index.php/Clickjacking) protection.
-* [xssFilter](https://github.com/helmetjs/x-xss-protection) sets `X-XSS-Protection` to enable the Cross-site scripting (XSS) filter in most recent web browsers.
+* [xssFilter](https://github.com/helmetjs/x-xss-protection) sets `X-XSS-Protection` to disable the buggy Cross-site scripting (XSS) filter in web browsers.
 
 Install Helmet like any other module:
 


### PR DESCRIPTION
The helmet package disables the XSS filter built into web browsers by setting the `X-XSS-Protection` header's value to `0`.
https://github.com/helmetjs/helmet#reference

The filter has been retired in Chrome & Edge, and Firefox has refused to implement it due to known issues:
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection

The [recommended practice](https://github.com/helmetjs/helmet/issues/230#issuecomment-614106165) is to disable the built-in filter and use alternate methods for protecting against XSS attacks like using a CSP header, sanitize inputs, etc.