### PR TITLE
Fix link to point to the English docs

### DIFF
--- a/_includes/api/en/4x/app-settings.md
+++ b/_includes/api/en/4x/app-settings.md
@@ -29,11 +29,10 @@ Sub-apps will not inherit the value of `view cache` in production (when `NODE_EN
   <td markdown="1">
   `env`
   </td>
-      <td>String</td>
-      <td>Environment mode.
-      Be sure to set to "production" in a production environment;
-      see <a href="/en/advanced/best-practice-performance.html#env">Production best practices: performance and reliability</a>.
-    </td>
+  <td>String</td>
+  <td markdown="1">
+  Environment mode. Be sure to set to "production" in a production environment; see [Production best practices: performance and reliability](/{{page.lang}}/advanced/best-practice-performance.html#env).
+  </td>
   <td markdown="1">
   `process.env.NODE_ENV` (`NODE_ENV` environment variable) or "development" if `NODE_ENV` is not set.
   </td>

--- a/_includes/api/en/4x/app-settings.md
+++ b/_includes/api/en/4x/app-settings.md
@@ -32,7 +32,7 @@ Sub-apps will not inherit the value of `view cache` in production (when `NODE_EN
       <td>String</td>
       <td>Environment mode.
       Be sure to set to "production" in a production environment;
-      see <a href="/advanced/best-practice-performance.html#env">Production best practices: performance and reliability</a>.
+      see <a href="/en/advanced/best-practice-performance.html#env">Production best practices: performance and reliability</a>.
     </td>
   <td markdown="1">
   `process.env.NODE_ENV` (`NODE_ENV` environment variable) or "development" if `NODE_ENV` is not set.


### PR DESCRIPTION
A /en was added to the link for the Performance best practices section in English.

Without it, the link redirects to the docs in some other language.