### PR TITLE
Fix incorrect link in companies using express

### DIFF
--- a/en/resources/companies-using-express.md
+++ b/en/resources/companies-using-express.md
@@ -54,7 +54,7 @@ redirect_from: "/resources/companies-using-express.html"
     <a target="_new" class="imagelink" href="https://www.yandex.ru/">
       <img alt="Yandex" class="memberlogo" src="/images/companies/yandex-logo.png" />
     </a>
-    <a target="_new" class="imagelink" href="http://www.agrippa.no/en">
+    <a target="_new" class="imagelink" href="https://agrippa.no">
       <img alt="Agrippa Solutions AS" class="memberlogo" src="/images/companies/OrgASLogo.png" />
     </a>
     <a target="_new" class="imagelink" href="https://www.circlehd.com">


### PR DESCRIPTION
## Incorrect link is found in [this](https://expressjs.com/en/resources/companies-using-express.html) page.

The link for Agrippa present on the page (https://agrippa.no/en) gives a page not found, which could be changed to https://agrippa.no.

## Screenshot for the reference.
![express_companies_incorrect](https://user-images.githubusercontent.com/63643748/162865350-d8c30c70-1afc-4879-8376-beda2c9a9945.png)
![express_companies_correct](https://user-images.githubusercontent.com/63643748/162865360-8954481b-2711-480d-8a57-9544e1d072b6.png)

