### PR TITLE
update res.end 

### DIFF
--- a/_includes/api/en/4x/res-end.md
+++ b/_includes/api/en/4x/res-end.md
@@ -1,10 +1,10 @@
-<h3 id='res.end'>res.end([data] [, encoding])</h3>
+<h3 id='res.end'>res.end([data[, encoding]][, callback])</h3>
 
-Ends the response process. This method actually comes from Node core, specifically the [response.end() method of  http.ServerResponse](https://nodejs.org/api/http.html#http_response_end_data_encoding_callback).
+Ends the response process. This method actually comes from Node core, specifically the [response.end() method of http.ServerResponse](https://nodejs.org/api/http.html#responseenddata-encoding-callback).
 
 Use to quickly end the response without any data. If you need to respond with data, instead use methods such as [res.send()](#res.send) and [res.json()](#res.json).
 
 ```js
-res.end()
-res.status(404).end()
+res.end();
+res.status(404).end();
 ```

--- a/_includes/api/en/4x/res-end.md
+++ b/_includes/api/en/4x/res-end.md
@@ -5,6 +5,6 @@ Ends the response process. This method actually comes from Node core, specifical
 Use to quickly end the response without any data. If you need to respond with data, instead use methods such as [res.send()](#res.send) and [res.json()](#res.json).
 
 ```js
-res.end();
-res.status(404).end();
+res.end()
+res.status(404).end()
 ```

--- a/_includes/api/en/5x/res-end.md
+++ b/_includes/api/en/5x/res-end.md
@@ -1,10 +1,10 @@
-<h3 id='res.end'>res.end([data] [, encoding])</h3>
+<h3 id='res.end'>res.end([data[, encoding]][, callback])</h3>
 
-Ends the response process. This method actually comes from Node core, specifically the [response.end() method of  http.ServerResponse](https://nodejs.org/api/http.html#http_response_end_data_encoding_callback).
+Ends the response process. This method actually comes from Node core, specifically the [response.end() method of http.ServerResponse](https://nodejs.org/api/http.html#responseenddata-encoding-callback).
 
 Use to quickly end the response without any data. If you need to respond with data, instead use methods such as [res.send()](#res.send) and [res.json()](#res.json).
 
 ```js
-res.end()
-res.status(404).end()
+res.end();
+res.status(404).end();
 ```

--- a/_includes/api/en/5x/res-end.md
+++ b/_includes/api/en/5x/res-end.md
@@ -5,6 +5,6 @@ Ends the response process. This method actually comes from Node core, specifical
 Use to quickly end the response without any data. If you need to respond with data, instead use methods such as [res.send()](#res.send) and [res.json()](#res.json).
 
 ```js
-res.end();
-res.status(404).end();
+res.end()
+res.status(404).end()
 ```


### PR DESCRIPTION
#### **Changes:**
- Added a note explaining that `res.end()` in Express accepts a `callback` parameter, which is passed directly to the Node.js `response.end()` method.
