### PR TITLE
Dark Mode Flash Fix

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -5,8 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="og:image" content="https://expressjs.com/images/express-facebook-share.png">
     <link rel="icon" type="image/png" href="/images/favicon.png" />
+    <script src="/js/theme.js"></script>
+    <link rel="stylesheet" href="/css/dark-theme.css?_={{ site.time | date: '%s' }}">
     <link rel="stylesheet" href="/css/style.css?_={{ site.time | date: '%s' }}">
-    <link rel="stylesheet" href="/css/theme.css?_={{ site.time | date: '%s' }}">
     <link rel="stylesheet" href="/css/dropit.css">
     <link rel="stylesheet" href="/css/prism.css">
     <link rel="stylesheet" href="/css/font-awesome.min.css">

--- a/_layouts/3x-api.html
+++ b/_layouts/3x-api.html
@@ -22,7 +22,6 @@
     </section>
 
     {% include footer/footer-{{ page.lang }}.html %}
-    <script src="/js/theme.js"></script>
 
 
   </body>

--- a/_layouts/4x-api.html
+++ b/_layouts/4x-api.html
@@ -22,7 +22,6 @@
     </section>
 
     {% include footer/footer-{{ page.lang }}.html %}
-    <script src="/js/theme.js"></script>
 
   </body>
 

--- a/_layouts/5x-api.html
+++ b/_layouts/5x-api.html
@@ -22,7 +22,6 @@
     </section>
 
     {% include footer/footer-{{ page.lang }}.html %}
-    <script src="/js/theme.js"></script>
 
   </body>
 

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -19,7 +19,6 @@
     {{ content }}
 
     {% include footer/footer-{{ page.lang }}.html %}
-    <script src="../js/theme.js"></script>
   </body>
 
 </html>

--- a/_layouts/middleware.html
+++ b/_layouts/middleware.html
@@ -26,7 +26,6 @@ layout: page
     {% else %}
       <h3>ERROR: No source specified for README {{page.module}}</h3>
     {% endif %}
-    <script src="/js/theme.js"></script>
 
   </div>
 </div>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -31,7 +31,6 @@
     </section>
 
     {% include footer/footer-{{ page.lang }}.html %}
-    <script src="/js/theme.js"></script>
 
   </body>
 

--- a/css/dark-theme.css
+++ b/css/dark-theme.css
@@ -15,57 +15,53 @@
   min-width: 50px;
   color: black;
 }
-body.dark-mode #theme-icon-container {
+html.dark-mode #theme-icon-container {
   color: var(--dark_text);
   background-color: var(--second_dark_bg);
 }
-body.dark-mode {
+html.dark-mode > body {
   background: var(--main_dark_bg);
   color: var(--dark_text);
 }
-body.dark-mode #blm-banner {
-  background-color: var(--main_dark_bg);
-  color: var(--dark _text);
-}
-body.dark-mode header {
+html.dark-mode header {
   background-color: var(--second_dark_bg);
   color: var(--dark_text);
 }
-body.dark-mode #logo > a {
+html.dark-mode #logo > a {
   color: var(--dark_text);
 }
 /* navbar links/drop down menu links */
-body.dark-mode #navbar ul#navmenu li a,
-body.dark-mode #navbar ul#navmenu li.dropit-trigger a {
+html.dark-mode #navbar ul#navmenu li a,
+html.dark-mode #navbar ul#navmenu li.dropit-trigger a {
   color: var(--dark_text);
 }
 /* first drop down link - some js is adding current class */
-body.dark-mode #navbar ul#navmenu li a.current {
+html.dark-mode #navbar ul#navmenu li a.current {
   background: transparent;
 }
-body.dark-mode #navbar ul#navmenu li a.current:hover {
+html.dark-mode #navbar ul#navmenu li a.current:hover {
   background: var(--dark_hover);
 }
-body.dark-mode .menu ul.dropit-submenu {
+html.dark-mode .menu ul.dropit-submenu {
   background: var(--dark_bg);
 }
 /* drop down menu links  */
-body.dark-mode #navbar .menu ul.dropit-submenu a:hover {
+html.dark-mode #navbar .menu ul.dropit-submenu a:hover {
   background: var(--dark_hover);
 }
-body.dark-mode #navbar #navmenu li {
+html.dark-mode #navbar #navmenu li {
   background: var(--second_dark_bg);
 }
 /* search bar */
-body.dark-mode #navbar > span.algolia-autocomplete > input {
+html.dark-mode #navbar > span.algolia-autocomplete > input {
   background-color: var(--second_dark_bg);
 }
-body.dark-mode #navbar > span.algolia-autocomplete > input,
-body.dark-mode #navbar > span.algolia-autocomplete > input::placeholder {
+html.dark-mode #navbar > span.algolia-autocomplete > input,
+html.dark-mode #navbar > span.algolia-autocomplete > input::placeholder {
   color: var(--dark_text);
 }
 /* search bar french */
-:lang(fr) body.dark-mode #navbar ul#navmenu > span.algolia-autocomplete > input {
+:lang(fr) html.dark-mode #navbar ul#navmenu > span.algolia-autocomplete > input {
   background-color: var(--second_dark_bg);
   color: var(--dark_text);
 }
@@ -87,10 +83,10 @@ body.dark-mode #navbar > span.algolia-autocomplete > input::placeholder {
 :lang(fr) span.algolia-autocomplete > input {
   max-width: 100%;
 }
-body.dark-mode #navbar ul#navmenu > span.algolia-autocomplete > input::placeholder {
+html.dark-mode #navbar ul#navmenu > span.algolia-autocomplete > input::placeholder {
   color: var(--dark_text);
 }
-body.dark-mode div#overlay {
+html.dark-mode div#overlay {
   opacity: 0.5;
 }
 @media (max-width: 899px) {
@@ -98,95 +94,95 @@ body.dark-mode div#overlay {
     bottom: 35px;
   }
   /* mobile menu main links hover */
-  body.dark-mode div#navbar ul#navmenu .dropit-trigger:hover {
+  html.dark-mode div#navbar ul#navmenu .dropit-trigger:hover {
     background: var(--dark_hover);
   }
     /* mobile menu inner links hover */
-  body.dark-mode div#navbar .menu ul.dropit-submenu a:hover {
+  html.dark-mode div#navbar .menu ul.dropit-submenu a:hover {
     background: var(--second_dark_hover);
     color: var(--dark_text) !important;
   }
 }
-body.dark-mode .doc-box.doc-info,
-body.dark-mode .doc-box.doc-notice,
-body.dark-mode .doc-box.doc-warn {
+html.dark-mode .doc-box.doc-info,
+html.dark-mode .doc-box.doc-notice,
+html.dark-mode .doc-box.doc-warn {
   color: var(--dark_text);
   background: var(--main_dark_bg);
 }
-body.dark-mode .doc-box.doc-info pre.language-javascript {
+html.dark-mode .doc-box.doc-info pre.language-javascript {
   background: var(--main_dark_bg);
 }
-body.dark-mode h1,
-body.dark-mode h2,
-body.dark-mode h3,
-body.dark-mode code,
-body.dark-mode em,
-body.dark-mode strong  {
+html.dark-mode h1,
+html.dark-mode h2,
+html.dark-mode h3,
+html.dark-mode code,
+html.dark-mode em,
+html.dark-mode strong  {
   color: var(--dark_text);
 }
-body.dark-mode pre {
+html.dark-mode pre {
   background: var(--second_dark_bg);
 }
 /* index.html */
-body.dark-mode #description .express > a {
+html.dark-mode #description .express > a {
   color: var(--dark_text);
 }
-body.dark-mode #install-command {
+html.dark-mode #install-command {
   background: var(--main_dark_bg);
 }
-body.dark-mode #announcements {
+html.dark-mode #announcements {
   background: var(--main_dark_bg);
 }
-body.dark-mode #boxes div > h3 {
+html.dark-mode #boxes div > h3 {
   color: var(--dark_text);
 }
 /* basic-routing.htlm */
-body.dark-mode [class*='language-'] {
+html.dark-mode [class*='language-'] {
   text-shadow: 0 1px var(--second_dark_bg);
 }
 /* js fat arrow operator */
-body.dark-mode .token.operator {
+html.dark-mode .token.operator {
   background: inherit;
 }
 /* debugging.htlm */
-body.dark-mode table tr:first-child th {
+html.dark-mode table tr:first-child th {
   background-color: var(--second_dark_bg);
   color: var(--dark_text);
 }
 /* api pages */
-body.dark-mode #menu li > * {
+html.dark-mode #menu li > * {
   color: var(--dark_text);
 }
-body.dark-mode #menu li ul li > em {
+html.dark-mode #menu li ul li > em {
   color: var(--dark_header_text);
 }
-body.dark-mode #menu li ul li > a {
+html.dark-mode #menu li ul li > a {
   color: var(--dark_inner_text);
 }
-body.dark-mode #api-doc > h3 {
+html.dark-mode #api-doc > h3 {
   color: var(--dark_header_text);
 }
-body.dark-mode #api-doc section h5 {
+html.dark-mode #api-doc section h5 {
   color: var(--dark_header_text);
 }
 /* 
 overriding search-bar results drop down  
 */
-body.dark-mode .ds-dropdown-menu .ds-dataset-1 {
+html.dark-mode .ds-dropdown-menu .ds-dataset-1 {
   background-color: var(--dark_bg);
 }
-body.dark-mode .ds-dropdown-menu .ds-dataset-1 .ds-suggestion a {
+html.dark-mode .ds-dropdown-menu .ds-dataset-1 .ds-suggestion a {
   background-color: var(--second_dark_bg);
   color: var(--dark_text);
 }
-body.dark-mode
+html.dark-mode
   .ds-dropdown-menu
   .ds-dataset-1
   .ds-suggestions
   .algolia-docsearch-suggestion--category-header {
   color: var(--dark_text);
 }
-body.dark-mode
+html.dark-mode
   .ds-dropdown-menu
   .ds-dataset-1
   .ds-suggestions
@@ -194,7 +190,7 @@ body.dark-mode
   .algolia-docsearch-suggestion--subcategory-column {
   color: var(--dark_header_text);
 }
-body.dark-mode
+html.dark-mode
   .ds-dropdown-menu
   .ds-dataset-1
   .ds-suggestions
@@ -202,7 +198,7 @@ body.dark-mode
   .algolia-docsearch-suggestion--title {
   color: var(--dark_text);
 }
-body.dark-mode
+html.dark-mode
   .ds-dropdown-menu
   .ds-dataset-1
   .ds-suggestions
@@ -210,7 +206,7 @@ body.dark-mode
   .algolia-docsearch-suggestion--text {
   color: var(--dark_text);
 }
-body.dark-mode
+html.dark-mode
   .ds-dropdown-menu
   .ds-dataset-1
   .ds-suggestions
@@ -218,8 +214,8 @@ body.dark-mode
   .algolia-docsearch-suggestion--highlight {
   color: var(--link);
 }
-body.dark-mode .ds-suggestion.ds-cursor .algolia-docsearch-suggestion--title,
-body.dark-mode .ds-suggestion.ds-cursor .algolia-docsearch-suggestion--content{
+html.dark-mode .ds-suggestion.ds-cursor .algolia-docsearch-suggestion--title,
+html.dark-mode .ds-suggestion.ds-cursor .algolia-docsearch-suggestion--content{
   background-color: var(--dark_hover);
 }
 

--- a/js/theme.js
+++ b/js/theme.js
@@ -1,8 +1,10 @@
 const themeWatcher = watchColorSchemeChange((colorScheme) => {
   if (!hasLocalStorage()) {
-    // remove icon - toggle not supported
-    document.querySelector('#theme-icon-container').remove()
-    toggleSystemTheme(colorScheme)
+    document?.addEventListener('DOMContentLoaded', () => {
+      // remove icon - toggle not supported
+      document.querySelector('#theme-icon-container').remove()
+      toggleSystemTheme(colorScheme)
+    })
   } else {
     const systemTheme = localStorage.getItem('system-theme')
     const localTheme = localStorage.getItem('local-theme')
@@ -26,9 +28,12 @@ const themeWatcher = watchColorSchemeChange((colorScheme) => {
         }
       }
     }
-    document
-      .querySelector('.theme-toggle')
-      .addEventListener('click', toggleStorageTheme)
+    document.addEventListener('DOMContentLoaded', () => {
+
+      document
+        .querySelector('.theme-toggle')
+        .addEventListener('click', toggleStorageTheme)
+    })
   }
 })
 function toggleSystemTheme(theme) {
@@ -40,6 +45,7 @@ function toggleSystemTheme(theme) {
   }
 }
 function toggleStorageTheme(e) {
+  console.log("hello")
   const localTheme = localStorage.getItem('local-theme')
   if (localTheme === 'light') {
     localStorage.setItem('local-theme', 'dark')
@@ -60,22 +66,22 @@ function toggleStorageTheme(e) {
   }
 }
 function darkModeOn() {
-  document.body.classList.add('dark-mode')
+  document?.documentElement?.classList?.add('dark-mode')
 }
 function lightModeOn() {
-  document.body.classList.remove('dark-mode')
+  document?.documentElement?.classList.remove('dark-mode')
 }
 function darkModeState() {
-  return document.body.classList.contains('dark-mode')
+  return document.documentElement.classList.contains('dark-mode')
 }
 function hasLocalStorage() {
   return typeof Storage !== 'undefined'
 }
 function watchColorSchemeChange(callback) {
-  const darkMediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
+  const darkMediaQuery = window?.matchMedia('(prefers-color-scheme: dark)')
 
   const handleChange = (event) => {
-    const newColorScheme = event.matches ? 'dark' : 'light'
+    const newColorScheme = event?.matches ? 'dark' : 'light'
     callback(newColorScheme)
   }
   darkMediaQuery.addEventListener('change', handleChange)

--- a/js/theme.js
+++ b/js/theme.js
@@ -45,7 +45,6 @@ function toggleSystemTheme(theme) {
   }
 }
 function toggleStorageTheme(e) {
-  console.log("hello")
   const localTheme = localStorage.getItem('local-theme')
   if (localTheme === 'light') {
     localStorage.setItem('local-theme', 'dark')


### PR DESCRIPTION
This fixes issue #1508. Adjust setting of the dark mode class and moved the order of the head to load to run the JS first and add the `dark-mode class`, then load dark mode style sheet first, if required. The theme class is now on the `html` tag to run this all before DOM load. 

If this is not the final solution, it is significantly better than the current situation, which is extremely jarring. 

I'm noticing a flicker now when loading the page, in the nav bar. It's occurring on my local build with the latest changes, but is not occurring on the production site online. So I'm going to submit this PR so I can see the preview to check for the flicker. 

EDIT: After checking, the flicker is there in preview, but is coming from the main branch for me. Doesn't seem to be caused by this PR.