### PR TITLE
Translate Footer Links to pt-BR

### DIFF
--- a/_includes/footer/footer-pt-br.html
+++ b/_includes/footer/footer-pt-br.html
@@ -8,11 +8,11 @@
                 <img src="https://raw.githubusercontent.com/openjs-foundation/artwork/main/openjs_foundation/openjs_foundation-logo-horizontal-color.svg" alt="OpenJS Foundation" width="125" height="39"/>
             </a>
             <div id="footer-policy">
-                <a href="https://terms-of-use.openjsf.org">Terms of Use</a>
-                <a href="https://privacy-policy.openjsf.org">Privacy Policy</a> 
-                <a id="coc" href="https://github.com/expressjs/express/blob/master/Code-Of-Conduct.md">Code of Conduct</a>
-                <a href="https://trademark-policy.openjsf.org">Trademark Policy</a>
-                <a id="security" href="https://github.com/expressjs/express/security/policy">Security Policy</a>
+                <a href="https://terms-of-use.openjsf.org">Termos de Uso</a>
+                <a href="https://privacy-policy.openjsf.org">Política de Privacidade</a> 
+                <a id="coc" href="https://github.com/expressjs/express/blob/master/Code-Of-Conduct.md">Código de Conduta</a>
+                <a href="https://trademark-policy.openjsf.org">Política de Marcas</a>
+                <a id="security" href="https://github.com/expressjs/express/security/policy">Política de Segurança</a>
                 <a id="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/">Licença</a>
             </div>
         </div>


### PR DESCRIPTION
This PR updates the translation of all footer links to pt-BR. Previously, only the "License" link was translated, while the others remained in English.

![expressjs](https://github.com/user-attachments/assets/2bd532cd-4946-409b-b3eb-9b8465a8d1d4)


