### PR TITLE
Change wildcard to catch routes

### DIFF
--- a/_includes/api/en/5x/app-all.md
+++ b/_includes/api/en/5x/app-all.md
@@ -25,14 +25,14 @@ can perform a task, then call `next()` to continue matching subsequent
 routes.
 
 ```js
-app.all('*', requireAuthentication, loadUser)
+app.all('(.*)', requireAuthentication, loadUser)
 ```
 
 Or the equivalent:
 
 ```js
-app.all('*', requireAuthentication)
-app.all('*', loadUser)
+app.all('(.*)', requireAuthentication)
+app.all('(.*)', loadUser)
 ```
 
 Another example is white-listed "global" functionality.
@@ -40,5 +40,5 @@ The example is similar to the ones above, but it only restricts paths that start
 "/api":
 
 ```js
-app.all('/api/*', requireAuthentication)
+app.all('/api/(.*)', requireAuthentication)
 ```

--- a/_includes/api/en/5x/router-all.md
+++ b/_includes/api/en/5x/router-all.md
@@ -12,14 +12,14 @@ can perform a task, then call `next()` to continue matching subsequent
 routes.
 
 ```js
-router.all('*', requireAuthentication, loadUser)
+router.all('(.*)', requireAuthentication, loadUser)
 ```
 
 Or the equivalent:
 
 ```js
-router.all('*', requireAuthentication)
-router.all('*', loadUser)
+router.all('(.*)', requireAuthentication)
+router.all('(.*)', loadUser)
 ```
 
 Another example of this is white-listed "global" functionality. Here,
@@ -27,5 +27,5 @@ the example is much like before, but it only restricts paths prefixed with
 "/api":
 
 ```js
-router.all('/api/*', requireAuthentication)
+router.all('/api/(.*)', requireAuthentication)
 ```


### PR DESCRIPTION
As #1408 points out, the wildcard defined no longer works. So, replaced `*` with `(.*)` in 5.x specific files. I have also installed the 5.x from npm and verified the wildcard change for root level and api level routes present in the docs.

#### Notes

- Closes #1408 