### PR TITLE
Update error-handling.md corrected mistake with example

### DIFF
--- a/en/guide/error-handling.md
+++ b/en/guide/error-handling.md
@@ -104,7 +104,7 @@ that return promises.  For example:
 
 ```js
 app.get('/', (req, res, next) => {
-  Promise.resolve().then(() => {
+  return Promise.resolve().then(() => {
     throw new Error('BROKEN')
   }).catch(next) // Errors will be passed to Express.
 })


### PR DESCRIPTION
The example supplied example did not `return` a promise, only created a promise and returned nothing.

I suspect this was originally wrote as `(req, res, next) => Promise.resolve().....` but was changed to `=> {}` for more readability, but failed to notice the change in behavior that this caused.