### PR TITLE
Add Express 4.18.1 changelog

### DIFF
--- a/_data/express.yml
+++ b/_data/express.yml
@@ -1,1 +1,1 @@
-current_version: "4.18.0"
+current_version: "4.18.1"

--- a/en/changelog/4x.md
+++ b/en/changelog/4x.md
@@ -8,6 +8,19 @@ redirect_from: "/changelog/4x.html"
 
 # Release Change Log
 
+## 4.18.1 - Release date: 2022-04-29
+{: id="4.18.1"}
+
+The 4.18.1 patch release includes the following bug fix:
+
+<ul>
+  <li markdown="1" class="changelog-item">
+  Fix the condition where if an Express.js application is created with a very large stack of routes, and all of those routes are sync (call `next()` synchronously), then the request processing may hang.
+  </li>
+</ul>
+
+For a complete list of changes in this release, see [History.md](https://github.com/expressjs/express/blob/master/History.md#4181--2022-04-29).
+
 ## 4.18.0 - Release date: 2022-04-25
 {: id="4.18.0"}
 


### PR DESCRIPTION
The Express homepage shows 4.18.0 as the latest version, but it's actually 4.18.1.

I modeled this change after 5c98ee4e949fc69b9dbc89b839c137b7a2eea3fc and f1f42d9bd202a13d6db83287ee075b02253822a7. If there's an automatic way to do this, let me know.