### PR TITLE
Automate the version change of Express

### DIFF
--- a/.github/workflows/update-external-docs.yml
+++ b/.github/workflows/update-external-docs.yml
@@ -14,12 +14,15 @@ jobs:
         if: github.repository_owner == 'expressjs'
         steps:
             - uses: actions/checkout@v4
-            - name: Use Node.js 20
+            - name: Set up Node.js
               uses: actions/setup-node@v4
               with:
                 node-version: 20
             - name: Run scripts
-              run: bash ./get-contributing.sh && bash ./get-readmes.sh && node ./get-express-version.mjs
+              run: |
+                bash ./get-contributing.sh
+                bash ./get-readmes.sh
+                node ./get-express-version.mjs  
             - name: Create Pull Request
               uses: gr2m/create-or-update-pull-request-action@v1
               env:

--- a/.github/workflows/update-external-docs.yml
+++ b/.github/workflows/update-external-docs.yml
@@ -13,8 +13,12 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v3
+            - name: Use Node.js 20
+              uses: actions/setup-node@v4
+              with:
+                node-version: 20
             - name: Run scripts
-              run: bash ./get-contributing.sh && bash ./get-readmes.sh
+              run: bash ./get-contributing.sh && bash ./get-readmes.sh && node ./get-express-version.mjs
             - name: Create Pull Request
               uses: peter-evans/create-pull-request@v5
               with: 

--- a/get-express-version.mjs
+++ b/get-express-version.mjs
@@ -1,0 +1,22 @@
+import { writeFileSync } from 'node:fs'
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+
+const NPMURL = 'https://registry.npmjs.org/express'
+
+const response = await fetch(NPMURL).then((res) => res.json())
+
+const { next, latest } = response['dist-tags']
+
+const contentFile = await readFile(
+  path.resolve(path.join('_data', 'express.yml')),
+  'utf8'
+)
+  .then((content) =>
+    content.replace(/current_version: ".*"/, `current_version: "${latest}"`)
+  )
+  .then((content) =>
+    content.replace(/next_version: ".*"/, `next_version: "${next}"`)
+  )
+
+writeFileSync('_data/express.yml', contentFile)

--- a/get-express-version.mjs
+++ b/get-express-version.mjs
@@ -1,22 +1,20 @@
-import { writeFileSync } from 'node:fs'
-import { readFile } from 'node:fs/promises'
+import { readFile, writeFile } from 'node:fs/promises'
 import path from 'node:path'
 
 const NPMURL = 'https://registry.npmjs.org/express'
 
-const response = await fetch(NPMURL).then((res) => res.json())
+const response = await (await fetch(NPMURL)).json()
 
 const { next, latest } = response['dist-tags']
 
-const contentFile = await readFile(
-  path.resolve(path.join('_data', 'express.yml')),
-  'utf8'
-)
-  .then((content) =>
-    content.replace(/current_version: ".*"/, `current_version: "${latest}"`)
-  )
-  .then((content) =>
-    content.replace(/next_version: ".*"/, `next_version: "${next}"`)
-  )
+try {
+  const filePath = path.resolve(path.join('_data', 'express.yml'))
+  let content = await readFile(filePath, 'utf8')
 
-writeFileSync('_data/express.yml', contentFile)
+  content = content.replace(/current_version: ".*"/, `current_version: "${latest}"`)
+  content = content.replace(/next_version: ".*"/, `next_version: "${next}"`)
+
+  await writeFile(filePath, content, 'utf8')
+} catch (error) {
+  console.error('Error updating versions in _data/express.yml:', error)
+}


### PR DESCRIPTION
This script automates the process of changing the version number in the documentation, see #1504.

To ensure the workflow functions correctly, please review #1606