### PR TITLE
remove open collective of footer

### DIFF
--- a/_includes/footer/footer-de.html
+++ b/_includes/footer/footer-de.html
@@ -44,9 +44,6 @@
               <div>
                 <a href="https://openjs-foundation.slack.com/archives/C02QB1731FH" aria-label="Go to the repository on Slack">{% include icons/slack.svg %}</a>
               </div>
-              <div>
-                <a href="https://opencollective.com/express" aria-label="Go to the repository on Open Collective">{% include icons/opencollective.svg %}</a>
-              </div>
             </div>
             <a href="https://www.netlify.com">
               <img src="https://www.netlify.com/v3/img/components/netlify-color-accent.svg" alt="Preview Deploys by Netlify" width="80" />

--- a/_includes/footer/footer-en.html
+++ b/_includes/footer/footer-en.html
@@ -50,9 +50,6 @@
         <div>
           <a href="https://openjs-foundation.slack.com/archives/C02QB1731FH" aria-label="Go to the repository on Slack">{% include icons/slack.svg %}</a>
         </div>
-        <div>
-          <a href="https://opencollective.com/express" aria-label="Go to the repository on Open Collective">{% include icons/opencollective.svg %}</a>
-        </div>
       </div>
       <a href="https://www.netlify.com">
         <img src="https://www.netlify.com/v3/img/components/netlify-color-accent.svg" alt="Preview Deploys by Netlify" width="80" />

--- a/_includes/footer/footer-es.html
+++ b/_includes/footer/footer-es.html
@@ -44,9 +44,6 @@
         <div>
           <a href="https://openjs-foundation.slack.com/archives/C02QB1731FH" aria-label="Go to the repository on Slack">{% include icons/slack.svg %}</a>
         </div>
-        <div>
-          <a href="https://opencollective.com/express" aria-label="Go to the repository on Open Collective">{% include icons/opencollective.svg %}</a>
-        </div>
       </div>
       <a href="https://www.netlify.com">
         <img src="https://www.netlify.com/v3/img/components/netlify-color-accent.svg" alt="Preview Deploys by Netlify" width="80" />

--- a/_includes/footer/footer-fr.html
+++ b/_includes/footer/footer-fr.html
@@ -44,9 +44,6 @@
               <div>
                 <a href="https://openjs-foundation.slack.com/archives/C02QB1731FH" aria-label="Go to the repository on Slack">{% include icons/slack.svg %}</a>
               </div>
-              <div>
-                <a href="https://opencollective.com/express" aria-label="Go to the repository on Open Collective">{% include icons/opencollective.svg %}</a>
-              </div>
             </div>
             <a href="https://www.netlify.com">
               <img src="https://www.netlify.com/v3/img/components/netlify-color-accent.svg" alt="Preview Deploys by Netlify" width="80" />

--- a/_includes/footer/footer-id.html
+++ b/_includes/footer/footer-id.html
@@ -50,9 +50,6 @@
         <div>
           <a href="https://openjs-foundation.slack.com/archives/C02QB1731FH" aria-label="Go to the repository on Slack">{% include icons/slack.svg %}</a>
         </div>
-        <div>
-          <a href="https://opencollective.com/express" aria-label="Go to the repository on Open Collective">{% include icons/opencollective.svg %}</a>
-        </div>
       </div>
       <a href="https://www.netlify.com">
         <img src="https://www.netlify.com/v3/img/components/netlify-color-accent.svg" alt="Preview Deploys by Netlify" width="80" />

--- a/_includes/footer/footer-it.html
+++ b/_includes/footer/footer-it.html
@@ -44,9 +44,6 @@
             <div>
               <a href="https://openjs-foundation.slack.com/archives/C02QB1731FH" aria-label="Go to the repository on Slack">{% include icons/slack.svg %}</a>
             </div>
-            <div>
-              <a href="https://opencollective.com/express" aria-label="Go to the repository on Open Collective">{% include icons/opencollective.svg %}</a>
-            </div>
           </div>
           <a href="https://www.netlify.com">
             <img src="https://www.netlify.com/v3/img/components/netlify-color-accent.svg" alt="Preview Deploys by Netlify" width="80" />

--- a/_includes/footer/footer-ja.html
+++ b/_includes/footer/footer-ja.html
@@ -44,9 +44,6 @@
             <div>
               <a href="https://openjs-foundation.slack.com/archives/C02QB1731FH" aria-label="Go to the repository on Slack">{% include icons/slack.svg %}</a>
             </div>
-            <div>
-              <a href="https://opencollective.com/express" aria-label="Go to the repository on Open Collective">{% include icons/opencollective.svg %}</a>
-            </div>
           </div>
           <a href="https://www.netlify.com">
             <img src="https://www.netlify.com/v3/img/components/netlify-color-accent.svg" alt="Preview Deploys by Netlify" width="80" />

--- a/_includes/footer/footer-ko.html
+++ b/_includes/footer/footer-ko.html
@@ -44,9 +44,6 @@
             <div>
               <a href="https://openjs-foundation.slack.com/archives/C02QB1731FH" aria-label="Go to the repository on Slack">{% include icons/slack.svg %}</a>
             </div>
-            <div>
-              <a href="https://opencollective.com/express" aria-label="Go to the repository on Open Collective">{% include icons/opencollective.svg %}</a>
-            </div>
           </div>
           <a href="https://www.netlify.com">
             <img src="https://www.netlify.com/v3/img/components/netlify-color-accent.svg" alt="Preview Deploys by Netlify" width="80" />

--- a/_includes/footer/footer-pt-br.html
+++ b/_includes/footer/footer-pt-br.html
@@ -45,9 +45,6 @@
                 <div>
                   <a href="https://openjs-foundation.slack.com/archives/C02QB1731FH" aria-label="Go to the repository on Slack">{% include icons/slack.svg %}</a>
                 </div>
-                <div>
-                  <a href="https://opencollective.com/express" aria-label="Go to the repository on Open Collective">{% include icons/opencollective.svg %}</a>
-                </div>
             </div>
         <a href="https://www.netlify.com">
             <img src="https://www.netlify.com/v3/img/components/netlify-color-accent.svg" alt="Preview Deploys by Netlify" width="80" />

--- a/_includes/footer/footer-ru.html
+++ b/_includes/footer/footer-ru.html
@@ -44,9 +44,6 @@
             <div>
               <a href="https://openjs-foundation.slack.com/archives/C02QB1731FH" aria-label="Go to the repository on Slack">{% include icons/slack.svg %}</a>
             </div>
-            <div>
-              <a href="https://opencollective.com/express" aria-label="Go to the repository on Open Collective">{% include icons/opencollective.svg %}</a>
-            </div>
           </div>
           <a href="https://www.netlify.com">
             <img src="https://www.netlify.com/v3/img/components/netlify-color-accent.svg" alt="Preview Deploys by Netlify" width="80" />

--- a/_includes/footer/footer-sk.html
+++ b/_includes/footer/footer-sk.html
@@ -44,9 +44,6 @@
             <div>
               <a href="https://openjs-foundation.slack.com/archives/C02QB1731FH" aria-label="Go to the repository on Slack">{% include icons/slack.svg %}</a>
             </div>
-            <div>
-              <a href="https://opencollective.com/express" aria-label="Go to the repository on Open Collective">{% include icons/opencollective.svg %}</a>
-            </div>
           </div>
           <a href="https://www.netlify.com">
             <img src="https://www.netlify.com/v3/img/components/netlify-color-accent.svg" alt="Preview Deploys by Netlify" width="80" />

--- a/_includes/footer/footer-th.html
+++ b/_includes/footer/footer-th.html
@@ -44,9 +44,6 @@
         <div>
           <a href="https://openjs-foundation.slack.com/archives/C02QB1731FH" aria-label="Go to the repository on Slack">{% include icons/slack.svg %}</a>
         </div>
-        <div>
-          <a href="https://opencollective.com/express" aria-label="Go to the repository on Open Collective">{% include icons/opencollective.svg %}</a>
-        </div>
       </div>
       <a href="https://www.netlify.com">
         <img src="https://www.netlify.com/v3/img/components/netlify-color-accent.svg" alt="Preview Deploys by Netlify" width="80" />

--- a/_includes/footer/footer-tr.html
+++ b/_includes/footer/footer-tr.html
@@ -44,9 +44,6 @@
         <div>
           <a href="https://openjs-foundation.slack.com/archives/C02QB1731FH" aria-label="Go to the repository on Slack">{% include icons/slack.svg %}</a>
         </div>
-        <div>
-          <a href="https://opencollective.com/express" aria-label="Go to the repository on Open Collective">{% include icons/opencollective.svg %}</a>
-        </div>
       </div>
       <a href="https://www.netlify.com">
         <img src="https://www.netlify.com/v3/img/components/netlify-color-accent.svg" alt="Preview Deploys by Netlify" width="80" />

--- a/_includes/footer/footer-uk.html
+++ b/_includes/footer/footer-uk.html
@@ -44,9 +44,6 @@
             <div>
               <a href="https://openjs-foundation.slack.com/archives/C02QB1731FH" aria-label="Go to the repository on Slack">{% include icons/slack.svg %}</a>
             </div>
-            <div>
-              <a href="https://opencollective.com/express" aria-label="Go to the repository on Open Collective">{% include icons/opencollective.svg %}</a>
-            </div>
           </div>
           <a href="https://www.netlify.com">
             <img src="https://www.netlify.com/v3/img/components/netlify-color-accent.svg" alt="Preview Deploys by Netlify" width="80" />

--- a/_includes/footer/footer-uz.html
+++ b/_includes/footer/footer-uz.html
@@ -44,9 +44,6 @@
             <div>
               <a href="https://openjs-foundation.slack.com/archives/C02QB1731FH" aria-label="Go to the repository on Slack">{% include icons/slack.svg %}</a>
             </div>
-            <div>
-              <a href="https://opencollective.com/express" aria-label="Go to the repository on Open Collective">{% include icons/opencollective.svg %}</a>
-            </div>
           </div>
           <a href="https://www.netlify.com">
             <img src="https://www.netlify.com/v3/img/components/netlify-color-accent.svg" alt="Preview Deploys by Netlify" width="80" />

--- a/_includes/footer/footer-zh-cn.html
+++ b/_includes/footer/footer-zh-cn.html
@@ -44,9 +44,6 @@
             <div>
               <a href="https://openjs-foundation.slack.com/archives/C02QB1731FH" aria-label="Go to the repository on Slack">{% include icons/slack.svg %}</a>
             </div>
-            <div>
-              <a href="https://opencollective.com/express" aria-label="Go to the repository on Open Collective">{% include icons/opencollective.svg %}</a>
-            </div>
           </div>
           <a href="https://www.netlify.com">
             <img src="https://www.netlify.com/v3/img/components/netlify-color-accent.svg" alt="Preview Deploys by Netlify" width="80" />

--- a/_includes/footer/footer-zh-tw.html
+++ b/_includes/footer/footer-zh-tw.html
@@ -44,9 +44,6 @@
             <div>
               <a href="https://openjs-foundation.slack.com/archives/C02QB1731FH" aria-label="Go to the repository on Slack">{% include icons/slack.svg %}</a>
             </div>
-            <div>
-              <a href="https://opencollective.com/express" aria-label="Go to the repository on Open Collective">{% include icons/opencollective.svg %}</a>
-            </div>
           </div>
           <a href="https://www.netlify.com">
             <img src="https://www.netlify.com/v3/img/components/netlify-color-accent.svg" alt="Preview Deploys by Netlify" width="80" />


### PR DESCRIPTION
This removes the open collective from the footer while we decide when to promote it

Relate: https://github.com/expressjs/express/pull/6064#issuecomment-2444511668