### PR TITLE
Fix: Added lang variable for guide links

### DIFF
--- a/_includes/api/en/4x/app-METHOD.md
+++ b/_includes/api/en/4x/app-METHOD.md
@@ -59,4 +59,4 @@ The method, `app.all()`, is not derived from any HTTP method and loads middlewar
 the specified path for _all_ HTTP request methods.
 For more information, see [app.all](#app.all).
 
-For more information on routing, see the [routing guide](/guide/routing.html).
+For more information on routing, see the [routing guide](/{{page.lang}}/guide/routing.html).

--- a/_includes/api/en/4x/app-delete-method.md
+++ b/_includes/api/en/4x/app-delete-method.md
@@ -1,7 +1,7 @@
 <h3 id='app.delete.method'>app.delete(path, callback [, callback ...])</h3>
 
 Routes HTTP DELETE requests to the specified path with the specified callback functions.
-For more information, see the [routing guide](/guide/routing.html).
+For more information, see the [routing guide](/{{page.lang}}/guide/routing.html).
 
 {% include api/en/4x/routing-args.html %}
 

--- a/_includes/api/en/4x/app-get-method.md
+++ b/_includes/api/en/4x/app-get-method.md
@@ -4,7 +4,7 @@ Routes HTTP GET requests to the specified path with the specified callback funct
 
 {% include api/en/4x/routing-args.html %}
 
-For more information, see the [routing guide](/guide/routing.html).
+For more information, see the [routing guide](/{{page.lang}}/guide/routing.html).
 
 #### Example
 

--- a/_includes/api/en/4x/app-post-method.md
+++ b/_includes/api/en/4x/app-post-method.md
@@ -1,7 +1,7 @@
 <h3 id='app.post.method'>app.post(path, callback [, callback ...])</h3>
 
 Routes HTTP POST requests to the specified path with the specified callback functions.
-For more information, see the [routing guide](/guide/routing.html).
+For more information, see the [routing guide](/{{page.lang}}/guide/routing.html).
 
 {% include api/en/4x/routing-args.html %}
 

--- a/_includes/api/en/4x/app-settings.md
+++ b/_includes/api/en/4x/app-settings.md
@@ -198,7 +198,7 @@ A custom query string parsing function will receive the complete query string, a
   <h5 id="trust.proxy.options.table">Options for `trust proxy` setting</h5>
 
   <p markdown="1">
-  Read [Express behind proxies](/guide/behind-proxies.html) for more
+  Read [Express behind proxies](/{{page.lang}}/guide/behind-proxies.html) for more
   information.
   </p>
 

--- a/_includes/api/en/4x/app-use.md
+++ b/_includes/api/en/4x/app-use.md
@@ -1,6 +1,6 @@
 <h3 id='app.use'>app.use([path,] callback [, callback...])</h3>
 
-Mounts the specified [middleware](/guide/using-middleware.html) function or functions
+Mounts the specified [middleware](/{{page.lang}}/guide/using-middleware.html) function or functions
 at the specified path:
 the middleware function is executed when the base of the requested path matches `path`.
 
@@ -284,7 +284,7 @@ app.use(mw1, [mw2, r1, r2], subApp)
 
 </table>
 
-Following are some examples of using the [express.static](/guide/using-middleware.html#middleware.built-in)
+Following are some examples of using the [express.static](/{{page.lang}}/guide/using-middleware.html#middleware.built-in)
 middleware in an Express app.
 
 Serve static content for the app from the "public" directory in the application directory:

--- a/_includes/api/en/5x/app-METHOD.md
+++ b/_includes/api/en/5x/app-METHOD.md
@@ -59,4 +59,4 @@ The method, `app.all()`, is not derived from any HTTP method and loads middlewar
 the specified path for _all_ HTTP request methods.
 For more information, see [app.all](#app.all).
 
-For more information on routing, see the [routing guide](/guide/routing.html).
+For more information on routing, see the [routing guide](/{{page.lang}}/guide/routing.html).

--- a/_includes/api/en/5x/app-delete-method.md
+++ b/_includes/api/en/5x/app-delete-method.md
@@ -1,7 +1,7 @@
 <h3 id='app.delete.method'>app.delete(path, callback [, callback ...])</h3>
 
 Routes HTTP DELETE requests to the specified path with the specified callback functions.
-For more information, see the [routing guide](/guide/routing.html).
+For more information, see the [routing guide](/{{page.lang}}/guide/routing.html).
 
 {% include api/en/5x/routing-args.html %}
 

--- a/_includes/api/en/5x/app-get-method.md
+++ b/_includes/api/en/5x/app-get-method.md
@@ -4,7 +4,7 @@ Routes HTTP GET requests to the specified path with the specified callback funct
 
 {% include api/en/5x/routing-args.html %}
 
-For more information, see the [routing guide](/guide/routing.html).
+For more information, see the [routing guide](/{{page.lang}}/guide/routing.html).
 
 #### Example
 

--- a/_includes/api/en/5x/app-post-method.md
+++ b/_includes/api/en/5x/app-post-method.md
@@ -1,7 +1,7 @@
 <h3 id='app.post.method'>app.post(path, callback [, callback ...])</h3>
 
 Routes HTTP POST requests to the specified path with the specified callback functions.
-For more information, see the [routing guide](/guide/routing.html).
+For more information, see the [routing guide](/{{page.lang}}/guide/routing.html).
 
 {% include api/en/5x/routing-args.html %}
 

--- a/_includes/api/en/5x/app-settings.md
+++ b/_includes/api/en/5x/app-settings.md
@@ -198,7 +198,7 @@ A custom query string parsing function will receive the complete query string, a
   <h5 id="trust.proxy.options.table">Options for `trust proxy` setting</h5>
 
   <p markdown="1">
-  Read [Express behind proxies](/guide/behind-proxies.html) for more
+  Read [Express behind proxies]/{{page.lang}}/behind-proxies.html) for more
   information.
   </p>
 

--- a/_includes/api/en/5x/app-use.md
+++ b/_includes/api/en/5x/app-use.md
@@ -1,6 +1,6 @@
 <h3 id='app.use'>app.use([path,] callback [, callback...])</h3>
 
-Mounts the specified [middleware](/guide/using-middleware.html) function or functions
+Mounts the specified [middleware](/{{page.lang}}/guide/using-middleware.html) function or functions
 at the specified path:
 the middleware function is executed when the base of the requested path matches `path`.
 
@@ -259,7 +259,7 @@ app.use(mw1, [mw2, r1, r2], subApp)
 
 </table>
 
-Following are some examples of using the [express.static](/guide/using-middleware.html#middleware.built-in)
+Following are some examples of using the [express.static](/{{page.lang}}/guide/using-middleware.html#middleware.built-in)
 middleware in an Express app.
 
 Serve static content for the app from the "public" directory in the application directory:

--- a/_includes/api/en/5x/res-render.md
+++ b/_includes/api/en/5x/res-render.md
@@ -8,7 +8,7 @@ Optional parameters:
 
 The `view` argument is a string that is the file path of the view file to render. This can be an absolute path, or a path relative to the `views` setting. If the path does not contain a file extension, then the `view engine` setting determines the file extension. If the path does contain a file extension, then Express will load the module for the specified template engine (via `require()`) and render it using the loaded module's `__express` function.
 
-For more information, see [Using template engines with Express](/guide/using-template-engines.html).
+For more information, see [Using template engines with Express](/{{page.lang}}/guide/using-template-engines.html).
 
 **NOTE:** The `view` argument performs file system operations like reading a file from disk and evaluating Node.js modules, and as so for security reasons should not contain input from the end-user.
 

--- a/uk/guide/writing-middleware.md
+++ b/uk/guide/writing-middleware.md
@@ -142,4 +142,4 @@ When you make a request to the root of the app, the app now displays the timesta
 
 Because you have access to the request object, the response object, the next middleware function in the stack, and the whole Node.js API, the possibilities with middleware functions are endless.
 
-For more information about Express middleware, see: [Using Express middleware](/guide/using-middleware.html).
+For more information about Express middleware, see: [Using Express middleware]/{{page.lang}}/using-middleware.html).

--- a/uz/guide/routing.md
+++ b/uz/guide/routing.md
@@ -131,7 +131,7 @@ app.get(/.*fly$/, function(req, res) {
 
 <h2 id="route-handlers">Route handlers</h2>
 
-You can provide multiple callback functions that behave just like [middleware](/guide/using-middleware.html) to handle a request. The only exception is that these callbacks may invoke `next('route')` to bypass the remaining route callback(s). You can use this mechanism to impose pre-conditions on a route, then pass control to subsequent routes if there's no reason to proceed with the current route.
+You can provide multiple callback functions that behave just like [middleware](/{{page.lang}}/guide/using-middleware.html) to handle a request. The only exception is that these callbacks may invoke `next('route')` to bypass the remaining route callback(s). You can use this mechanism to impose pre-conditions on a route, then pass control to subsequent routes if there's no reason to proceed with the current route.
 
 Route handlers can come in the form of a function, an array of functions, or various combinations of both, as shown the following examples.
 

--- a/uz/starter/basic-routing.md
+++ b/uz/starter/basic-routing.md
@@ -39,4 +39,4 @@ app.delete('/user', function (req, res) {
 })
 </code></pre>
 
-Marshrutizatsiya haqida to'liq ma'lumot olish uchun, ma'lumotnoma orqali [Marshrutizatsiya](/guide/routing.html) bo'limini o'qib chiqing.
+Marshrutizatsiya haqida to'liq ma'lumot olish uchun, ma'lumotnoma orqali [Marshrutizatsiya](/{{page.lang}}/guide/routing.html) bo'limini o'qib chiqing.

--- a/uz/starter/faq.md
+++ b/uz/starter/faq.md
@@ -84,7 +84,7 @@ app.use(function(err, req, res, next){
 });
 </code></pre>
 
-Batafsil ma'lumot uchun [Xatolarni qayta ishlash](/guide/error-handling.html) o'qing.
+Batafsil ma'lumot uchun [Xatolarni qayta ishlash](/{{page.lang}}/guide/error-handling.html) o'qing.
 
 ## Qanday qilib plain HTMLni render qilishim mumkin?
 


### PR DESCRIPTION
**Fixes #1406**

## :memo:  Description
Prepended `{{page.lang}}` to `/guide/...` links in the markdown files at `_includes/api/en/4x/`. So, now the correct language shows up in the links & it leads to the correct documentations. 

The following show the changes at [https://expressjs.com/en/api.html#res.render](https://expressjs.com/en/api.html#res.render)
## :framed_picture: Current behavior 

![image](https://github.com/expressjs/expressjs.com/assets/70562711/a074b9e6-9f3d-4ea8-95a4-cde7718feece)

## :zap: New behavior
Now, the correct language shows in the link.

![image](https://github.com/expressjs/expressjs.com/assets/70562711/134402a2-cef6-4edf-a30a-62168560d3cd)