### PR TITLE
[docs]: Routing - `timeLog` not defined

### DIFF
--- a/en/guide/routing.md
+++ b/en/guide/routing.md
@@ -328,8 +328,8 @@ const router = express.Router()
 const timeLog = (req, res, next) => {
   console.log('Time: ', Date.now())
   next()
-};
-router.use(timeLog);
+}
+router.use(timeLog)
 
 // define the home page route
 router.get('/', (req, res) => {

--- a/en/guide/routing.md
+++ b/en/guide/routing.md
@@ -325,10 +325,12 @@ const express = require('express')
 const router = express.Router()
 
 // middleware that is specific to this router
-router.use((req, res, next) => {
+const timeLog = (req, res, next) => {
   console.log('Time: ', Date.now())
   next()
-})
+};
+router.use(timeLog);
+
 // define the home page route
 router.get('/', (req, res) => {
   res.send('Birds home page')


### PR DESCRIPTION
Either have a function named `timeLog` or reword the last sentence of the page to remove the use of that name.