### PR TITLE
Add require('path') to starter/static-files path example

### DIFF
--- a/en/starter/static-files.md
+++ b/en/starter/static-files.md
@@ -70,6 +70,7 @@ http://localhost:3000/static/hello.html
 However, the path that you provide to the `express.static` function is relative to the directory from where you launch your `node` process. If you run the express app from another directory, it's safer to use the absolute path of the directory that you want to serve:
 
 ```js
+const path = require('path')
 app.use('/static', express.static(path.join(__dirname, 'public')))
 ```
 

--- a/th/starter/static-files.md
+++ b/th/starter/static-files.md
@@ -69,6 +69,7 @@ http://localhost:3000/static/hello.html
 อย่างไรก็ตาม เส้นทางที่คุณให้ไว้ในฟังก์ชัน `express.static` มีความสัมพันธ์กับไดเรกเทอรีจากที่ซึ่งคุณการบวนการรัน `node` ของคุณ ถ้าคุณรัน app จากไดเรกเทอรีอื่น มันจะปลอดภัยกว่าถ้าใช้เส้นทางจริงของไดเรกเทอรีที่คุณต้องการบริการไฟล์คงที่:
 
 ```js
+const path = require('path')
 app.use('/static', express.static(path.join(__dirname, 'public')))
 ```
 

--- a/tr/starter/static-files.md
+++ b/tr/starter/static-files.md
@@ -69,6 +69,7 @@ http://localhost:3000/static/hello.html
 `express.static` fonksiyonu ile tanımladığınız yollar `node` processini çalıştırdığınız dizine bağlıdır. Bu yüzden, eğer express uygulamasını başka bir dizinden çalıştırıyorsanız, statik dizini tam adres olarak tanımlamanız daha güvenli olur.
 
 ```js
+const path = require('path')
 app.use('/static', express.static(path.join(__dirname, 'public')))
 ```
 


### PR DESCRIPTION
I was going through the getting started guides and got an error that 'path' is not defined.
