### PR TITLE
docs: add minimum nodejs version in docs

### DIFF
--- a/en/4x/api.md
+++ b/en/4x/api.md
@@ -9,6 +9,8 @@ redirect_from: "/4x/api.html"
 
   <h1>4.x API</h1>
 
+  {% include note.html content="Express 4.0 requires Node.js 0.10 or higher." %}
+
   {% include api/{{ page.lang }}/4x/express.md %}
   {% include api/{{ page.lang }}/4x/app.md %}
   {% include api/{{ page.lang }}/4x/req.md %}

--- a/en/5x/api.md
+++ b/en/5x/api.md
@@ -11,7 +11,7 @@ redirect_from: "/5x/api.html"
 
   {% include note.html content="This is early beta documentation that may be incomplete and is still under development." %}
 
-  {% include note.html content="Express 5.0 will require Node.js 18 or higher." %}
+  {% include note.html content="Express 5.0 requires Node.js 18 or higher." %}
 
   {% include api/{{ page.lang }}/5x/express.md %}
   {% include api/{{ page.lang }}/5x/app.md %}

--- a/en/5x/api.md
+++ b/en/5x/api.md
@@ -11,6 +11,8 @@ redirect_from: "/5x/api.html"
 
   {% include note.html content="This is early beta documentation that may be incomplete and is still under development." %}
 
+  {% include note.html content="Express 5.0 will require Node.js 18 or higher." %}
+
   {% include api/{{ page.lang }}/5x/express.md %}
   {% include api/{{ page.lang }}/5x/app.md %}
   {% include api/{{ page.lang }}/5x/req.md %}

--- a/en/starter/faq.md
+++ b/en/starter/faq.md
@@ -90,4 +90,11 @@ If you have a specific file, use the `res.sendFile()` function.
 If you are serving many assets from a directory, use the `express.static()`
 middleware function.
 
+<a name="which-is-the-minimum-version-of-nodejs-that-express-supports"></a>
+
+## Which is the minimum version of Node.js that Express supports?
+
+* [Express 4.x](/{{ page.lang }}/4x/api.html) requires Node.js 0.10 or higher.
+* [Express 5.x](/{{ page.lang }}/5x/api.html) will require Node.js 18 or higher.
+
 ###  [Previous: More examples ](/{{ page.lang }}/starter/examples.html)

--- a/en/starter/faq.md
+++ b/en/starter/faq.md
@@ -90,8 +90,6 @@ If you have a specific file, use the `res.sendFile()` function.
 If you are serving many assets from a directory, use the `express.static()`
 middleware function.
 
-<a name="what-version-of-nodejs-does-express-require"></a>
-
 ## What version of Node.js does Express require?
 
 * [Express 4.x](/{{ page.lang }}/4x/api.html) requires Node.js 0.10 or higher.

--- a/en/starter/faq.md
+++ b/en/starter/faq.md
@@ -90,11 +90,11 @@ If you have a specific file, use the `res.sendFile()` function.
 If you are serving many assets from a directory, use the `express.static()`
 middleware function.
 
-<a name="which-is-the-minimum-version-of-nodejs-that-express-supports"></a>
+<a name="what-version-of-nodejs-does-express-require"></a>
 
-## Which is the minimum version of Node.js that Express supports?
+## What version of Node.js does Express require?
 
 * [Express 4.x](/{{ page.lang }}/4x/api.html) requires Node.js 0.10 or higher.
-* [Express 5.x](/{{ page.lang }}/5x/api.html) will require Node.js 18 or higher.
+* [Express 5.x](/{{ page.lang }}/5x/api.html) requires Node.js 18 or higher.
 
 ###  [Previous: More examples ](/{{ page.lang }}/starter/examples.html)

--- a/en/starter/installing.md
+++ b/en/starter/installing.md
@@ -10,6 +10,10 @@ redirect_from: "/starter/installing.html"
 
 Assuming you've already installed [Node.js](https://nodejs.org/), create a directory to hold your application, and make that your working directory.
 
+<div class="doc-box doc-info" markdown="1">
+Check the minimum required Node.js for each Express version [here](/{{ page.lang }}/starter/faq.html#which-is-the-minimum-version-of-nodejs-that-express-supports).
+</div>
+
 ```console
 $ mkdir myapp
 $ cd myapp

--- a/en/starter/installing.md
+++ b/en/starter/installing.md
@@ -10,9 +10,8 @@ redirect_from: "/starter/installing.html"
 
 Assuming you've already installed [Node.js](https://nodejs.org/), create a directory to hold your application, and make that your working directory.
 
-<div class="doc-box doc-info" markdown="1">
-Check the minimum required Node.js for each Express version [here](/{{ page.lang }}/starter/faq.html#which-is-the-minimum-version-of-nodejs-that-express-supports).
-</div>
+* [Express 4.x](/{{ page.lang }}/4x/api.html) requires Node.js 0.10 or higher.
+* [Express 5.x](/{{ page.lang }}/5x/api.html) requires Node.js 18 or higher.
 
 ```console
 $ mkdir myapp


### PR DESCRIPTION
The purpose of this PR is to update the documentation to indicate the minimum nodejs version required for each express version, as required [here](https://github.com/expressjs/expressjs.com/issues/1478).

I have added this information:
- in the [FAQ section](https://expressjs.com/en/starter/faq.html)
- referenced the FAQ section in the [installation guide](https://expressjs.com/en/starter/installing.html)
- in the express [4.x API](https://expressjs.com/en/4x/api.html)
- in the express [5.x API](https://expressjs.com/en/5x/api.html)

> [!WARNING]
> Please note that I have only made the change for the English version, as I don't know how translations of content into other languages are handled.

![Captura de pantalla 2024-04-25 a las 8 23 46](https://github.com/expressjs/expressjs.com/assets/25435858/ebfe4a12-ce60-485e-8c91-586142065948)
![Captura de pantalla 2024-04-25 a las 8 24 02](https://github.com/expressjs/expressjs.com/assets/25435858/5880c840-90b8-42c1-a6fa-c72d25754af9)
![Captura de pantalla 2024-04-25 a las 8 24 15](https://github.com/expressjs/expressjs.com/assets/25435858/b57566f4-6b6f-4e2d-a57a-0ae8ed5580d4)
![Captura de pantalla 2024-04-25 a las 8 24 24](https://github.com/expressjs/expressjs.com/assets/25435858/996dc476-314d-4637-9b59-17b99292851e)
