### PR TITLE
fix: replace broken link in the v5 release post

### DIFF
--- a/_posts/2024-10-15-v5-release.md
+++ b/_posts/2024-10-15-v5-release.md
@@ -29,7 +29,7 @@ As soon as possible, we'll provide more details on our long-term support (LTS) p
 
 The v5 release has the minimum possible number of breaking changes, listed here in order of impact to applications. 
 
-- [Ending support for old Node.js versions](#goodbye-nodejs-010-hello-node-18)
+- [Ending support for old Node.js versions](#ending-support-for-old-nodejs-versions)
 - [Changes to path matching and regular expressions](#changes-to-path-matching-and-regular-expressions)
 - [Promise support](#promise-support)
 - [Body parser changes](#body-parser-changes)


### PR DESCRIPTION
Corrected the href for "Ending support for old Node.js versions" in the v5 release post.