### PR TITLE
fix: Correct typo in example documentation

### DIFF
--- a/_includes/api/en/4x/req-baseUrl.md
+++ b/_includes/api/en/4x/req-baseUrl.md
@@ -12,7 +12,7 @@ var greet = express.Router()
 
 greet.get('/jp', function (req, res) {
   console.log(req.baseUrl) // /greet
-  res.send('Konichiwa!')
+  res.send('Konnichiwa!')
 })
 
 app.use('/greet', greet) // load the router on '/greet'


### PR DESCRIPTION
- Fixed typo in the req.baseUrl example: changed 'konichiwa' to 'konnichiwa'