### PR TITLE
[build] ignore node_modules when building jekyll

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -15,6 +15,7 @@ kramdown:
 exclude: 
   - [uk/CHANGELOG.md]
   - vendor/bundle
+  - node_modules/
 
 
 github: [metadata]


### PR DESCRIPTION
Setting up netlify previews, and can't get it to build locally for me unless I ignore node_modules, so trying it out here