### PR TITLE
fix: remove broken link for error handling 

### DIFF
--- a/de/advanced/best-practice-performance.md
+++ b/de/advanced/best-practice-performance.md
@@ -84,7 +84,6 @@ Um näher auf diese Themen eingehen zu können, müssen Sie sich ein grundlegend
 
 Weitere Informationen zu den Grundlagen der Fehlerbehandlung siehe:
 
-* [Fehlerbehandlung in Node.js](https://www.joyent.com/developers/node/design/errors)
 * [Aufbau leistungsfähiger Node-Anwendungen: Fehlerbehandlung](https://strongloop.com/strongblog/robust-node-applications-error-handling/) (StrongLoop-Blog)
 
 #### Was Sie unterlassen sollten

--- a/de/advanced/best-practice-performance.md
+++ b/de/advanced/best-practice-performance.md
@@ -84,6 +84,7 @@ Um näher auf diese Themen eingehen zu können, müssen Sie sich ein grundlegend
 
 Weitere Informationen zu den Grundlagen der Fehlerbehandlung siehe:
 
+* [Fehlerbehandlung in Node.js](https://www.tritondatacenter.com/node-js/production/design/errors)
 * [Aufbau leistungsfähiger Node-Anwendungen: Fehlerbehandlung](https://strongloop.com/strongblog/robust-node-applications-error-handling/) (StrongLoop-Blog)
 
 #### Was Sie unterlassen sollten

--- a/en/advanced/best-practice-performance.md
+++ b/en/advanced/best-practice-performance.md
@@ -82,7 +82,6 @@ Before diving into these topics, you should have a basic understanding of Node/E
 
 For more on the fundamentals of error handling, see:
 
-* [Error Handling in Node.js](https://www.joyent.com/developers/node/design/errors)
 * [Building Robust Node Applications: Error Handling](https://strongloop.com/strongblog/robust-node-applications-error-handling/) (StrongLoop blog)
 
 #### What not to do

--- a/en/advanced/best-practice-performance.md
+++ b/en/advanced/best-practice-performance.md
@@ -82,6 +82,7 @@ Before diving into these topics, you should have a basic understanding of Node/E
 
 For more on the fundamentals of error handling, see:
 
+* [Error Handling in Node.js](https://www.tritondatacenter.com/node-js/production/design/errors)
 * [Building Robust Node Applications: Error Handling](https://strongloop.com/strongblog/robust-node-applications-error-handling/) (StrongLoop blog)
 
 #### What not to do

--- a/es/advanced/best-practice-performance.md
+++ b/es/advanced/best-practice-performance.md
@@ -86,7 +86,6 @@ Antes de profundizar en estos temas, deberá tener unos conocimientos básicos d
 
 Para obtener más información sobre los aspectos básicos del manejo de errores, consulte:
 
--   [Error Handling in Node.js](https://www.joyent.com/developers/node/design/errors)
 -   [Building Robust Node Applications: Error Handling](https://strongloop.com/strongblog/robust-node-applications-error-handling/) (blog StrongLoop)
 
 #### Qué no debe hacer

--- a/es/advanced/best-practice-performance.md
+++ b/es/advanced/best-practice-performance.md
@@ -86,6 +86,7 @@ Antes de profundizar en estos temas, deberá tener unos conocimientos básicos d
 
 Para obtener más información sobre los aspectos básicos del manejo de errores, consulte:
 
+-   [Error Handling in Node.js](https://www.tritondatacenter.com/node-js/production/design/errors)
 -   [Building Robust Node Applications: Error Handling](https://strongloop.com/strongblog/robust-node-applications-error-handling/) (blog StrongLoop)
 
 #### Qué no debe hacer

--- a/fr/advanced/best-practice-performance.md
+++ b/fr/advanced/best-practice-performance.md
@@ -84,7 +84,6 @@ Avant de s'immerger dans les rubriques qui suivent, il est conseillé de posséd
 
 Pour plus d'informations sur les bases du traitement des erreurs, voir :
 
-* [Error Handling in Node.js](https://www.joyent.com/developers/node/design/errors)
 * [Building Robust Node Applications: Error Handling](https://strongloop.com/strongblog/robust-node-applications-error-handling/) (blogue StrongLoop)
 
 #### A ne pas faire

--- a/fr/advanced/best-practice-performance.md
+++ b/fr/advanced/best-practice-performance.md
@@ -84,6 +84,7 @@ Avant de s'immerger dans les rubriques qui suivent, il est conseillé de posséd
 
 Pour plus d'informations sur les bases du traitement des erreurs, voir :
 
+* [Error Handling in Node.js](https://www.tritondatacenter.com/node-js/production/design/errors)
 * [Building Robust Node Applications: Error Handling](https://strongloop.com/strongblog/robust-node-applications-error-handling/) (blogue StrongLoop)
 
 #### A ne pas faire

--- a/it/advanced/best-practice-performance.md
+++ b/it/advanced/best-practice-performance.md
@@ -84,7 +84,6 @@ Prima di leggere questi argomenti, è necessario avere una conoscenza base della
 
 Per ulteriori informazioni sulle nozioni di base della gestione degli errori, consultare:
 
-* [Gestione degli errori in Node.js](https://www.joyent.com/developers/node/design/errors)
 * [Come creare applicazioni Node solide: Gestione degli errori](https://strongloop.com/strongblog/robust-node-applications-error-handling/) (blog di StrongLoop)
 
 #### Cosa non fare

--- a/it/advanced/best-practice-performance.md
+++ b/it/advanced/best-practice-performance.md
@@ -84,6 +84,7 @@ Prima di leggere questi argomenti, è necessario avere una conoscenza base della
 
 Per ulteriori informazioni sulle nozioni di base della gestione degli errori, consultare:
 
+* [Gestione degli errori in Node.js](https://www.tritondatacenter.com/node-js/production/design/errors)
 * [Come creare applicazioni Node solide: Gestione degli errori](https://strongloop.com/strongblog/robust-node-applications-error-handling/) (blog di StrongLoop)
 
 #### Cosa non fare

--- a/ja/advanced/best-practice-performance.md
+++ b/ja/advanced/best-practice-performance.md
@@ -81,7 +81,6 @@ Node アプリケーションは、キャッチされていない例外が発生
 
 エラー処理のその他の基礎については、下記を参照してください。
 
-* [Error Handling in Node.js](https://www.joyent.com/developers/node/design/errors)
 * [Building Robust Node Applications: Error Handling](https://strongloop.com/strongblog/robust-node-applications-error-handling/) (StrongLoop ブログ)
 
 #### 実行してはならないこと

--- a/ja/advanced/best-practice-performance.md
+++ b/ja/advanced/best-practice-performance.md
@@ -81,6 +81,7 @@ Node アプリケーションは、キャッチされていない例外が発生
 
 エラー処理のその他の基礎については、下記を参照してください。
 
+* [Error Handling in Node.js](https://www.tritondatacenter.com/node-js/production/design/errors)
 * [Building Robust Node Applications: Error Handling](https://strongloop.com/strongblog/robust-node-applications-error-handling/) (StrongLoop ブログ)
 
 #### 実行してはならないこと

--- a/ko/advanced/best-practice-performance.md
+++ b/ko/advanced/best-practice-performance.md
@@ -91,7 +91,6 @@ Node 앱은 처리되지 않은 예외가 발생할 때 충돌이 발생합니�
 
 오류 처리의 기본사항 대한 자세한 내용은 다음을 참조하십시오.
 
-* [Error Handling in Node.js](https://www.joyent.com/developers/node/design/errors)
 * [Building Robust Node Applications: Error Handling](https://strongloop.com/strongblog/robust-node-applications-error-handling/)(StrongLoop 블로그)
 
 #### 수행하지 않아야 하는 항목

--- a/ko/advanced/best-practice-performance.md
+++ b/ko/advanced/best-practice-performance.md
@@ -91,6 +91,7 @@ Node 앱은 처리되지 않은 예외가 발생할 때 충돌이 발생합니�
 
 오류 처리의 기본사항 대한 자세한 내용은 다음을 참조하십시오.
 
+* [Error Handling in Node.js](https://www.tritondatacenter.com/node-js/production/design/errors)
 * [Building Robust Node Applications: Error Handling](https://strongloop.com/strongblog/robust-node-applications-error-handling/)(StrongLoop 블로그)
 
 #### 수행하지 않아야 하는 항목

--- a/pt-br/advanced/best-practice-performance.md
+++ b/pt-br/advanced/best-practice-performance.md
@@ -122,8 +122,8 @@ convenção de retorno de chamada erros-first para tratar o erro de forma signif
 
 Para obter mais informações sobre os fundamentos de manipulação de erros, consulte:
 
-* [Construindo
-Aplicativos Node Robustos: Manipulação de Erros](https://strongloop.com/strongblog/robust-node-applications-error-handling/) (blog do StrongLoop)
+* [Manipulação de Erros no Node.js](https://www.tritondatacenter.com/node-js/production/design/errors)
+* [Construindo Aplicativos Node Robustos: Manipulação de Erros](https://strongloop.com/strongblog/robust-node-applications-error-handling/) (blog do StrongLoop)
 
 #### O que não fazer
 

--- a/pt-br/advanced/best-practice-performance.md
+++ b/pt-br/advanced/best-practice-performance.md
@@ -122,7 +122,6 @@ convenção de retorno de chamada erros-first para tratar o erro de forma signif
 
 Para obter mais informações sobre os fundamentos de manipulação de erros, consulte:
 
-* [Manipulação de Erros no Node.js](https://www.joyent.com/developers/node/design/errors)
 * [Construindo
 Aplicativos Node Robustos: Manipulação de Erros](https://strongloop.com/strongblog/robust-node-applications-error-handling/) (blog do StrongLoop)
 

--- a/ru/advanced/best-practice-performance.md
+++ b/ru/advanced/best-practice-performance.md
@@ -84,7 +84,6 @@ app.use(compression())
 
 Более подробная информация об основных принципах обработки ошибок приведена в разделе:
 
-* [Обработка ошибок в Node.js](https://www.joyent.com/developers/node/design/errors)
 * [Разработка устойчивых к сбоям приложений Node: обработка ошибок](https://strongloop.com/strongblog/robust-node-applications-error-handling/) (корпоративный блог StrongLoop)
 
 #### Чего не нужно делать

--- a/ru/advanced/best-practice-performance.md
+++ b/ru/advanced/best-practice-performance.md
@@ -84,6 +84,7 @@ app.use(compression())
 
 Более подробная информация об основных принципах обработки ошибок приведена в разделе:
 
+* [Обработка ошибок в Node.js](https://www.tritondatacenter.com/node-js/production/design/errors)
 * [Разработка устойчивых к сбоям приложений Node: обработка ошибок](https://strongloop.com/strongblog/robust-node-applications-error-handling/) (корпоративный блог StrongLoop)
 
 #### Чего не нужно делать

--- a/sk/advanced/best-practice-performance.md
+++ b/sk/advanced/best-practice-performance.md
@@ -88,7 +88,6 @@ Predtým, ako sa hlbšie pustíme do týchto tém, mali by ste mať základné z
 
 Pre viac informácií ohľadom základov error handlingu sa pozrite na:
 
-* [Error Handling in Node.js](https://www.joyent.com/developers/node/design/errors)
 * [Building Robust Node Applications: Error Handling](https://strongloop.com/strongblog/robust-node-applications-error-handling/) (StrongLoop blog)
 
 #### Čo nerobiť

--- a/sk/advanced/best-practice-performance.md
+++ b/sk/advanced/best-practice-performance.md
@@ -88,6 +88,7 @@ Predtým, ako sa hlbšie pustíme do týchto tém, mali by ste mať základné z
 
 Pre viac informácií ohľadom základov error handlingu sa pozrite na:
 
+* [Error Handling in Node.js](https://www.tritondatacenter.com/node-js/production/design/errors)
 * [Building Robust Node Applications: Error Handling](https://strongloop.com/strongblog/robust-node-applications-error-handling/) (StrongLoop blog)
 
 #### Čo nerobiť

--- a/th/advanced/best-practice-performance.md
+++ b/th/advanced/best-practice-performance.md
@@ -81,7 +81,6 @@ Before diving into these topics, you should have a basic understanding of Node/E
 
 For more on the fundamentals of error handling, see:
 
-* [Error Handling in Node.js](https://www.joyent.com/developers/node/design/errors)
 * [Building Robust Node Applications: Error Handling](https://strongloop.com/strongblog/robust-node-applications-error-handling/) (StrongLoop blog)
 
 #### What not to do

--- a/th/advanced/best-practice-performance.md
+++ b/th/advanced/best-practice-performance.md
@@ -81,6 +81,7 @@ Before diving into these topics, you should have a basic understanding of Node/E
 
 For more on the fundamentals of error handling, see:
 
+* [Error Handling in Node.js](https://www.tritondatacenter.com/node-js/production/design/errors)
 * [Building Robust Node Applications: Error Handling](https://strongloop.com/strongblog/robust-node-applications-error-handling/) (StrongLoop blog)
 
 #### What not to do

--- a/tr/advanced/best-practice-performance.md
+++ b/tr/advanced/best-practice-performance.md
@@ -83,7 +83,6 @@ Bu konulara girmeden önce Node/Express istisna işleme ile ilgili temel bir anl
 
 Hata işleme temelleri hakkında daha fazla bilgi için bakınız: 
 
-* [Node.js'te Hata İşleme](https://www.joyent.com/developers/node/design/errors)
 * [Güçlü Node Uygulamaları Yazmak: Hata İşleme](https://strongloop.com/strongblog/robust-node-applications-error-handling/) (StrongLoop blogu)
 
 #### Ne yapmamalı

--- a/tr/advanced/best-practice-performance.md
+++ b/tr/advanced/best-practice-performance.md
@@ -83,6 +83,7 @@ Bu konulara girmeden önce Node/Express istisna işleme ile ilgili temel bir anl
 
 Hata işleme temelleri hakkında daha fazla bilgi için bakınız: 
 
+* [Node.js'te Hata İşleme](https://www.tritondatacenter.com/node-js/production/design/errors)
 * [Güçlü Node Uygulamaları Yazmak: Hata İşleme](https://strongloop.com/strongblog/robust-node-applications-error-handling/) (StrongLoop blogu)
 
 #### Ne yapmamalı

--- a/uk/advanced/best-practice-performance.md
+++ b/uk/advanced/best-practice-performance.md
@@ -84,7 +84,6 @@ Before diving into these topics, you should have a basic understanding of Node/E
 
 For more on the fundamentals of error handling, see:
 
-* [Error Handling in Node.js](https://www.joyent.com/developers/node/design/errors)
 * [Building Robust Node Applications: Error Handling](https://strongloop.com/strongblog/robust-node-applications-error-handling/) (StrongLoop blog)
 
 #### What not to do

--- a/uk/advanced/best-practice-performance.md
+++ b/uk/advanced/best-practice-performance.md
@@ -84,6 +84,7 @@ Before diving into these topics, you should have a basic understanding of Node/E
 
 For more on the fundamentals of error handling, see:
 
+* [Error Handling in Node.js](https://www.tritondatacenter.com/node-js/production/design/errors)
 * [Building Robust Node Applications: Error Handling](https://strongloop.com/strongblog/robust-node-applications-error-handling/) (StrongLoop blog)
 
 #### What not to do

--- a/zh-cn/advanced/best-practice-performance.md
+++ b/zh-cn/advanced/best-practice-performance.md
@@ -76,6 +76,7 @@ Node 应用程序在遇到未捕获的异常时会崩溃。不处理异常并采
 
 有关错误处理基本知识的更多信息，请参阅：
 
+* [Error Handling in Node.js](https://www.tritondatacenter.com/node-js/production/design/errors)
 * [Building Robust Node Applications: Error Handling](https://strongloop.com/strongblog/robust-node-applications-error-handling/)（StrongLoop 博客）
 
 #### 请勿执行以下操作

--- a/zh-cn/advanced/best-practice-performance.md
+++ b/zh-cn/advanced/best-practice-performance.md
@@ -76,7 +76,6 @@ Node 应用程序在遇到未捕获的异常时会崩溃。不处理异常并采
 
 有关错误处理基本知识的更多信息，请参阅：
 
-* [Error Handling in Node.js](https://www.joyent.com/developers/node/design/errors)
 * [Building Robust Node Applications: Error Handling](https://strongloop.com/strongblog/robust-node-applications-error-handling/)（StrongLoop 博客）
 
 #### 请勿执行以下操作

--- a/zh-tw/advanced/best-practice-performance.md
+++ b/zh-tw/advanced/best-practice-performance.md
@@ -85,7 +85,6 @@ Node 應用程式一旦遇到未捕捉到的異常狀況，就會當機。如果
 
 如需進一步瞭解錯誤處理的基本概念，請參閱：
 
-* [Error Handling in Node.js](https://www.joyent.com/developers/node/design/errors)
 * [Building Robust Node Applications: Error Handling](https://strongloop.com/strongblog/robust-node-applications-error-handling/) (StrongLoop blog)
 
 #### 禁止事項

--- a/zh-tw/advanced/best-practice-performance.md
+++ b/zh-tw/advanced/best-practice-performance.md
@@ -85,6 +85,7 @@ Node 應用程式一旦遇到未捕捉到的異常狀況，就會當機。如果
 
 如需進一步瞭解錯誤處理的基本概念，請參閱：
 
+* [Error Handling in Node.js](https://www.tritondatacenter.com/node-js/production/design/errors)
 * [Building Robust Node Applications: Error Handling](https://strongloop.com/strongblog/robust-node-applications-error-handling/) (StrongLoop blog)
 
 #### 禁止事項


### PR DESCRIPTION
Remove broken link in [Performance Best Practices Using Express in Production](https://expressjs.com/en/advanced/best-practice-performance.html) on Handle exceptions properly section, there is a link point to [Error Handling in Node.js](https://www.joyent.com/developers/node/design/errors) but the page is not found now and I can't find a replacement for this so I think this is better to be removed
