### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,15 @@ To preview the website locally:
    ```
    $ gem install jekyll-redirect-from
    ```
+   
+1. clone this repository by running the following command:
+   ```
+   $ git clone https://github.com/expressjs/expressjs.com.git
+   ```
 
-1. `cd` to the repository directory and run the following command:
+1. navigate to the cloned repository directory and run the following command:
 
    ```
-   $ cd expressjs.com
    $ bundle install
    ```
 


### PR DESCRIPTION
**1. Remove redundant line:**
Previously, step 3 instructed to navigate to the repository directory, then in the code block right under, this line is present:
```
$ cd expressjs.com
```
Which is the navigation step itself.
Reading the instruction closely, it implies that the commands in the code block should be run _after_ navigating to the repository directory. It says `"and run"`, not `"by running"`.
Therefore I see that including the `cd` command in the code block is redundant. Anyone following the steps will be already inside the repository directory when he reaches what's in the code block.
Also, I expect in rare cases that this might confuse someone into thinking that something is wrong with the directory structure, for example.
I also used the word `navigate` instead of `cd`, I felt it would play nicer with the previous step (also new) which I talk about below.

**2. Add a clarifying step:**
I added a step right before step 3 (which will become step 4) instructing to clone the repository and providing the clone command.
I added this step for extra clarity on how to correctly get the repository mentioned in the next step, so there is no jump or gap felt by anyone following.