### PR TITLE
Added documentation for calling acceptsLanguages without argument

### DIFF
--- a/_includes/api/en/4x/req-acceptsLanguages.md
+++ b/_includes/api/en/4x/req-acceptsLanguages.md
@@ -1,7 +1,15 @@
-<h3 id='req.acceptsLanguages'>req.acceptsLanguages(lang [, ...])</h3>
+<h3 id='req.acceptsLanguages'>req.acceptsLanguages([lang, ...])</h3>
 
 Returns the first accepted language of the specified languages,
 based on the request's `Accept-Language` HTTP header field.
 If none of the specified languages is accepted, returns `false`.
 
+If no `lang` argument is given, then `req.acceptsLanguages()`
+returns all languages from the HTTP `Accept-Language` header
+as an `Array`.
+
 For more information, or if you have issues or concerns, see [accepts](https://github.com/expressjs/accepts).
+
+Express (4.x) source: [request.js line 179](https://github.com/expressjs/express/blob/4.x/lib/request.js#L179)
+
+Accepts (1.3) source: [index.js line 195](https://github.com/jshttp/accepts/blob/f69c19e459bd501e59fb0b1a40b7471bb578113a/index.js#L195)


### PR DESCRIPTION
Calling `req.acceptsLanguages` without argument(s) returns an `array` of languages from the HTTP `Accept-Language` header.

This is much easier than calling `req.get('Accept-Language')`, because you do not need to parse the `Accept-Language` header `string`.

Close #1401