### PR TITLE
docs: add v5 migration note for app.listen

### DIFF
--- a/en/guide/migrating-5.md
+++ b/en/guide/migrating-5.md
@@ -45,6 +45,7 @@ You can then run your automated tests to see what fails, and fix problems accord
   <li><a href="#path-syntax">Path route matching syntax</a></li>
   <li><a href="#rejected-promises">Rejected promises handled from middleware and handlers</a></li>
   <li><a href="#express.urlencoded">express.urlencoded</a></li>
+  <li><a href="#app.listen">app.listen</a></li>
   <li><a href="#app.router">app.router</a></li>
   <li><a href="#req.body">req.body</a></li>
   <li><a href="#req.host">req.host</a></li>
@@ -158,6 +159,20 @@ Details of how Express handles errors is covered in the [error handling document
 <h4 id="express.urlencoded">express.urlencoded</h4>
 
 The `express.urlencoded` method makes the `extended` option `false` by default.
+
+<h4 id="app.listen">app.listen</h4>
+
+In Express 5, the `app.listen` method will invoke the user-provided callback function (if provided) when the server receives an error event. In Express 4, such errors would be thrown. This change shifts error-handling responsibility to the callback function in Express 5. If there is an error, it will be passed to the callback as an argument.
+For example:
+
+```js
+const server = app.listen(8080, '0.0.0.0', (error) => {
+  if (error) {
+    throw error // e.g. EADDRINUSE
+  }
+  console.log(`Listening on ${JSON.stringify(server.address())}`)
+})
+```
 
 <h4 id="app.router">app.router</h4>
 


### PR DESCRIPTION
Adds a note to the `migrating-5` guide alerting users that error events received by a server will now cause the callback argument in `app.listen` to be invoked. In Express 4, this was not the case and errors would be thrown.

Resolves https://github.com/expressjs/express/issues/6191

Any feedback, rewording, etc. is welcome!

<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->