### PR TITLE
Remove claim that examples are valid everywhere

### DIFF
--- a/_includes/api/en/4x/app-use.md
+++ b/_includes/api/en/4x/app-use.md
@@ -12,7 +12,7 @@ A route will match any path that follows its path immediately with a "`/`".
 For example: `app.use('/apple', ...)` will match "/apple", "/apple/images",
 "/apple/images/news", and so on.
 
-Since `path` defaults to "/", middleware mounted without a path will be executed for every request to the app.  
+Since `path` defaults to "/", middleware mounted without a path will be executed for every request to the app.
 For example, this middleware function will be executed for _every_ request to the app:
 
 ```js
@@ -165,7 +165,6 @@ app.use(['/abcd', '/xyza', /\/lmn|\/pqr/], function (req, res, next) {
 
 The following table provides some simple examples of middleware functions that
 can be used as the `callback` argument to `app.use()`, `app.METHOD()`, and `app.all()`.
-Even though the examples are for `app.use()`, they are also valid for `app.use()`, `app.METHOD()`, and `app.all()`.
 
 <table class="doctable" border="1">
 

--- a/_includes/api/en/5x/app-use.md
+++ b/_includes/api/en/5x/app-use.md
@@ -12,7 +12,7 @@ A route will match any path that follows its path immediately with a "`/`".
 For example: `app.use('/apple', ...)` will match "/apple", "/apple/images",
 "/apple/images/news", and so on.
 
-Since `path` defaults to "/", middleware mounted without a path will be executed for every request to the app.  
+Since `path` defaults to "/", middleware mounted without a path will be executed for every request to the app.
 For example, this middleware function will be executed for _every_ request to the app:
 
 ```js
@@ -142,7 +142,6 @@ app.use(['/abcd', '/xyza', /\/lmn|\/pqr/], (req, res, next) => {
 
 The following table provides some simple examples of middleware functions that
 can be used as the `callback` argument to `app.use()`, `app.METHOD()`, and `app.all()`.
-Even though the examples are for `app.use()`, they are also valid for `app.use()`, `app.METHOD()`, and `app.all()`.
 
 <table class="doctable" border="1">
 
@@ -176,6 +175,7 @@ app.use(router)
 ```
 
 An Express app is valid middleware.
+
 ```js
 const subApp = express()
 subApp.get('/', (req, res, next) => {


### PR DESCRIPTION
This line was introduced in https://github.com/expressjs/expressjs.com/commit/47d0b10af52644bb7712dab4f6842edce5511f58, but I don't think it was intended as the way it's read (i.e. `.use` can be swapped for any other method). Swapping them as-is didn't actually work, but I suspect it meant the middleware can be used in any of the methods.

Related to https://github.com/expressjs/express/issues/5955.