### PR TITLE
Update Resources > Contributing to Express

### DIFF
--- a/en/resources/contributing.md
+++ b/en/resources/contributing.md
@@ -36,6 +36,7 @@ contributors can be involved in decision making.
 
 * A **Contributor** is any individual creating or commenting on an issue or pull request.
 * A **Committer** is a subset of contributors who have been given write access to the repository.
+* A **Project Captain** is the lead maintainer of a repository.
 * A **TC (Technical Committee)** is a group of committers representing the required technical
 expertise to resolve rare disputes.
 * A **Triager** is a subset of contributors who have been given triage access to the repository.
@@ -68,7 +69,7 @@ become involved in the discussion and review process if they wish.
 The default for each contribution is that it is accepted once no committer has an objection.
 During a review, committers may also request that a specific contributor who is most versed in a
 particular area gives a "LGTM" before the PR can be merged. There is no additional "sign off"
-process for contributions to land. Once all issues brought by committers are addressed, it can
+process for contributions to land. Once all issues brought by committers are addressed it can
 be landed by any committer.
 
 In the case of an objection being raised in a pull request by another committer, all involved
@@ -76,7 +77,7 @@ committers should seek to arrive at a consensus by way of addressing concerns be
 by discussion, compromise on the proposed change, or withdrawal of the proposed change.
 
 If a contribution is controversial and committers cannot agree about how to get it to land
-or if it should land, then it should be escalated to the TC. TC members should regularly
+or if it should land then it should be escalated to the TC. TC members should regularly
 discuss pending contributions in order to find a resolution. It is expected that only a
 small minority of issues be brought to the TC for resolution and that discussion and
 compromise among committers be the default resolution mechanism.
@@ -86,29 +87,14 @@ compromise among committers be the default resolution mechanism.
 Anyone can become a triager! Read more about the process of being a triager in
 [the triage process document](https://github.com/expressjs/express/blob/master/Triager-Guide.md).
 
-[Open an issue in `expressjs/express` repo](https://github.com/expressjs/express/issues/new)
-to request the triage role. State that you have read and agree to the
-[Code of Conduct](https://github.com/expressjs/express/blob/master/Code-Of-Conduct.md) and details of the role.
+Currently, any existing [organization member](https://github.com/orgs/expressjs/people) can nominate 
+a new triager. If you are interested in becoming a triager, our best advice is to actively participate 
+in the community by helping triaging issues and pull requests. As well we recommend
+to engage in other community activities like attending the TC meetings, and participating in the Slack 
+discussions.
 
-Here is an example issue content you can copy and paste:
-
-```
-Title: Request triager role for <your GitHub username>
-
-I have read and understood the project's Code of Conduct.
-I also have read and understood the process and best practices around Express triaging.
-
-I request for a triager role for the following GitHub organizations:
-
-jshttp
-pillarjs
-express
-```
-
-Once you have opened your issue, a member of the TC will add you to the `triage` team in
-the organizations requested. They will then close the issue.
-
-Happy triaging!
+You can also reach out to any of the [organization members](https://github.com/orgs/expressjs/people) 
+if you have questions or need guidance.
 
 ### Becoming a Committer
 
@@ -122,19 +108,87 @@ proper review, and have other committers merge their pull requests.
 
 The TC uses a "consensus seeking" process for issues that are escalated to the TC.
 The group tries to find a resolution that has no open objections among TC members.
-If a consensus cannot be reached that has no objections, then a majority wins vote
+If a consensus cannot be reached that has no objections then a majority wins vote
 is called. It is also expected that the majority of decisions made by the TC are via
 a consensus seeking process and that voting is only used as a last-resort.
 
-Resolution may involve returning the issue to committers with suggestions on how to
-move forward towards a consensus. It is not expected that a meeting of the TC
+Resolution may involve returning the issue to project captains with suggestions on
+how to move forward towards a consensus. It is not expected that a meeting of the TC
 will resolve all issues on its agenda during that meeting and may prefer to continue
-the discussion happening among the committers.
+the discussion happening among the project captains.
 
-Members can be added to the TC at any time. Any committer can nominate another committer
+Members can be added to the TC at any time. Any TC member can nominate another committer
 to the TC and the TC uses its standard consensus seeking process to evaluate whether or
-not to add this new member. Members who do not participate consistently at the level of
-a majority of the other members are expected to resign.
+not to add this new member. The TC will consist of a minimum of 3 active members and a
+maximum of 10. If the TC should drop below 5 members the active TC members should nominate
+someone new. If a TC member is stepping down, they are encouraged (but not required) to
+nominate someone to take their place.
+
+TC members will be added as admin's on the Github orgs, npm orgs, and other resources as
+necessary to be effective in the role.
+
+To remain "active" a TC member should have participation within the last 12 months and miss
+no more than six consecutive TC meetings. Our goal is to increase participation, not punish
+people for any lack of participation, this guideline should be only be used as such
+(replace an inactive member with a new active one, for example). Members who do not meet this
+are expected to step down. If A TC member does not step down, an issue can be opened in the
+discussions repo to move them to inactive status. TC members who step down or are removed due
+to inactivity will be moved into inactive status.
+
+Inactive status members can become active members by self nomination if the TC is not already
+larger than the maximum of 10. They will also be given preference if, while at max size, an
+active member steps down.
+
+### Project Captains
+
+The Express TC can designate captains for individual projects/repos in the
+organizations. These captains are responsible for being the primary
+day-to-day maintainers of the repo on a technical and community front.
+Repo captains are empowered with repo ownership and package publication rights.
+When there are conflicts, especially on topics that effect the Express project
+at large, captains are responsible to raise it up to the TC and drive
+those conflicts to resolution. Captains are also responsible for making sure
+community members follow the community guidelines, maintaining the repo
+and the published package, as well as in providing user support.
+
+Like TC members, Repo captains are a subset of committers.
+
+To become a captain for a project the candidate is expected to participate in that
+project for at least 6 months as a committer prior to the request. They should have
+helped with code contributions as well as triaging issues. They are also required to
+have 2FA enabled on both their GitHub and npm accounts. Any TC member or existing
+captain on the repo can nominate another committer to the captain role, submit a PR to
+this doc, under `Current Project Captains` section (maintaining the sort order) with
+the project, their GitHub handle and npm username (if different). The PR will require
+at least 2 approvals from TC members and 2 weeks hold time to allow for comment and/or
+dissent.  When the PR is merged, a TC member will add them to the proper GitHub/npm groups.
+
+#### Current Project Captains
+
+- `expressjs/express`: @wesleytodd
+- `expressjs/discussions`: @wesleytodd
+- `expressjs/expressjs.com`: @crandmck, @jonchurch
+- `expressjs/body-parser`: @wesleytodd, @jonchurch
+- `expressjs/multer`: @LinusU
+- `expressjs/morgan`: @jonchurch
+- `expressjs/cookie-parser`: @wesleytodd
+- `expressjs/cors`: @jonchurch
+- `expressjs/generator`: @wesleytodd
+- `expressjs/statusboard`: @wesleytodd
+- `pillarjs/encodeurl`: @blakeembrey
+- `pillarjs/path-to-regexp`: @blakeembrey
+- `pillarjs/router`: @dougwilson, @wesleytodd
+- `pillarjs/finalhandler`: @wesleytodd
+- `pillarjs/request`: @wesleytodd
+- `jshttp/http-errors`: @wesleytodd, @jonchurch
+- `jshttp/cookie`: @wesleytodd
+- `jshttp/on-finished`: @wesleytodd
+- `jshttp/forwarded`: @wesleytodd
+- `jshttp/proxy-addr`: @wesleytodd
+
+#### Current Initiative Captains
+
+- Triage team [ref](https://github.com/expressjs/discussions/issues/227): @UlisesGascon
 
 ## Collaborator's guide
 
@@ -223,6 +277,12 @@ announcement, and may ask for additional information or guidance.
 Report security bugs in third-party modules to the person or team maintaining
 the module.
 
+### Pre-release Versions
+
+Alpha and Beta releases are unstable and **not suitable for production use**.
+Vulnerabilities found in pre-releases should be reported according to the [Reporting a Bug](#reporting-a-bug) section.
+Due to the unstable nature of the branch it is not guaranteed that any fixes will be released in the next pre-release.
+
 ### Disclosure Policy
 
 When the security team receives a security bug report, they will assign it to a
@@ -234,8 +294,12 @@ involving the following steps:
   * Prepare fixes for all releases still under maintenance. These fixes will be
     released as fast as possible to npm.
 
+### The Express Threat Model
+
+We are currently working on a new version of the security model, the most updated version can be found [here](https://github.com/expressjs/security-wg/blob/main/docs/ThreatModel.md)
+
 ### Comments on this Policy
 
-If you have suggestions on how this process could be improved, please submit a
+If you have suggestions on how this process could be improved please submit a
 pull request.
 


### PR DESCRIPTION
https://expressjs.com/en/resources/contributing.html reproduces the content of these files by running `get-contributing.sh`:
- https://github.com/expressjs/express/blob/master/Contributing.md
- https://github.com/expressjs/express/blob/master/Collaborator-Guide.md
- https://github.com/expressjs/express/blob/master/Security.md

Several of these files have been updated recently and I realized that we've been negligent in updating this page.