### PR TITLE
Add a notice for the different match-patterns between middleware and routers

### DIFF
--- a/_includes/api/en/4x/app-use.md
+++ b/_includes/api/en/4x/app-use.md
@@ -65,6 +65,9 @@ app.use(function (err, req, res, next) {
 The following table provides some simple examples of valid `path` values for
 mounting middleware.
 
+**Routers implement exactly matching for paths, instead of comparing only leading string**
+**For instance, the path `/abc` does NOT match `/abcd` in routers. (For middleware, it DOES match!)**
+
 <div class="table-scroller">
 <table class="doctable" border="1">
 

--- a/_includes/api/en/5x/app-use.md
+++ b/_includes/api/en/5x/app-use.md
@@ -65,6 +65,9 @@ app.use(function (err, req, res, next) {
 The following table provides some simple examples of valid `path` values for
 mounting middleware.
 
+**Routers implement exactly matching for paths, instead of comparing only leading string**
+**For instance, the path `/abc` does NOT match `/abcd` in routers. (For middleware, it DOES match!)**
+
 <div class="table-scroller">
 <table class="doctable" border="1">
 


### PR DESCRIPTION
All app.method() functions have linked their path parameter explanation to <https://expressjs.com/en/4x/api.html#path-examples> (And 5x API), However, it is said:

> This will match paths **starting with /abcd**: ...

Which is not true for routers (For routers, exactly matching is implemented).

So I think it is necessary to add a notice there.