### PR TITLE
docs: change current and next version for the docs

### DIFF
--- a/_data/express.yml
+++ b/_data/express.yml
@@ -1,2 +1,2 @@
-current_version: "4.20.0"
+current_version: "4.21.0"
 next_version: "5.0.0"

--- a/_data/express.yml
+++ b/_data/express.yml
@@ -1,2 +1,2 @@
-current_version: "4.19.2"
-next_version: "5.0.0-beta.1"
+current_version: "4.20.0"
+next_version: "5.0.0"


### PR DESCRIPTION
As we have [Express 5 stable released](https://github.com/expressjs/express/releases/tag/v5.0.0),

- changed the next version to _5.0.0_
- changed current version to _4.20.0_ as of current latest