### PR TITLE
Fix: Removed background image form style.css

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -14,7 +14,7 @@
 
 body {
   font: 400 14px/1.6 "Open Sans", sans-serif;
-/*   background: url(/images/bg.jpg); */
+  background: url(/images/bg.jpg); 
   margin: 0;
   padding: 0;
   color: #555;
@@ -668,6 +668,12 @@ footer {
   }
 
 }
+
+@media (prefers-color-scheme:dark) {
+    .en-doc{
+        background: black;
+    }
+  }
 
 /* navigation */
 

--- a/css/style.css
+++ b/css/style.css
@@ -14,7 +14,7 @@
 
 body {
   font: 400 14px/1.6 "Open Sans", sans-serif;
-  background: url(/images/bg.jpg);
+/*   background: url(/images/bg.jpg); */
   margin: 0;
   padding: 0;
   color: #555;


### PR DESCRIPTION
**Fixes** #1382

Sometimes it creates eye strain when you are learning form a white backgrounded documentation since 4 to 6 hours a day.  That is why, I removed that white background image and the website is looking very good now.

> One important thing I need to mention that people who don't have enabled **Auto Dark Mode for Web Contents** they will still enjoy the same view as it is. But, like me those who enabled that they would view this website like below ...

### Examples:


![image](https://github.com/expressjs/expressjs.com/assets/106915718/10f4da44-b653-4a5b-a7da-d589cc029057)

![image](https://github.com/expressjs/expressjs.com/assets/106915718/f03d95eb-5e98-4368-86fb-09755c3fbe4c)


