### PR TITLE
Add async functionality to docs

### DIFF
--- a/_includes/api/en/5x/routing-args.html
+++ b/_includes/api/en/5x/routing-args.html
@@ -39,6 +39,8 @@ that these callbacks can invoke <code>next('route')</code> to bypass
 the remaining route callback(s). You can use this mechanism to impose pre-conditions
 on a route, then pass control to subsequent routes if there is no reason to proceed with the current route.
 </p><p>
+When a callback function throws an error or returns a rejected promise, `next(err)` will be invoked automatically.
+</p><p>
 Since <a href="#router">router</a> and <a href="#application">app</a> implement the middleware interface,
 you can use them as you would any other middleware function.
 </p><p>

--- a/en/guide/migrating-5.md
+++ b/en/guide/migrating-5.md
@@ -40,6 +40,7 @@ You can then run your automated tests to see what fails, and fix problems accord
 
 <ul class="doclist">
   <li><a href="#path-syntax">Path route matching syntax</a></li>
+  <li><a href="#rejected-promises">Rejected promises handled from middleware and handlers</a></li>
   <li><a href="#app.router">app.router</a></li>
   <li><a href="#req.host">req.host</a></li>
   <li><a href="#req.query">req.query</a></li>
@@ -121,6 +122,12 @@ Path route matching syntax is when a string is supplied as the first parameter t
   * `/\\d+` is no longer valid and must be written as `/(\\d+)`.
 - Special `*` path segment behavior removed.
   * `/foo/*/bar` will match a literal `*` as the middle segment.
+
+<h4 id="rejected-promises">Rejected promises handled from middleware and handlers</h4>
+
+Request middleware and handlers that return rejected promises are now handled by forwarding the rejected value as an `Error` to the error handling middleware. This means that using `async` functions as middleware and handlers are easier than ever. When an error is thrown in an `async` function or a rejected promise is `await`ed inside an async function, those errors will be passed to the error handler as if calling `next(err)`.
+
+Details of how Express handles errors is covered in the [error handling documentation](/en/guide/error-handling.html).
 
 <h4 id="app.router">app.router</h4>
 


### PR DESCRIPTION
This pull request adds details about the new handling of `async` middleware to the documentation.

Additionally, I have:
* Updated v5 examples to use arrow functions.
* Updates some v5 examples to demonstrate use of `async` request handlers.
* Expanded the documentation around how route callbacks are used.

One thing I wasn't sure about - I have added the `async` keyword to some handler callbacks that don't actually `await` on anything as a way of demonstrating this new functionality. I wonder whether it would be better to only use `async` callbacks in code that demonstrates use of `await`? In practise, however, I (and many others, likely) will simply mark all their request handlers as async (there's no downside, is there?).

This addresses https://github.com/expressjs/expressjs.com/issues/1313.