### PR TITLE
Installing express 5 without piping into a file

### DIFF
--- a/en/guide/migrating-5.md
+++ b/en/guide/migrating-5.md
@@ -14,7 +14,7 @@ Express 5.0 is still in the beta release stage, but here is a preview of the cha
 To install the latest beta and to preview Express 5, enter the following command in your application root directory:
 
 ```console
-$ npm install express@>=5.0.0-beta.1 --save
+$ npm install "express@>=5.0.0-beta.1" --save
 ```
 
 You can then run your automated tests to see what fails, and fix problems according to the updates listed below. After addressing test failures, run your app to see what errors occur. You'll find out right away if the app uses any methods or properties that are not supported.


### PR DESCRIPTION
I was trying to install express version 5 and I couldn't figure out why I was getting version 4, and a file called `=5.0.0-beta.1` was getting created. It had this content:

```

added 1 package, and audited 72 packages in 751ms

2 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
```

After messing around with different terminals (cmd, git bash), and trying it out in a different, empty project, I finally realized the `>` bracket was piping.