### PR TITLE
Fixed disappearing links

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -812,6 +812,14 @@ h2 a {
 
 /* responsive */
 
+@media all and (min-width: 900px) {
+ 
+  #navmenu {
+   display: block !important;
+  }
+ 
+}
+
 @media all and (max-width: 899px) {
 
   #conference a img {


### PR DESCRIPTION
The links were diaappearing due to the toggle method called on the #navmenu ul in jqeury, which let to an inline styling of display:none . Now when we click on hamburger menu in smaller width two times it first adds display block and then changes to none on the second click. Now as it is an inline css we can override it using !important. 

Files changed:
1. css/style.css

Changes description:
Added `display: block !important;` on screen width being more than equal to 900px

Issue fixed: [Link to the issue](https://github.com/expressjs/expressjs.com/issues/1398)


