### PR TITLE
Translated resources/middleware page to ukrainian

### DIFF
--- a/uk/resources/middleware.md
+++ b/uk/resources/middleware.md
@@ -1,65 +1,58 @@
 ---
-layout: page
-title: Проміжні обробники Express
+layout: middleware
+title: Проміжні Express-модулі
+description: Ознайомтесь із списком проміжних модулів Express.js, які підтримуються командою Express та спільнотою, й включають вбудовані модулі та популярні сторонні пакети.
 menu: resources
 lang: uk
-description: Explore a list of Express.js middleware modules maintained by the Express
-  team and the community, including built-in middleware and popular third-party modules.
+redirect_from: "/resources/middleware.html"
+module: mw-home
 ---
 
-# Проміжні обробники третій сторін
+## Проміжні Express-модулі
 
-Here are some Express middleware modules:
+Проміжні Express-модулі, перелічені тут, підтримуюються [командою Expressjs](https://github.com/orgs/expressjs/people).
 
-  - [body-parser](https://github.com/expressjs/body-parser): previously `express.bodyParser`, `json`, and `urlencoded`.
-  See also:
-    - [body](https://github.com/raynos/body)
-    - [co-body](https://github.com/visionmedia/co-body)
-    - [raw-body](https://github.com/stream-utils/raw-body)
-  - [compression](https://github.com/expressjs/compression):  previously `express.compress`
-  - [connect-image-optimus](https://github.com/msemenistyi/connect-image-optimus): Connect/Express middleware modules for optimal image serving. Switches images to `.webp` or `.jxr`, if possible.
-  - [connect-timeout](https://github.com/expressjs/timeout): previously `express.timeout`
-  - [cookie-parser](https://github.com/expressjs/cookie-parser): previously `express.cookieParser`
-  - [cookie-session](https://github.com/expressjs/cookie-session): previously `express.cookieSession`
-  - [errorhandler](https://github.com/expressjs/errorhandler): previously `express.errorHandler`
-  - [express-debug](https://github.com/devoidfury/express-debug): unobtrusive development tool that adds a tab with information about template variables (locals), current session, useful request data, and more to your application.
-  - [express-partial-response](https://github.com/nemtsov/express-partial-response): Express middleware module for filtering-out parts of JSON responses based on the `fields` query-string; by using Google API's Partial Response.
-  - [express-session](https://github.com/expressjs/session): previously `express.session`
-  - [express-simple-cdn](https://github.com/jamiesteven/express-simple-cdn): Express middleware module for using a CDN for static assets, with multiple host support (For example: cdn1.host.com, cdn2.host.com).
-  - [express-slash](https://github.com/ericf/express-slash): Express middleware module for people who are strict about trailing slashes.
-  - [express-stormpath](https://github.com/stormpath/stormpath-express): Express middleware module for user storage, authentication, authorization, SSO, and data security.
-  - [express-uncapitalize](https://github.com/jamiesteven/express-uncapitalize): middleware module for redirecting HTTP requests containing uppercase to a canonical lowercase form.
-  - [helmet](https://github.com/helmetjs/helmet): module to help secure your apps by setting various HTTP headers.
-  - [join-io](https://github.com/coderaiser/join-io "join-io"): module for joining files on the fly to reduce the requests count.
-  - [method-override](https://github.com/expressjs/method-override): previously `express.methodOverride`
-  - [morgan](https://github.com/expressjs/morgan):  previously `logger`
-  - [passport](https://github.com/jaredhanson/passport): Express middleware module for authentication.
-  - [response-time](https://github.com/expressjs/response-time): previously `express.responseTime`
-  - [serve-favicon](https://github.com/expressjs/serve-favicon): previously `express.favicon`
-  - [serve-index](https://github.com/expressjs/serve-index): previously `express.directory`
-  - [serve-static](https://github.com/expressjs/serve-static): module for serving static content.
-  - [static-expiry](https://github.com/paulwalker/connect-static-expiry): fingerprinted URLs or Caching Headers for static assets including support for one or more external domains.
-  - [vhost](https://github.com/expressjs/vhost): previously `express.vhost`
-  - [view-helpers](https://github.com/madhums/node-view-helpers): Express middleware module that provides common helper methods to the views.
-  - [sriracha-admin](https://github.com/hdngr/siracha): Express middleware module that dynamically generates an admin site for Mongoose.
+| Проміжний модуль | Опис | Заміняє таку вбудовану функцію (Express 3) |
+|---------------------------|---------------------|----------------------|
+| [body-parser](/resources/middleware/body-parser.html) | Аналізує та перетворює в об'єкт тіло HTTP запиту. Також перегляньте: [body](https://github.com/raynos/body), [co-body](https://github.com/visionmedia/co-body), і [raw-body](https://github.com/stream-utils/raw-body). | express.bodyParser |
+| [compression](/resources/middleware/compression.html) | Стискає HTTP відповіді. | express.compress |
+| [connect-rid](/resources/middleware/connect-rid.html) | Генерує унікальний ідентифікатор запиту. | NA |
+| [cookie-parser](/resources/middleware/cookie-parser.html) | Аналізує cookie-заголовок та поміщає його вміст у `req.cookies`. Також перегляньте [cookies](https://github.com/jed/cookies) і [keygrip](https://github.com/jed/keygrip). | express.cookieParser|
+| [cookie-session](/resources/middleware/cookie-session.html) | Додає створення сесій на основі cookies.| express.cookieSession |
+| [cors](/resources/middleware/cors.html) | Додає підтримку спільного доступу до ресурсів між різними джерелами (CORS) з можливістю конфігурації. | NA
+| [errorhandler](/resources/middleware/errorhandler.html) | Додає обробку помилок та полегшує виправку багів під час розробки. | express.errorHandler |
+| [method-override](/resources/middleware/method-override.html) | Замінює HTTP метод через заголовки. | express.methodOverride |
+| [morgan](/resources/middleware/morgan.html) | Фіксує HTTP запити в логах. | express.logger |
+| [multer](/resources/middleware/multer.html) | Обробляє запити з даними, які містять файли. | express.bodyParser |
+| [response-time](/resources/middleware/response-time.html) | Фіксує тривалість обробки HTTP запиту. |express.responseTime |
+| [serve-favicon](/resources/middleware/serve-favicon.html) | Додає іконку сайту. | express.favicon |
+| [serve-index](/resources/middleware/serve-index.html) | Відображає список файлів у вказаній шляхом директорії. | express.directory |
+| [serve-static](/resources/middleware/serve-static.html) | Додає підтримку передачі статичних файлів. | express.static |
+| [session](/resources/middleware/session.html) | Додає серверні сесії (лише для розробки). | express.session |
+| [timeout](/resources/middleware/timeout.html) | Встановлює обмеження часу обробки HTTP-запиту. | express.timeout |
+| [vhost](/resources/middleware/vhost.html) | Створює віртуальні домени. | express.vhost |
 
-Some middleware modules previously included with Connect are no longer supported by the Connect/Express team. These modules are replaced by an alternative module, or should be superseded by a better module. Use one of the following alternatives:
+## Додаткові проміжні модулі
 
-  - express.cookieParser
-    - [cookies](https://github.com/jed/cookies) and [keygrip](https://github.com/jed/keygrip)
-  - express.limit
-    - [raw-body](https://github.com/stream-utils/raw-body)
-  - express.multipart
-    - [connect-busboy](https://github.com/mscdex/connect-busboy)
-    - [multer](https://github.com/expressjs/multer)
-    - [connect-multiparty](https://github.com/superjoe30/connect-multiparty)
-  - express.query
-    - [qs](https://github.com/visionmedia/node-querystring)
-  - express.staticCache
-    - [st](https://github.com/isaacs/st)
-    - [connect-static](https://github.com/andrewrk/connect-static)
+Кілька інших популярних проміжних модулів.
 
-For more middleware modules, see:
+{% include community-caveat.html %}
 
- - [http-framework](https://github.com/Raynos/http-framework/wiki/Modules)
- - [expressjs](https://github.com/expressjs)
+| Проміжний&nbsp;модуль | Опис |
+|---------------------------|---------------------|
+| [cls-rtracer](https://github.com/puzpuzpuz/cls-rtracer) | Проміжний модуль для генерації ідентифікаторів запитів на основі CLS. Готове рішення для додавання ідентифікаторів запитів у ваші логи. |
+| [connect-image-optimus](https://github.com/msemenistyi/connect-image-optimus) | Оптимізує передачу зображень. Перетворює зображення в формат `.webp` або `.jxr`, якщо це можливо. |
+| [error-handler-json](https://github.com/mifi/error-handler-json) | Обробник помилок для JSON API (форк з `api-error-handler`.)|
+| [express-debug](https://github.com/devoidfury/express-debug) | Інструмент для розробки, який додає інформацію про шаблонні змінні (locals), поточну сесію та інше. |
+| [express-partial-response](https://github.com/nemtsov/express-partial-response) | Фільтрує частини JSON-відповідей на основі параметра `fields`, використовуючи схожий до Google API підхід часткової відповіді. |
+| [express-simple-cdn](https://github.com/jamiesteven/express-simple-cdn) | Додає CDN для статичних ресурсів із підтримкою кількох хостів. |
+| [express-slash](https://github.com/ericf/express-slash) | Дає змогу обробляє маршрути з і без косої риски в кінці. |
+| [express-uncapitalize](https://github.com/jamiesteven/express-uncapitalize) | Перенаправляє HTTP-запити, що містять великі літери, до канонічного шляху з малими літерами. |
+| [helmet](https://github.com/helmetjs/helmet) | Допомагає забезпечити безпеку ваших додатків шляхом встановлення різних HTTP-заголовків. |
+| [join-io](https://github.com/coderaiser/join-io) | Об'єднує файли на льоту для зменшення кількості запитів. |
+| [passport](https://github.com/jaredhanson/passport) | Дозволяє автентифікацію за допомогою "стратегій", таких як OAuth, OpenID та багатьох інших. Перегляньте [http://passportjs.org/](http://passportjs.org/) для додаткової інформації. |
+| [static-expiry](https://github.com/paulwalker/connect-static-expiry) | Додає унікальні URL-ідентифікатори та заголовки кешування для статичних ресурсів. |
+| [view-helpers](https://github.com/madhums/node-view-helpers) | Поширені допоміжні функції для шаблонізації. |
+| [sriracha-admin](https://github.com/hdngr/siracha) | Динамічно генерує адмін-панель для Mongoose. |
+
+Щоби знайти більше проміжних модулів, перегляньте [http-framework](https://github.com/Raynos/http-framework#modules).


### PR DESCRIPTION
Translated the `resources/middleware` page into Ukrainian, using the English version as a reference.

The old version had no table, the new one has it.