### PR TITLE
Deprecation of body-parser.md

### DIFF
--- a/en/resources/middleware/body-parser.md
+++ b/en/resources/middleware/body-parser.md
@@ -6,3 +6,5 @@ lang: en
 redirect_from: '/resources/middleware/body-parser.html'
 module: body-parser
 ---
+
+###This body-parser is already deprecated. Use ```  app.use(express.json()); ``` instead


### PR DESCRIPTION
This body-parser is already deprecated. Use ```  app.use(express.json()); ``` instead