### PR TITLE
fix: temporary change to enable CI on review submission

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,16 @@ on:
   push:
     branches:
     - gh-pages
+  pull_request_review:
+      types: [submitted]
 
 jobs:
   test:
     runs-on: ubuntu-latest
+    if: |
+      github.event.pull_request.draft != true &&
+      (github.event_name == 'pull_request_review' && github.event.review.state == 'approved') ||
+      github.event_name != 'pull_request_review'
     strategy:
       matrix:
         node-version:


### PR DESCRIPTION
This is a change (ideally temporary) to run ci when we approve PRs. There was a conflicting setting to not allow merges when CI hadn't run, but also the branch protections were set to require CI to merge. We could just override, but why have CI if we are not going to run it?