### PR TITLE
--save is no longer necessary

### DIFF
--- a/en/starter/installing.md
+++ b/en/starter/installing.md
@@ -34,7 +34,7 @@ Enter `app.js`, or whatever you want the name of the main file to be. If you wan
 Now install Express in the `myapp` directory and save it in the dependencies list. For example:
 
 ```sh
-$ npm install express --save
+$ npm install express
 ```
 
 To install Express temporarily and not add it to the dependencies list:


### PR DESCRIPTION
Since npm 5.0.0, installed modules are added as a dependency by default, so the --save option is no longer needed.