### PR TITLE
Fix duplicate link in menu.md

### DIFF
--- a/_includes/api/en/5x/menu.md
+++ b/_includes/api/en/5x/menu.md
@@ -42,8 +42,6 @@
             </li>
             <li><a href="#app.get">app.get()</a>
             </li>
-            <li><a href="#app.get.method">app.get()</a>
-            </li>
             <li><a href="#app.listen">app.listen()</a>
             </li>
             <li><a href="#app.METHOD">app.METHOD()</a>


### PR DESCRIPTION
On the API Methods menu, `app.get` appears twice. As the duplicate link only increments the menu by one item, and offers no distinction between `app.get` and `app.get.method`, the duplicate can therefore be removed to improve navigation.