### PR TITLE
Clarify `server` variable in Example Shutdown

### DIFF
--- a/en/advanced/healthcheck-graceful-shutdown.md
+++ b/en/advanced/healthcheck-graceful-shutdown.md
@@ -14,6 +14,8 @@ When you deploy a new version of your application, you must replace the previous
 
 ### Example Graceful Shutdown
 ```js
+const server = app.listen(port)
+
 process.on('SIGTERM', () => {
   debug('SIGTERM signal received: closing HTTP server')
   server.close(() => {


### PR DESCRIPTION
As someone not familiar with how Express works internally, I was confused as to how to shutdown the server. Apparently `app.close()` used to be a thing (or so the internet might lead one to believe, as it did me) but no longer.

This page comes up in the results, but right away, a newcomer won't know what `server` refers to. The documentation on `app.listen()` briefly mentions it returns a server object, but it is still difficult for some to make the connection when reading both the documentation and this example for the first time.

Explicitly initializing `server` in the example removes most of the ambiguity that might confuse someone.