### PR TITLE
Add `error-handler-json`

### DIFF
--- a/en/guide/error-handling.md
+++ b/en/guide/error-handling.md
@@ -189,6 +189,8 @@ function errorHandler (err, req, res, next) {
 Note that the default error handler can get triggered if you call `next()` with an error
 in your code more than once, even if custom error handling middleware is in place.
 
+Other error handling middleware can be found at [Express middleware](/{{ page.lang }}/resources/middleware.html).
+
 ## Writing error handlers
 
 Define error-handling middleware functions in the same way as other middleware functions,

--- a/en/resources/middleware.md
+++ b/en/resources/middleware.md
@@ -43,6 +43,7 @@ These are some additional popular middleware modules.
 |---------------------------|---------------------|
 | [cls-rtracer](https://github.com/puzpuzpuz/cls-rtracer) | Middleware for CLS-based request id generation. An out-of-the-box solution for adding request ids into your logs.|
 | [connect-image-optimus](https://github.com/msemenistyi/connect-image-optimus) | Optimize image serving. Switches images to `.webp` or `.jxr`, if possible.|
+| [error-handler-json](https://github.com/mifi/error-handler-json) | An error handler for JSON APIs (fork of `api-error-handler`.)|
 | [express-debug](https://github.com/devoidfury/express-debug) | Development tool that adds information about template variables (locals), current session, and so on.|
 | [express-partial-response](https://github.com/nemtsov/express-partial-response) | Filters out parts of JSON responses based on the `fields` query-string; by using Google API's Partial Response.|
 | [express-simple-cdn](https://github.com/jamiesteven/express-simple-cdn) | Use a CDN for static assets, with multiple host support.|


### PR DESCRIPTION
Replacement for https://github.com/expressjs/api-error-handler

from #1359