### PR TITLE
remove unncessary jekyll install, snap to gh-pages version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,5 @@
 source 'https://rubygems.org'
 
-gem "jekyll", "~> 3.7"
 gem 'github-pages', group: :jekyll_plugins
 gem 'webrick'
 


### PR DESCRIPTION
When using the `github-pages` gem we don't need to manage a jekyll version ourselves, it will use the version currently being used by github

gh-pages builds with the version of jekyll it builds with, so we should let `github-pages` gem manage it