### PR TITLE
fix permissions for translation workflow

### DIFF
--- a/.github/workflows/translation.yml
+++ b/.github/workflows/translation.yml
@@ -40,8 +40,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Check modified files and add labels
-        uses: actions/github-script@v5
+        uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.TRANSLATION_TOKEN }}
           script: |
             const languages = ['en', 'es', 'fr', 'it', 'id', 'ja', 'ko', 'pt-br', 'ru', 'sk', 'th', 'tr', 'uk', 'uz', 'zh-cn', 'zh-tw'];
             const prNumber = context.eventName === 'workflow_dispatch' ? context.payload.inputs.prNumber : context.issue.number;


### PR DESCRIPTION
This should fix the workflow for people who do not have write permissions by adding a new custom token

The requested token should have the following permissions:

```
permissions:
  contents: read
  pull-requests: write
  issues: write
```

ref: https://github.com/actions/github-script/tree/v7?tab=readme-ov-file#using-a-separate-github-token

close: #1553