### PR TITLE
Fix 404 error for statusboard link

### DIFF
--- a/en/resources/community.md
+++ b/en/resources/community.md
@@ -45,7 +45,7 @@ Additionally, the Express community maintains modules in these two GitHub orgs:
 - [jshttp](https://jshttp.github.io/) modules providing useful utility functions; see [Utility modules](/{{ page.lang }}/resources/utils.html).
 - [pillarjs](https://pillarjs.github.io/): low-level modules that Express uses internally.
 
-To keep up with what is going on in the whole community, check out the [ExpressJS StatusBoard](https://expressjs.github.com/statusboard).
+To keep up with what is going on in the whole community, check out the [ExpressJS StatusBoard](https://expressjs.github.io/statusboard/).
 
 ## Gitter
 


### PR DESCRIPTION
From https://expressjs.github.com/statusboard
To https://expressjs.github.io/statusboard/