### PR TITLE
Fixed Bug: Links on the blog dont break to a new line on mobile - improved text flow

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1263,20 +1263,26 @@ h2 a {
 @media (max-width: 500px) {
   #blog-doc {
     display: flex;
+    flex-wrap: wrap;
     flex-direction: column;
-    align-items: center;
+    align-items: flex-start;
     margin: 0;
     padding-right: 10px;
+    row-gap: 40px;
   }
   #blog-doc .blog-details + p {
     display: flex;
+    flex-wrap: wrap;
     flex-direction: column;
-    align-items: center;
+    align-items: flex-start;
+    row-gap: 40px;
   }
   #blog-doc .blog-details + p > img {
     margin-bottom: 15px;
   }
+
 }
+
 /* blog tablet and up*/
 @media (min-width: 768px) {
   .blog-post {

--- a/css/style.css
+++ b/css/style.css
@@ -150,8 +150,9 @@ strong, th {
 }
 
 .content {
-  margin: 153px 2% 7%;
-  max-width: 1590px;
+  margin: 153px 3% 7%;
+  max-width: 1090px;
+  padding-left: 225px;
 }
 
 span.block-section {
@@ -1264,23 +1265,24 @@ h2 a {
     display: flex;
     flex-wrap: wrap;
     flex-direction: column;
-    align-items: flex-start;
+    align-items: center;
     margin-right: 0;
     padding-right: 10px;
   }
-  #blog-doc .blog-details + p {
-    display: flex;
-    flex-wrap: wrap;
-    flex-direction: column;
-    align-items: flex-start;
-    margin-right: 0;
-    padding-right: 10px;
+  
+
+
+  #blog-doc .blog-details + p a,
+  #blog-doc .blog-details + p a + span {
+    white-space: nowrap;
   }
+
   #blog-doc .blog-details + p > img {
     margin-bottom: 15px;
   }
-
 }
+
+
 
 /* blog tablet and up*/
 @media (min-width: 768px) {

--- a/css/style.css
+++ b/css/style.css
@@ -1272,11 +1272,6 @@ h2 a {
   
 
 
-  #blog-doc .blog-details + p a,
-  #blog-doc .blog-details + p a + span {
-    white-space: nowrap;
-  }
-
   #blog-doc .blog-details + p > img {
     margin-bottom: 15px;
   }

--- a/css/style.css
+++ b/css/style.css
@@ -150,9 +150,8 @@ strong, th {
 }
 
 .content {
-  margin: 153px 3% 7%;
-  max-width: 1090px;
-  padding-left: 225px;
+  margin: 153px 2% 7%;
+  max-width: 1590px;
 }
 
 span.block-section {
@@ -1266,16 +1265,16 @@ h2 a {
     flex-wrap: wrap;
     flex-direction: column;
     align-items: flex-start;
-    margin: 0;
+    margin-right: 0;
     padding-right: 10px;
-    row-gap: 40px;
   }
   #blog-doc .blog-details + p {
     display: flex;
     flex-wrap: wrap;
     flex-direction: column;
     align-items: flex-start;
-    row-gap: 40px;
+    margin-right: 0;
+    padding-right: 10px;
   }
   #blog-doc .blog-details + p > img {
     margin-bottom: 15px;


### PR DESCRIPTION
Fixed issue https://github.com/expressjs/expressjs.com/issues/1637

Links on the blog were not breaking on mobile view which was assigned as a bug.

I improved the alignment further to make sure the text gets a better flow.

<h2> Output of new change </h2>

![image](https://github.com/user-attachments/assets/8a3fbe30-eff3-45f5-9101-ce184f3740d6)


