### PR TITLE
ci: update team name

### DIFF
--- a/.github/workflows/update-external-docs.yml
+++ b/.github/workflows/update-external-docs.yml
@@ -26,5 +26,5 @@ jobs:
                 body: >
                   This auto-generated PR updates external documentation to the expressjs.com repository.
                 labels: doc
-                team_reviewers: expressjs/docs-wg
+                team_reviewers: expressjs/docs-captains
                 branch: external-docs-${{ github.sha }}


### PR DESCRIPTION
Currently, reviewers are not automatically assigned because the team needs to have write permissions

ref: https://github.com/expressjs/expressjs.com/pull/1660#issuecomment-2427665780