### PR TITLE
Update "query parser" default value in 5.x

### DIFF
--- a/_includes/api/en/5x/app-settings.md
+++ b/_includes/api/en/5x/app-settings.md
@@ -109,7 +109,7 @@ The extended query parser is based on [qs](https://www.npmjs.org/package/qs).
 
 A custom query string parsing function will receive the complete query string, and must return an object of query keys and their values.
   </td>
-      <td>"extended"</td>
+      <td>"simple"</td>
     </tr>
     <tr>
   <td markdown="1">


### PR DESCRIPTION
"query parser" defaults to `"simple"` since 5.0.0-beta.1, but 9ce25ebb5362d399cac912d873a9bd792afefb6d did not update the value in `app-settings.md`.