### PR TITLE
removed <pre> tag reason syntax hilighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,13 +43,12 @@ Jekyll uses the [Liquid template engine](http://liquidmarkup.org/) for templatin
 
 You can use [GFM](https://kramdown.gettalong.org/parser/gfm.html) fenced code blocks for JavaScript; for example:
 
-<pre>
+
 ```js
 var express = require('express')
 var app = express()
 app.listen(3000)
 ```
-</pre>
 
 The result looks like this:
 


### PR DESCRIPTION
# before
![before](https://github.com/expressjs/expressjs.com/assets/59386700/158d3950-4b4d-4d31-b14f-e4299c61db51)

# after 
![after](https://github.com/expressjs/expressjs.com/assets/59386700/352eb5ae-fd68-41a3-b3fb-7d1de82d07a1)

