### PR TITLE
Fix: remove non-existing link sentence

### DIFF
--- a/en/advanced/best-practice-security.md
+++ b/en/advanced/best-practice-security.md
@@ -51,8 +51,7 @@ Also, a handy tool to get a free TLS certificate is [Let's Encrypt](https://lets
 ## Do not trust user input
 
 For web applications, one of the most critical security requirements is proper user input validation and handling. This comes in many forms and we will not cover all of them here.
-Ultimately, the responsibility for validating and correctly handling the types of user input your application accepts. Here are a few examples of validating user input specifically
-using a few `express` apis.
+Ultimately, the responsibility for validating and correctly handling the types of user input your application accepts is yours.
 
 ### Prevent open redirects
 


### PR DESCRIPTION
One of the sentences in the advanced security section had a non-existing link I couldn't find. If someone does find, they can inform me below, and edits are welcome. Otherwise, this pull request contains changes to remove the sentence.

Also, the previous sentence was incomplete. This was fixed, although changes are welcome: the semantics of the original sentence were vague. Hope this makes the docs even more clear and professional.