### PR TITLE
Fix typo in `req.query` code example

### DIFF
--- a/_includes/api/en/4x/req-query.md
+++ b/_includes/api/en/4x/req-query.md
@@ -11,7 +11,7 @@ The value of this property can be configured with the [query parser application 
 
 ```js
 var qs = require('qs')
-app.setting('query parser', function (str) {
+app.set('query parser', function (str) {
   return qs.parse(str, { /* custom options */ })
 })
 ```


### PR DESCRIPTION
`app.setting` method does not exist. It seemed like a typo that should be changed to `app.settings`. But `app.settings` is an object, not a function. So I believe, it was intended to use `app.set` in that example