### PR TITLE
Offer html-express-js as a new template engine

### DIFF
--- a/en/resources/template-engines.md
+++ b/en/resources/template-engines.md
@@ -32,6 +32,7 @@ These template engines work "out-of-the-box" with Express:
 - **[express-tl](https://github.com/Drulac/express-tl)**: A template-literal engine implementation for Express.
 - **[Twing](https://www.npmjs.com/package/twing)**: First-class Twig engine for Node.js.
 - **[Sprightly](https://www.npmjs.com/package/sprightly)**: A very light-weight JS template engine (45 lines of code), that consists of all the bare-bones features that you want to see in a template engine.
+- **[html-express-js](https://www.npmjs.com/package/html-express-js)**: A small template engine for those that want to just serve static or dynamic HTML pages using native JavaScript.
 
 The [Consolidate.js](https://github.com/tj/consolidate.js) library unifies the APIs of these template engines to a single Express-compatible API.
 


### PR DESCRIPTION
This adds [`html-express-js`](https://www.npmjs.com/package/html-express-js), a new template engine I've created that I'm now using on a few projects. I thought it would be a great idea to offer this up to the rest of the community.

At a basic level, it renders either static HTML pages or HTML pages with dynamic content that gets interpolated using only native JavaScript (Template literals).