### PR TITLE
Added job level permissions in `.github/workflows/translation.yml`

### DIFF
--- a/.github/workflows/translation.yml
+++ b/.github/workflows/translation.yml
@@ -57,9 +57,11 @@ jobs:
             });
             const modifiedLanguages = new Set(files.map(file => file.filename.split('/')[0]));
             const labelsToAdd = languages.filter(lang => !modifiedLanguages.has(lang)).map(lang => `requires-translation-${lang}`);
-            await github.rest.issues.addLabels({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: pullRequest.number,
-              labels: labelsToAdd
-            });
+            if (labelsToAdd.length > 0) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pullRequest.number,
+                labels: labelsToAdd
+              });
+            }

--- a/.github/workflows/translation.yml
+++ b/.github/workflows/translation.yml
@@ -30,6 +30,11 @@ on:
 jobs:
   check-translation:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
As seen in #1552, translation.yml fails to add labels to PR due to permissions. 

- [x] Added appropriate permissions for the `check-translation` job.
- [x] Called `github.rest.issues.addLabels()` when `labelsToAdd` is not empty.

#### Notes

- Fixes #1553 