### PR TITLE
Add support for Docker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,3 +45,9 @@ jobs:
     - name: Run tests
       shell: bash
       run: npm test
+    
+    - name: Check Docker support
+      shell: bash
+      run: |
+        docker --version
+        make build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# Use the official Jekyll image as the base
+FROM jekyll/jekyll:3.7
+
+# Set the working directory
+WORKDIR /usr/src/app
+
+# Change the permissions of the working directory
+RUN chmod 777 /usr/src/app
+
+# Copy the Gemfile into the image
+COPY Gemfile ./
+
+# Install the gems and delete the Gemfile.lock
+RUN bundle install --no-cache && rm Gemfile.lock
+
+# Copy the rest of the project into the image
+COPY . .
+
+# Expose the port Jekyll will run on
+EXPOSE 4000
+
+# The default command to run Jekyll
+CMD ["jekyll", "serve", "--host", "0.0.0.0", "--livereload"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use the official Jekyll image as the base
-FROM jekyll/jekyll:3.7
+FROM jekyll/jekyll:4.2.2
 
 # Set the working directory
 WORKDIR /usr/src/app

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+GREEN := \033[1;32m
+BLUE := \033[1;34m
+RESET := \033[0m
+
+# The directory of this file
+DIR := $(shell echo $(shell cd "$(shell dirname "${BASH_SOURCE[0]}" )" && pwd ))
+
+# This will output the help for each task
+# thanks to https://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
+.PHONY: help
+
+help: ## This help
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "${GREEN}%-30s${RESET} %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+
+.DEFAULT_GOAL := help
+
+serve: ## Local server
+	@echo "${BLUE}Servering website in localhost:4000${RESET}"
+	docker run -p 4000:4000 -v $(DIR):/usr/src/app my-jekyll-project
+
+build: ## Build site
+	@echo "${BLUE}Building site...${RESET}"
+	docker build -t expressjs.com .
+
+clean: ## Clean up
+	@echo "${BLUE}Clean up...${RESET}"
+	docker rmi expressjs.com

--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,8 @@ help: ## This help
 .DEFAULT_GOAL := help
 
 serve: ## Local server
-	@echo "${BLUE}Servering website in localhost:4000${RESET}"
-	docker run -p 4000:4000 -v $(DIR):/usr/src/app expressjs.com
+	@echo "${BLUE}Starting expressjs.com at http://localhost:4000${RESET}"
+	docker run -p 4000:4000 -p 35729:35729 -v $(DIR):/usr/src/app expressjs.com
 
 build: ## Build site
 	@echo "${BLUE}Building site...${RESET}"

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ help: ## This help
 
 serve: ## Local server
 	@echo "${BLUE}Servering website in localhost:4000${RESET}"
-	docker run -p 4000:4000 -v $(DIR):/usr/src/app my-jekyll-project
+	docker run -p 4000:4000 -v $(DIR):/usr/src/app expressjs.com
 
 build: ## Build site
 	@echo "${BLUE}Building site...${RESET}"

--- a/README.md
+++ b/README.md
@@ -37,12 +37,13 @@ To preview the website locally:
 
 ## Local Setup using Docker
 
+>[!TIP]
+> You can run `make help` to obtain detailed information on how to use our make commands.
+
 0. Ensure that you have Docker and Make installed.
 1. Run `make build` to build the project.
 2. Run `make serve` to serve the project, this include live reloading so any change will be reflected (it can take a while, check the logs).
 3. Run `make clean` to remove the docker images and resources generated.
-
-Note: You can run `make help` to obtain detailed information on how to use our make commands.
 
 ## Formatting
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ To preview the website locally:
 
    Then, load <http://localhost:4000> in your browser.
 
+## Local Setup using Docker
+
+0. Ensure that you have Docker and Make installed.
+1. Run `make build` to build the project.
+2. Run `make serve` to serve the project, this include live reloading so any change will be reflected (it can take a while, check the logs).
+3. Run `make clean` to remove the docker images and resources generated.
+
 ## Formatting
 
 Jekyll uses a variant of Markdown known as [Kramdown](https://kramdown.gettalong.org/quickref.html).

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ To preview the website locally:
 2. Run `make serve` to serve the project, this include live reloading so any change will be reflected (it can take a while, check the logs).
 3. Run `make clean` to remove the docker images and resources generated.
 
+Note: You can run `make help` to obtain detailed information on how to use our make commands.
+
 ## Formatting
 
 Jekyll uses a variant of Markdown known as [Kramdown](https://kramdown.gettalong.org/quickref.html).


### PR DESCRIPTION
### Main Changes

I had some issues to run the project locally, so I explored a way to run the project using Docker (including live reloading). Also I added an additional step in the CI to ensure that the Docker support is tested on every change.

### Acknowledgments

I used [this article](https://monkiki.github.io/2020/07/01/usando-jekyll-con-docker.html) by @monkiki as a reference for the Makefile configuration.

### Changelog
- 36fc9da chore: add a Dockerfile by @UlisesGascon
- d549dce chore: add a Makefile to support Docker operations by @UlisesGascon
- 50070b7 docs: update documentation to include Docker support by @UlisesGascon
- c85b810 ci: add step to check Docker build by @UlisesGascon
- b3163fb fix: typo in docker image reference by @UlisesGascon
- d5aa944 docs: add information about make help by @UlisesGascon

