### PR TITLE
Fix broken link

### DIFF
--- a/_includes/api/en/4x/res-render.md
+++ b/_includes/api/en/4x/res-render.md
@@ -8,7 +8,7 @@ Optional parameters:
 
 The `view` argument is a string that is the file path of the view file to render. This can be an absolute path, or a path relative to the `views` setting. If the path does not contain a file extension, then the `view engine` setting determines the file extension. If the path does contain a file extension, then Express will load the module for the specified template engine (via `require()`) and render it using the loaded module's `__express` function.
 
-For more information, see [Using template engines with Express](/guide/using-template-engines.html).
+For more information, see [Using template engines with Express](/{{page.lang}}/guide/using-template-engines.html).
 
 <div class="doc-box doc-warn" markdown="1">
 The `view` argument performs file system operations like reading a file from


### PR DESCRIPTION
Link to template engines guide redirects wrongly to turkish page. Added `{{page.lang}}` in the URL string