### PR TITLE
move scripts to .github folder

### DIFF
--- a/.github/scripts/get-contributing.sh
+++ b/.github/scripts/get-contributing.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-DEST="en/resources/contributing.md"
+DEST="../../en/resources/contributing.md"
 
 # This script replaces the contents of a section with the contents from
 # the annotated source address.

--- a/.github/scripts/get-express-version.mjs
+++ b/.github/scripts/get-express-version.mjs
@@ -8,7 +8,7 @@ const response = await (await fetch(NPMURL)).json()
 const { next, latest } = response['dist-tags']
 
 try {
-  const filePath = path.resolve(path.join('_data', 'express.yml'))
+  const filePath = path.resolve(path.join('..', '..', '_data', 'express.yml'))
   let content = await readFile(filePath, 'utf8')
 
   content = content.replace(/current_version: ".*"/, `current_version: "${latest}"`)

--- a/.github/scripts/get-readmes.sh
+++ b/.github/scripts/get-readmes.sh
@@ -29,7 +29,7 @@ expressjs express master/examples
 LIST_END
 ) | while read org repo branch; do
   # Write the README.md to a file named after the repo
-  DEST="_includes/readmes/$repo.md"
+  DEST="../../_includes/readmes/$repo.md"
   # When fetching from a branch of a gh repo
   GHURL="https://raw.githubusercontent.com/$org/$repo/$branch/README.md"
   # When fetching from the latest release of a node module
@@ -42,7 +42,7 @@ LIST_END
     # This allows us to specify a branch other than master if we want to.
     # In this case, the branch name is added to the readme name in the filename.
     if [ "$branch" != "master" ]; then
-      DEST="_includes/readmes/$repo-$branch.md"
+      DEST="../../_includes/readmes/$repo-$branch.md"
     fi
     echo "fetching $org/$repo/$branch from GitHub's raw content domain..."
     curl -s $GHURL > $DEST

--- a/.github/workflows/update-external-docs.yml
+++ b/.github/workflows/update-external-docs.yml
@@ -19,6 +19,7 @@ jobs:
               with:
                 node-version: 20
             - name: Run scripts
+              working-directory: .github/scripts
               run: |
                 bash ./get-contributing.sh
                 bash ./get-readmes.sh


### PR DESCRIPTION
These scripts are part of the automation to bring external documentation into this repository,
it would be good to move them into the GitHub Actions folder