### PR TITLE
fix: Erase a sentence about discussion

### DIFF
--- a/ko/guide/migrating-5.md
+++ b/ko/guide/migrating-5.md
@@ -63,7 +63,7 @@ $ npm install "express@>={{ site.data.express.next_version }}" --save
 
 Express 5는 `app.del()` 함수를 더 이상 지원하지 않습니다. 이 함수를 사용하면 오류에 대한 예외 처리(throw)가 발생합니다. HTTP DELETE 라우트를 등록하려면 `app.delete()` 함수를 대신 사용하십시오.
 
-`delete`는 JavaScript의 예약된 키워드이므로, 처음에는 `delete` 대신 `del`이 사용되었습니다. 그러나, ECMAScript 6을 기준으로, `delete` 및 다른 예약된 키워드를 정식 특성 이름으로 사용할 수 있게 되었습니다. `app.del` 함수 사용 중단의 요인이 된 토론을 여기서 읽을 수 있습니다.
+`delete`는 JavaScript의 예약된 키워드이므로, 처음에는 `delete` 대신 `del`이 사용되었습니다. 그러나, ECMAScript 6을 기준으로, `delete` 및 다른 예약된 키워드를 정식 특성 이름으로 사용할 수 있게 되었습니다.
 
 <h4 id="app.param">app.param(fn)</h4>
 


### PR DESCRIPTION
In English version, the sentence 'You can read the discussion that led to the deprecation of the `app.del` function here.' is deleted 9 years ago([commit](https://github.com/expressjs/expressjs.com/commit/2b103e4be2278fc76f46ac9d9e60cc4281f4fe19#diff-380ce9fbefe3250db0463611f085b37c748e503a54e6576c9a7bbc20a27adadeL71)), but it still exists in a Korean migration guide. So this commit erases it.