### PR TITLE
Updates Releases page w/ last two patches  (4.18.2, 4.18.3)

### DIFF
--- a/_data/express.yml
+++ b/_data/express.yml
@@ -1,1 +1,1 @@
-current_version: "4.18.1"
+current_version: "4.18.3"

--- a/en/changelog/4x.md
+++ b/en/changelog/4x.md
@@ -8,6 +8,32 @@ redirect_from: "/changelog/4x.html"
 
 # Release Change Log
 
+## 4.18.3 - Release date: 2024-02-26
+{: id="4.18.3"}
+
+The 4.18.3 patch release includes the following bug fix:
+
+<ul>
+  <li markdown="1" class="changelog-item">
+  Fix routing requests without method [commit](https://github.com/expressjs/express/commit/74beeac0718c928b4ba249aba3652c52fbe32ca8)
+  </li>
+</ul>
+
+For a complete list of changes in this release, see [History.md](https://github.com/expressjs/express/blob/master/History.md#4183--2024-02-26)
+
+## 4.18.2 - Release date: 2022-10-08
+{: id="4.18.2"}
+
+The 4.18.2 patch release includes the following bug fix:
+
+<ul>
+  <li markdown="1" class="changelog-item">
+  Fix regression routing a large stack in a single route [commit](https://github.com/expressjs/express/commit/7ec5dd2b3c5e7379f68086dae72859f5573c8b9b)
+  </li>
+</ul>
+
+For a complete list of changes in this release, see [History.md](https://github.com/expressjs/express/blob/master/History.md#4182--2022-10-08)
+
 ## 4.18.1 - Release date: 2022-04-29
 {: id="4.18.1"}
 


### PR DESCRIPTION
This PR closes #1468 

This is a manual process today, evidenced by commits like https://github.com/expressjs/expressjs.com/commit/5c98ee4e949fc69b9dbc89b839c137b7a2eea3fc and https://github.com/expressjs/expressjs.com/commit/f1f42d9bd202a13d6db83287ee075b02253822a7

We should at least make sure this is part of our release checklist, until we change things to automate this. Thought we had an issue about Relase Process, found https://github.com/expressjs/discussions/issues/187

cc @UlisesGascon do we have a checklist? We should add updating the Releases page and current version number in expressjs.com to it