### PR TITLE
Clarify relationship between res.locals and render

### DIFF
--- a/_includes/api/en/4x/app-locals.md
+++ b/_includes/api/en/4x/app-locals.md
@@ -1,6 +1,7 @@
 <h3 id='app.locals'>app.locals</h3>
 
-The `app.locals` object has properties that are local variables within the application.
+The `app.locals` object has properties that are local variables within the application,
+and will be available in templates rendered with [res.render](#res.render).
 
 ```js
 console.dir(app.locals.title)

--- a/_includes/api/en/4x/res-locals.md
+++ b/_includes/api/en/4x/res-locals.md
@@ -1,14 +1,18 @@
 <h3 id='res.locals'>res.locals</h3>
 
-An object that contains response local variables scoped to the request, and therefore available only to
-the view(s) rendered during that request / response cycle (if any). Otherwise,
-this property is identical to [app.locals](#app.locals).
+Use this property to set variables accessible in templates rendered with [res.render](#res.render).
+The variables set on `res.locals` are available within a single request-response cycle, and will not
+be shared between requests.
+
+In order to keep local variables for use in template rendering between requests, use
+[app.locals](#app.locals) instead.
 
 This property is useful for exposing request-level information such as the request path name,
-authenticated user, user settings, and so on.
+authenticated user, user settings, and so on to templates rendered within the application.
 
 ```js
 app.use(function (req, res, next) {
+  // Make `user` and `authenticated` available in templates
   res.locals.user = req.user
   res.locals.authenticated = !req.user.anonymous
   next()

--- a/_includes/api/en/5x/app-locals.md
+++ b/_includes/api/en/5x/app-locals.md
@@ -1,6 +1,7 @@
 <h3 id='app.locals'>app.locals</h3>
 
-The `app.locals` object has properties that are local variables within the application.
+The `app.locals` object has properties that are local variables within the application,
+and will be available in templates rendered with [res.render](#res.render).
 
 ```js
 console.dir(app.locals.title)

--- a/_includes/api/en/5x/res-locals.md
+++ b/_includes/api/en/5x/res-locals.md
@@ -1,14 +1,18 @@
 <h3 id='res.locals'>res.locals</h3>
 
-An object that contains response local variables scoped to the request, and therefore available only to
-the view(s) rendered during that request / response cycle (if any). Otherwise,
-this property is identical to [app.locals](#app.locals).
+Use this property to set variables accessible in templates rendered with [res.render](#res.render).
+The variables set on `res.locals` are available within a single request-response cycle, and will not
+be shared between requests.
+
+In order to keep local variables for use in template rendering between requests, use
+[app.locals](#app.locals) instead.
 
 This property is useful for exposing request-level information such as the request path name,
-authenticated user, user settings, and so on.
+authenticated user, user settings, and so on to templates rendered within the application.
 
 ```js
 app.use((req, res, next) => {
+  // Make `user` and `authenticated` available in templates
   res.locals.user = req.user
   res.locals.authenticated = !req.user.anonymous
   next()


### PR DESCRIPTION
The documentation left the relationship between `res.locals` and rendering templates unclear, leading to some confusion, c.f. [this discussion on StackOverflow](https://stackoverflow.com/a/71487552/1080564), despite the `app.locals` documentation being referenced and the relationship being clearer there.

I have tried clarifying slightly in the language, in the hope that this will leave fewer readers confused.