### PR TITLE
"zh-cn":Improve Chinese translation guide/routing.md

### DIFF
--- a/zh-cn/guide/routing.md
+++ b/zh-cn/guide/routing.md
@@ -10,6 +10,10 @@ lang: zh-cn
 *路由*表示应用程序端点 (URI) 的定义以及端点响应客户机请求的方式。
 有关路由的简介，请参阅[基本路由](/{{ page.lang }}/starter/basic-routing.html)。
 
+我们所使用的 app 与 HTTP 方法相对应的 Express 对象方法来定义路由，如 ```app.get()``` 用于处理 GET 请求，而 ```app.get``` 则用于处理 POST 请求。
+
+这些路由方法都指定了回调函数（或者：“处理程序函数”），当程序接收到指定的路由（端点）的时候（也就是说 HTTP 方法请求时被调用），来调用回调函数，换句话说就是应用程序监听与指定路由和方法匹配的请求，当检测到匹配时，他会调用对应的回调函数。
+
 以下代码是非常基本的路由示例。
 
 <pre>
@@ -17,7 +21,7 @@ lang: zh-cn
 var express = require('express');
 var app = express();
 
-// respond with "hello world" when a GET request is made to the homepage
+// 当对主页发出 GET 请求时，响应“hello world”
 app.get('/', function(req, res) {
   res.send('hello world');
 });


### PR DESCRIPTION
As I am studying express js and ejs today, I sorted out my notes and saw that the express Chinese document is somewhat different from English, so translation is provided.

Mainly through http://expressjs.com/en/guide/routing.html to improve the grammar for http://expressjs.com/zh-cn/guide/routing.html, and modify the English in the comments

I personally think that the description of the document under the English interface is clearer and more detailed than the Chinese one, so I have added some descriptions in the Chinese document through my own understanding. The original translation in the Chinese document is:

> 路由表示应用程序端点 (URI) 的定义以及端点响应客户机请求的方式。 有关路由的简介，请参阅基本路由。

In the case of comparing English documents:

> Routing refers to how an application’s endpoints (URIs) respond to client requests. For an introduction to routing, see Basic routing.
>
> You define routing using methods of the Express app object that correspond to HTTP methods; for example, app.get() to handle GET requests and app.post to handle POST requests. For a full list, see app.METHOD. You can also use app.all() to handle all HTTP methods and app.use() to specify middleware as the callback function (See Using middleware for details).
>
> These routing methods specify a callback function (sometimes called “handler functions”) called when the application receives a request to the specified route (endpoint) and HTTP method. In other words, the application “listens” for requests that match the specified route(s) and method(s), and when it detects a match, it calls the specified callback function.
>
> In fact, the routing methods can have more than one callback function as arguments. With multiple callback functions, it is important to provide next as an argument to the callback function and then call next() within the body of the function to hand off control to the next callback.

After translation：

> 我们所使用的app与HTTP方法相对应的Express对象方法来定义路由，则如```app.get()```用于处理GET请求，而```app.get```用于处理POST 请求。
>
> 这些路由方法都指定了消息函数（“或者函数”），程序接收到指定的消息（当程序）的时候（HTTP 响应方法），来请求时函数，调用调用函数的时候就是应用程序监听与指定路由和方法匹配的请求，当检测到匹配时，他会调用响应函数。

