### PR TITLE
Add req.res in menu

### DIFF
--- a/_includes/api/en/3x/menu.md
+++ b/_includes/api/en/3x/menu.md
@@ -94,6 +94,8 @@
             </li>
             <li><a href="#req.acceptsLanguage">req.acceptsLanguage()</a>
             </li>
+            <li><a href="#req.res">req.res</a>
+            </li>
         </ul>
     </li>
     <li id="res-api"> <a href="#response">Response</a>

--- a/_includes/api/en/4x/menu.md
+++ b/_includes/api/en/4x/menu.md
@@ -98,6 +98,8 @@
             </li>
             <li><a href="#req.query">req.query</a>
             </li>
+            <li><a href="#req.res">req.res</a>
+            </li>
             <li><a href="#req.route">req.route</a>
             </li>
             <li><a href="#req.secure">req.secure</a>

--- a/_includes/api/en/5x/menu.md
+++ b/_includes/api/en/5x/menu.md
@@ -100,6 +100,8 @@
             </li>
             <li><a href="#req.query">req.query</a>
             </li>
+            <li><a href="#req.res">req.res</a>
+            </li>
             <li><a href="#req.route">req.route</a>
             </li>
             <li><a href="#req.secure">req.secure</a>


### PR DESCRIPTION
In API reference docs, `req.res` is not present in the menu. I have added in the menu for 3x, 4x, 5x.
closes: #1388