### PR TITLE
fix i18n banner

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -11,7 +11,7 @@
   <body class="en-doc">
   {% else %}
   <body class="non-en-doc">
-    <div id="i18n-notice-box" class="doc-box doc-warn">
+    <div id="i18n-notice-box" class="doc-box doc-notice">
       {% include i18n-notice.html %}
     </div>
   {% endif %}

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -21,7 +21,7 @@
       <div id="overlay"></div>
 
       {% if page.lang != 'en' %}
-        <div id="i18n-notice-box" class="doc-box doc-warn">
+        <div id="i18n-notice-box" class="doc-box doc-notice">
           {% include i18n-notice.html %}
         </div>
       {% endif %}

--- a/css/style.css
+++ b/css/style.css
@@ -74,10 +74,14 @@ strong, th {
 }
 
 #home-content {
-  margin: 183px 0 2% 5%;
+  margin: 40px 0 2% 5%;
   max-width: 900px;
   padding-right: 9%;
   display: flex;
+}
+
+.en-doc #home-content {
+  margin-top: 150px;
 }
 
 #homepage-leftpane {
@@ -929,7 +933,7 @@ h2 a {
   }
 
   #home-content {
-    margin: 150px 0 0 5%;
+    margin: 60px 0 0 5%;
     padding-right: 5%;
   }
 

--- a/css/style.css
+++ b/css/style.css
@@ -562,7 +562,7 @@ html[xmlns] .clearfix {
 }
 
 #i18n-notice-box {
-  margin-top: 150px;
+  margin: 100px 3% 20px 3%;
   position: relative;
 }
 
@@ -570,7 +570,7 @@ html[xmlns] .clearfix {
   position: absolute;
   top: 3px;
   right: 4px;
-  color: #550000;
+  color: var(--notice-accent);
   cursor: pointer;
 }
 


### PR DESCRIPTION
The margin for i18n has been improved, and the admonition used has been changed to caution.

![image](https://github.com/user-attachments/assets/a13f1a0a-e3ef-4fda-b5c6-c2f3f6f56287)

