### PR TITLE
fix rules issues for update_external_docs workflow

### DIFF
--- a/.github/workflows/update-external-docs.yml
+++ b/.github/workflows/update-external-docs.yml
@@ -1,7 +1,8 @@
 name: Update External Docs
 on:
+    workflow_dispatch:
     schedule:
-    - cron:  '0 8 * * 1'
+        - cron:  '0 8 * * 1'
 
 permissions:
     pull-requests: write

--- a/.github/workflows/update-external-docs.yml
+++ b/.github/workflows/update-external-docs.yml
@@ -12,7 +12,7 @@ jobs:
         runs-on: ubuntu-latest
         if: github.repository_owner == 'expressjs'
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
             - name: Run scripts
               run: bash ./get-contributing.sh && bash ./get-readmes.sh
             - name: Create Pull Request

--- a/.github/workflows/update-external-docs.yml
+++ b/.github/workflows/update-external-docs.yml
@@ -3,7 +3,6 @@ on:
     schedule:
     - cron:  '0 8 * * 1'
 
-
 permissions:
     pull-requests: write
     contents: write
@@ -11,20 +10,20 @@ permissions:
 jobs:
     update-docs:
         runs-on: ubuntu-latest
+        if: github.repository_owner == 'expressjs'
         steps:
             - uses: actions/checkout@v3
             - name: Run scripts
               run: bash ./get-contributing.sh && bash ./get-readmes.sh
             - name: Create Pull Request
-              uses: peter-evans/create-pull-request@v5
+              uses: gr2m/create-or-update-pull-request-action@v1
+              env:
+                GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               with: 
-                token: ${{ secrets.GITHUB_TOKEN }}
                 commit-message: update external docs
                 title: 'Update external docs'
                 body: >
                   This auto-generated PR updates external documentation to the expressjs.com repository.
                 labels: doc
+                team_reviewers: docs-wg
                 branch: external-docs-${{ github.sha }}
-                delete-branch: true
-
-


### PR DESCRIPTION
Changes are made to run the workflow correctly and prevent this workflow from running in a forked repository.

## Changes:
- Allow the workflow to run manually
- Now the workflow will only run in the main repository (expressjs/expressjs.com).
- The tool is updated to use an external action allowed by the organization.
- Automatically add the review for the @expressjs/docs-wg team.
- Update the checkout action to its latest version