### PR TITLE
fix typo in req-query.md

### DIFF
--- a/_includes/api/en/4x/req-query.md
+++ b/_includes/api/en/4x/req-query.md
@@ -11,7 +11,7 @@ The value of this property can be configured with the [query parser application 
 
 ```js
 var qs = require('qs')
-app.setting('query parser', function (str) {
+app.set('query parser', function (str) {
   return qs.parse(str, { /* custom options */ })
 })
 ```

--- a/_includes/api/en/5x/req-query.md
+++ b/_includes/api/en/5x/req-query.md
@@ -11,7 +11,7 @@ The value of this property can be configured with the [query parser application 
 
 ```js
 const qs = require('qs')
-app.setting('query parser',
+app.set('query parser',
   (str) => qs.parse(str, { /* custom options */ }))
 ```
 


### PR DESCRIPTION
`app.setting('query parser', ...)` should be `app.set('query parser', ...)`. 
same as #1361, but for both 4x and 5x
@dougwilson