### PR TITLE
feat: add Version Support page and Commercial Support Options

### DIFF
--- a/2x/applications.html
+++ b/2x/applications.html
@@ -201,8 +201,9 @@
 			<div id="container">
 				<a href='http://github.com/visionmedia/express' id='logo'>Express</a> 
 				<div id="warning">
-				<center><strong>Express 2.x</strong> IS NO LONGER MAINTAINED</center>
+				<center><strong>Express 2.x</strong> IS END-OF-LIFE AND NO LONGER MAINTAINED</center>
 				<p>Known and unknown security and performance issues in 2.x have not been addressed since the last update (29 June, 2012). It is highly recommended to <a href="https://github.com/expressjs/express/wiki/Migrating-from-2.x-to-3.x">upgrade to <strong>Express 3.x</strong></a> or to <a href="http://expressjs.com/4x/api.html"><strong>Express 4.x</strong></a>.</p>
+				<p>If you are unable to upgrade past 2.x, please consider <a href="/{{ page.lang }}/support#commercial-support-options">Commercial Support Options</a>.</p>
 				</div>
 				<p id="tagline">
 				   High performance, high class web development for

--- a/2x/contrib.html
+++ b/2x/contrib.html
@@ -201,8 +201,9 @@
 			<div id="container">
 				<a href='http://github.com/visionmedia/express' id='logo'>Express</a> 
 				<div id="warning">
-				<center><strong>Express 2.x</strong> IS NO LONGER MAINTAINED</center>
+				<center><strong>Express 2.x</strong> IS END-OF-LIFE AND NO LONGER MAINTAINED</center>
 				<p>Known and unknown security and performance issues in 2.x have not been addressed since the last update (29 June, 2012). It is highly recommended to <a href="https://github.com/expressjs/express/wiki/Migrating-from-2.x-to-3.x">upgrade to <strong>Express 3.x</strong></a> or to <a href="http://expressjs.com/4x/api.html"><strong>Express 4.x</strong></a>.</p>
+				<p>If you are unable to upgrade past 2.x, please consider <a href="/{{ page.lang }}/support#commercial-support-options">Commercial Support Options</a>.</p>
 				</div>
 				<p id="tagline">
 				   High performance, high class web development for

--- a/2x/executable.html
+++ b/2x/executable.html
@@ -201,8 +201,9 @@
 			<div id="container">
 				<a href='http://github.com/visionmedia/express' id='logo'>Express</a> 
 				<div id="warning">
-				<center><strong>Express 2.x</strong> IS NO LONGER MAINTAINED</center>
+				<center><strong>Express 2.x</strong> IS END-OF-LIFE AND NO LONGER MAINTAINED</center>
 				<p>Known and unknown security and performance issues in 2.x have not been addressed since the last update (29 June, 2012). It is highly recommended to <a href="https://github.com/expressjs/express/wiki/Migrating-from-2.x-to-3.x">upgrade to <strong>Express 3.x</strong></a> or to <a href="http://expressjs.com/4x/api.html"><strong>Express 4.x</strong></a>.</p>
+				<p>If you are unable to upgrade past 2.x, please consider <a href="/{{ page.lang }}/support#commercial-support-options">Commercial Support Options</a>.</p>
 				</div>
 				<p id="tagline">
 				   High performance, high class web development for

--- a/2x/guide.html
+++ b/2x/guide.html
@@ -263,8 +263,9 @@
 </ul>
 				<a href='http://github.com/visionmedia/express' id='logo'>Express</a> 
                 <div id="warning">
-                <center><strong>Express 2.x</strong> IS NO LONGER MAINTAINED</center>
+                <center><strong>Express 2.x</strong> IS END-OF-LIFE AND NO LONGER MAINTAINED</center>
                 <p>Known and unknown security and performance issues in 2.x have not been addressed since the last update (29 June, 2012). It is highly recommended to <a href="https://github.com/expressjs/express/wiki/Migrating-from-2.x-to-3.x">upgrade to <strong>Express 3.x</strong></a> or to <a href="http://expressjs.com/4x/api.html"><strong>Express 4.x</strong></a>.</p>
+                <p>If you are unable to upgrade past 2.x, please consider <a href="/{{ page.lang }}/support#commercial-support-options">Commercial Support Options</a>.</p>
                 </div>
 				<p id="tagline">
 				   High performance, high class web development for

--- a/2x/index.html
+++ b/2x/index.html
@@ -202,8 +202,9 @@
 			<div id="container">
 				<a href='http://github.com/visionmedia/express' id='logo'>Express</a>
 				<div id="warning">
-				<center><strong>Express 2.x</strong> IS NO LONGER MAINTAINED</center>
+				<center><strong>Express 2.x</strong> IS END-OF-LIFE AND NO LONGER MAINTAINED</center>
 				<p>Known and unknown security and performance issues in 2.x have not been addressed since the last update (29 June, 2012). It is highly recommended to use the latest version of Express.</p>
+				<p>If you are unable to upgrade past 2.x, please consider <a href="/{{ page.lang }}/support#commercial-support-options">Commercial Support Options</a>.</p>
 				</div>
 				<p id="tagline">
 				   High performance, high class web development for

--- a/2x/migrate.html
+++ b/2x/migrate.html
@@ -201,8 +201,9 @@
 			<div id="container">
 				<a href='http://github.com/visionmedia/express' id='logo'>Express</a> 
 				<div id="warning">
-				<center><strong>Express 2.x</strong> IS NO LONGER MAINTAINED</center>
+				<center><strong>Express 2.x</strong> IS END-OF-LIFE AND NO LONGER MAINTAINED</center>
 				<p>Known and unknown security and performance issues in 2.x have not been addressed since the last update (29 June, 2012). It is highly recommended to <a href="https://github.com/expressjs/express/wiki/Migrating-from-2.x-to-3.x">upgrade to <strong>Express 3.x</strong></a> or to <a href="http://expressjs.com/4x/api.html"><strong>Express 4.x</strong></a>.</p>
+				<p>If you are unable to upgrade past 2.x, please consider <a href="/{{ page.lang }}/support#commercial-support-options">Commercial Support Options</a>.</p>
 				</div>
 				<p id="tagline">
 				   High performance, high class web development for

--- a/2x/screencasts.html
+++ b/2x/screencasts.html
@@ -201,8 +201,9 @@
 			<div id="container">
 				<a href='http://github.com/visionmedia/express' id='logo'>Express</a> 
 				<div id="warning">
-				<center><strong>Express 2.x</strong> IS NO LONGER MAINTAINED</center>
+				<center><strong>Express 2.x</strong> IS END-OF-LIFE AND NO LONGER MAINTAINED</center>
 				<p>Known and unknown security and performance issues in 2.x have not been addressed since the last update (29 June, 2012). It is highly recommended to <a href="https://github.com/expressjs/express/wiki/Migrating-from-2.x-to-3.x">upgrade to <strong>Express 3.x</strong></a> or to <a href="http://expressjs.com/4x/api.html"><strong>Express 4.x</strong></a>.</p>
+				<p>If you are unable to upgrade past 2.x, please consider <a href="/{{ page.lang }}/support#commercial-support-options">Commercial Support Options</a>.</p>
 				</div>
 				<p id="tagline">
 				   High performance, high class web development for

--- a/_includes/header/header-en.html
+++ b/_includes/header/header-en.html
@@ -141,6 +141,7 @@
                   </li>
               </ul>
           </li>
+          <li><a href="/{{ page.lang }}/support" id="support-menu"{% if page.menu == 'support' %} class="active"{% endif %}>Support</a></li>
           <li>
               <ul id="blog-menu" class="menu">
                   <li><a href="{{site.posts.first.url}}"{% if page.menu == 'blog' %} class="active"{% endif %}>Blog</a>

--- a/css/style.css
+++ b/css/style.css
@@ -1362,3 +1362,18 @@ h2 a {
     max-width: 80%;
   }
 }
+
+.no-release {
+  color: gray;
+  opacity: 0.8;
+}
+html.dark-mode .no-release {
+  color: #abc8c3;
+}
+
+.supported {
+  color: green !important;
+}
+.eol {
+  color: red !important;
+}

--- a/en/3x/api.md
+++ b/en/3x/api.md
@@ -8,9 +8,11 @@ redirect_from: "/3x/api.html"
 <div id="api-doc" markdown="1">
 
   <div class="doc-box doc-warn" markdown="1">
-  **Express 3.x IS NO LONGER MAINTAINED**
+  **Express 3.x IS END-OF-LIFE AND NO LONGER MAINTAINED**
 
   Known and unknown security and performance issues in 3.x have not been addressed since the last update (1 August, 2015). It is highly recommended to use the latest version of Express.
+
+  If you are unable to upgrade past 3.x, please consider [Commercial Support Options](/{{ page.lang }}/support#commercial-support-options).
   </div>
 
   <h1>3.x API</h1>

--- a/en/advanced/best-practice-security.md
+++ b/en/advanced/best-practice-security.md
@@ -36,7 +36,7 @@ Security best practices for Express applications in production include:
 
 ## Don't use deprecated or vulnerable versions of Express
 
-Express 2.x and 3.x are no longer maintained. Security and performance issues in these versions won't be fixed. Do not use them! If you haven't moved to version 4, follow the [migration guide](/{{ page.lang }}/guide/migrating-4.html).
+Express 2.x and 3.x are no longer maintained. Security and performance issues in these versions won't be fixed. Do not use them! If you haven't moved to version 4, follow the [migration guide](/{{ page.lang }}/guide/migrating-4.html) or consider [Commercial Support Options](/{{ page.lang }}/support#commercial-support-options).
 
 Also ensure you are not using any of the vulnerable Express versions listed on the [Security updates page](/{{ page.lang }}/advanced/security-updates.html). If you are, update to one of the stable releases, preferably the latest.
 

--- a/en/advanced/security-updates.md
+++ b/en/advanced/security-updates.md
@@ -44,9 +44,11 @@ The list below enumerates the Express vulnerabilities that were fixed in the spe
 ## 3.x
 
   <div class="doc-box doc-warn" markdown="1">
-  **Express 3.x IS NO LONGER MAINTAINED**
+  **Express 3.x IS END-OF-LIFE AND NO LONGER MAINTAINED**
 
-  Known and unknown security issues in 3.x have not been addressed since the last update (1 August, 2015). Using the 3.x line should not be considered secure.
+  Known and unknown security and performance issues in 3.x have not been addressed since the last update (1 August, 2015). It is highly recommended to use the latest version of Express.
+
+  If you are unable to upgrade past 3.x, please consider [Commercial Support Options](/{{ page.lang }}/support#commercial-support-options).
   </div>
 
   * 3.19.1

--- a/en/support/index.md
+++ b/en/support/index.md
@@ -1,0 +1,27 @@
+---
+layout: page
+title: Version Support
+menu: support
+lang: en
+---
+
+# Version Support
+
+Only the latest version of any given major release line is supported.
+
+Versions that are EOL (end-of-life) _may_ receive updates for critical security vulnerabilities, but the Express team offers no guarantee and does not plan to address or release fixes for any issues found.
+
+| Major Version | Support Start Date | Support End Date |
+| -- | -- | -- |
+| [**v5.x**{: .no-release }](/{{page.lang}}/5x/api.html) | **not yet released**{: .no-release } | **not yet released**{: .no-release } |
+| [**v4.x**{: .supported }](/{{page.lang}}/4x/api.html) | April 2014 | **ongoing**{: .supported } |
+| [**v3.x**{: .eol }](/{{page.lang}}/3x/api.html) | October 2012 | July 2015 |
+| [**v2.x**{: .eol }](/{{page.lang}}/2x/) | March 2011 | July 2012 |
+| **v1.x**{: .eol } | December 2010 | March 2011 |
+| **v0.14.x**{: .eol } | December 2010 | December 2010 |
+
+## Commercial Support Options
+
+If you are unable to update to a supported version of Express, please contact one of our partners to receive security updates:
+
+ - [HeroDevs Never-Ending Support](http://www.herodevs.com/support/express-nes?utm_source=expressjs&utm_medium=link&utm_campaign=express_eol_page)

--- a/id/advanced/best-practice-security.md
+++ b/id/advanced/best-practice-security.md
@@ -35,7 +35,7 @@ Security best practices for Express applications in production include:
 
 ## Don't use deprecated or vulnerable versions of Express
 
-Express 2.x and 3.x are no longer maintained. Security and performance issues in these versions won't be fixed. Do not use them! If you haven't moved to version 4, follow the [migration guide](/{{ page.lang }}/guide/migrating-4.html).
+Express 2.x and 3.x are no longer maintained. Security and performance issues in these versions won't be fixed. Do not use them! If you haven't moved to version 4, follow the [migration guide](/{{ page.lang }}/guide/migrating-4.html), or consider [Commercial Support Options](/{{ page.lang }}/support#commercial-support-options).
 
 Also ensure you are not using any of the vulnerable Express versions listed on the [Security updates page](/{{ page.lang }}/advanced/security-updates.html). If you are, update to one of the stable releases, preferably the latest.
 

--- a/id/advanced/security-updates.md
+++ b/id/advanced/security-updates.md
@@ -43,9 +43,11 @@ The list below enumerates the Express vulnerabilities that were fixed in the spe
 ## 3.x
 
   <div class="doc-box doc-warn" markdown="1">
-  **Express 3.x IS NO LONGER MAINTAINED**
+  **Express 3.x IS END-OF-LIFE AND NO LONGER MAINTAINED**
 
-  Known and unknown security issues in 3.x have not been addressed since the last update (1 August, 2015). Using the 3.x line should not be considered secure.
+  Known and unknown security and performance issues in 3.x have not been addressed since the last update (1 August, 2015). It is highly recommended to use the latest version of Express.
+
+  If you are unable to upgrade past 3.x, please consider [Commercial Support Options](/{{ page.lang }}/support#commercial-support-options).
   </div>
 
   * 3.19.1

--- a/th/3x/api.md
+++ b/th/3x/api.md
@@ -7,9 +7,11 @@ lang: th
 <div id="api-doc" markdown="1">
 
   <div class="doc-box doc-warn" markdown="1">
-  **Express 3.x IS NO LONGER MAINTAINED**
+ **Express 3.x IS END-OF-LIFE AND NO LONGER MAINTAINED**
 
   Known and unknown security and performance issues in 3.x have not been addressed since the last update (1 August, 2015). It is highly recommended to use the latest version of Express.
+
+  If you are unable to upgrade past 3.x, please consider [Commercial Support Options](/{{ page.lang }}/support#commercial-support-options).
   </div>
 
   <h1>3.x API</h1>

--- a/th/advanced/best-practice-security.md
+++ b/th/advanced/best-practice-security.md
@@ -30,7 +30,7 @@ Security best practices for Express applications in production include:
 
 ## Don't use deprecated or vulnerable versions of Express
 
-Express 2.x and 3.x are no longer maintained. Security and performance issues in these versions won't be fixed. Do not use them!  If you haven't moved to version 4, follow the [migration guide](/{{ page.lang }}/guide/migrating-4.html).
+Express 2.x and 3.x are no longer maintained. Security and performance issues in these versions won't be fixed. Do not use them!  If you haven't moved to version 4, follow the [migration guide](/{{ page.lang }}/guide/migrating-4.html) or consider [Commercial Support Options](/{{ page.lang }}/support#commercial-support-options).
 
 Also ensure you are not using any of the vulnerable Express versions listed on the [Security updates page](/{{ page.lang }}/advanced/security-updates.html). If you are, update to one of the stable releases, preferably the latest.
 

--- a/th/advanced/security-updates.md
+++ b/th/advanced/security-updates.md
@@ -44,9 +44,11 @@ The list below enumerates the Express vulnerabilities that were fixed in the spe
 ## 3.x
 
   <div class="doc-box doc-warn" markdown="1">
-  **Express 3.x IS NO LONGER MAINTAINED**
+  **Express 3.x IS END-OF-LIFE AND NO LONGER MAINTAINED**
 
-  Known and unknown security issues in 3.x have not been addressed since the last update (1 August, 2015). Using the 3.x line should not be considered secure.
+  Known and unknown security and performance issues in 3.x have not been addressed since the last update (1 August, 2015). It is highly recommended to use the latest version of Express.
+
+  If you are unable to upgrade past 3.x, please consider [Commercial Support Options](/{{ page.lang }}/support#commercial-support-options).
   </div>
 
   * 3.19.1

--- a/tr/3x/api.md
+++ b/tr/3x/api.md
@@ -7,9 +7,11 @@ lang: tr
 <div id="api-doc" markdown="1">
 
   <div class="doc-box doc-warn" markdown="1">
-  **Express 3.x IS NO LONGER MAINTAINED**
+  **Express 3.x IS END-OF-LIFE AND NO LONGER MAINTAINED**
 
   Known and unknown security and performance issues in 3.x have not been addressed since the last update (1 August, 2015). It is highly recommended to use the latest version of Express.
+
+  If you are unable to upgrade past 3.x, please consider [Commercial Support Options](/{{ page.lang }}/support#commercial-support-options).
   </div>
 
   <h1>3.x API</h1>

--- a/tr/advanced/security-updates.md
+++ b/tr/advanced/security-updates.md
@@ -37,9 +37,11 @@ The list below enumerates the Express vulnerabilities that were fixed in the spe
 ## 3.x
 
   <div class="doc-box doc-warn" markdown="1">
-  **Express 3.x IS NO LONGER MAINTAINED**
+  **Express 3.x IS END-OF-LIFE AND NO LONGER MAINTAINED**
 
-  Known and unknown security issues in 3.x have not been addressed since the last update (1 August, 2015). Using the 3.x line should not be considered secure.
+  Known and unknown security and performance issues in 3.x have not been addressed since the last update (1 August, 2015). It is highly recommended to use the latest version of Express.
+
+  If you are unable to upgrade past 3.x, please consider [Commercial Support Options](/{{ page.lang }}/support#commercial-support-options).
   </div>
 
   * 3.19.1

--- a/uk/advanced/best-practice-security.md
+++ b/uk/advanced/best-practice-security.md
@@ -20,7 +20,7 @@ This article discusses some security best practices for Express applications dep
 
 ## Don't use deprecated or vulnerable versions of Express
 
-Express 2.x and 3.x are no longer maintained. Security and performance issues in these versions won't be fixed. Do not use them!  If you haven't moved to version 4, follow the [migration guide](/{{ page.lang }}/guide/migrating-4.html).
+Express 2.x and 3.x are no longer maintained. Security and performance issues in these versions won't be fixed. Do not use them!  If you haven't moved to version 4, follow the [migration guide](/{{ page.lang }}/guide/migrating-4.html) or consider [Commercial Support Options](/{{ page.lang }}/support#commercial-support-options).
 
 Also ensure you are not using any of the vulnerable Express versions listed on the [Security updates page](/{{ page.lang }}/advanced/security-updates.html). If you are, update to one of the stable releases, preferably the latest.
 

--- a/uk/advanced/security-updates.md
+++ b/uk/advanced/security-updates.md
@@ -34,9 +34,11 @@ The list below enumerates the Express vulnerabilities that were fixed in the spe
 ## 3.x
 
   <div class="doc-box doc-warn" markdown="1">
-  **Express 3.x IS NO LONGER MAINTAINED**
+  **Express 3.x IS END-OF-LIFE AND NO LONGER MAINTAINED**
 
-  Known and unknown security issues in 3.x have not been addressed since the last update (1 August, 2015). Using the 3.x line should not be considered secure.
+  Known and unknown security and performance issues in 3.x have not been addressed since the last update (1 August, 2015). It is highly recommended to use the latest version of Express.
+
+  If you are unable to upgrade past 3.x, please consider [Commercial Support Options](/{{ page.lang }}/support#commercial-support-options).
   </div>
 
   * 3.19.1


### PR DESCRIPTION
### Main Changes
- Added support page (including link in the navbar)
- Added banner on the deprecated APIs documentation


### Context

Related to https://github.com/expressjs/discussions/issues/257

### Details

**Support page**

Preview: https://deploy-preview-1585--expressjscom-preview.netlify.app/en/support/

<img width="1016" alt="Screenshot 2024-08-27 at 6 00 43 PM" src="https://github.com/user-attachments/assets/8ad785b5-424d-4f50-9f96-d6f0a0a2189f">

**Banner**

Preview: https://deploy-preview-1585--expressjscom-preview.netlify.app/en/3x/api

<img width="842" alt="Screenshot 2024-08-27 at 5 59 51 PM" src="https://github.com/user-attachments/assets/dc2cd221-6cfd-42fc-86cb-762d8e23771a">