### PR TITLE
fix url metadata

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -16,9 +16,9 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta name="description" content="{{page.description}}">
 
-    <meta property="og:url" content="https://expressjs.com">
+    <meta property="og:url" content="https://expressjs.com{{page.url}}">
     <meta property="og:type" content="website">
-    <meta property="og:title" content="{{page.title}}">
+    <meta name="title" property="og:title" content="{{page.title}}">
     <meta property="og:description" content="{{page.description}}">
     <meta property="og:image" content="https://expressjs.com/images/og.png">                
 


### PR DESCRIPTION
The title wasn't displaying correctly on LinkedIn, probably because og:url was always the same and wasn't dynamic with the page

https://www.linkedin.com/post-inspector/inspect/https:%2F%2Fexpressjs.com%2Fen%2Fblog%2Fposts