### PR TITLE
Change Jekyll config settings and .gitignore for Jekyll stuff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ _site
 **/Thumbs.db
 Gemfile.lock
 .jekyll-metadata
+vendor
+.bundle

--- a/_config.yml
+++ b/_config.yml
@@ -3,7 +3,7 @@
 # Build settings
 markdown: kramdown
 
-gems:
+plugins:
   - jekyll-redirect-from
 
 kramdown:
@@ -12,6 +12,9 @@ kramdown:
   syntax_highlighter_opts:
     disable : true
 
-exclude: [uk/CHANGELOG.md]
+exclude: 
+  - [uk/CHANGELOG.md]
+  - vendor/bundle
+
 
 github: [metadata]


### PR DESCRIPTION
I installed Jekyll on a new laptop and need to update .gitignore.
Also changed `gems` to `plugins` in config, based on the warning from Jekyll.