### PR TITLE
ci: update team name for Update External Docs

### DIFF
--- a/.github/workflows/update-external-docs.yml
+++ b/.github/workflows/update-external-docs.yml
@@ -26,5 +26,5 @@ jobs:
                 body: >
                   This auto-generated PR updates external documentation to the expressjs.com repository.
                 labels: doc
-                team_reviewers: docs-wg
+                team_reviewers: expressjs/docs-wg
                 branch: external-docs-${{ github.sha }}


### PR DESCRIPTION
Ref: https://github.com/expressjs/expressjs.com/pull/1659

This will ensure that the docs-wg is assigned on the PR creation. Currently this review assignation is not working