### PR TITLE
Added the minimum supported node.js version to the support page

### DIFF
--- a/de/support/index.md
+++ b/de/support/index.md
@@ -11,14 +11,14 @@ Only the latest version of any given major release line is supported.
 
 Versions that are EOL (end-of-life) _may_ receive updates for critical security vulnerabilities, but the Express team offers no guarantee and does not plan to address or release fixes for any issues found.
 
-| Major Version | Support Start Date | Support End Date |
-| -- | -- | -- |
-| [**v5.x**{: .no-release }](/{{page.lang}}/5x/api.html) | **not yet released**{: .no-release } | **not yet released**{: .no-release } |
-| [**v4.x**{: .supported }](/{{page.lang}}/4x/api.html) | April 2014 | **ongoing**{: .supported } |
-| [**v3.x**{: .eol }](/{{page.lang}}/3x/api.html) | October 2012 | July 2015 |
-| [**v2.x**{: .eol }](/{{page.lang}}/2x/) | March 2011 | July 2012 |
-| **v1.x**{: .eol } | December 2010 | March 2011 |
-| **v0.14.x**{: .eol } | December 2010 | December 2010 |
+| Major Version | Minimum Node.js Version | Support Start Date | Support End Date |
+| -- | -- | -- | -- |
+| [**v5.x**{: .supported }](/{{page.lang}}/5x/api.html) | 18.0.0 | September 2024 | **ongoing**{: .supported } |
+| [**v4.x**{: .supported }](/{{page.lang}}/4x/api.html) | 0.10.0 | April 2014 | **ongoing**{: .supported } |
+| [**v3.x**{: .eol }](/{{page.lang}}/3x/api.html) | 0.8.0 | October 2012 | July 2015 |
+| [**v2.x**{: .eol }](/{{page.lang}}/2x/) | 0.4.1 | March 2011 | July 2012 |
+| **v1.x**{: .eol } | 0.2.0 | December 2010 | March 2011 |
+| **v0.14.x**{: .eol } | 0.1.98 | December 2010 | December 2010 |
 
 ## Commercial Support Options
 

--- a/de/support/index.md
+++ b/de/support/index.md
@@ -13,7 +13,7 @@ Versions that are EOL (end-of-life) _may_ receive updates for critical security 
 
 | Major Version | Minimum Node.js Version | Support Start Date | Support End Date |
 | -- | -- | -- | -- |
-| [**v5.x**{: .supported }](/{{page.lang}}/5x/api.html) | 18.0.0 | September 2024 | **ongoing**{: .supported } |
+| [**v5.x**{: .supported }](/{{page.lang}}/5x/api.html) | 18 | September 2024 | **ongoing**{: .supported } |
 | [**v4.x**{: .supported }](/{{page.lang}}/4x/api.html) | 0.10.0 | April 2014 | **ongoing**{: .supported } |
 | [**v3.x**{: .eol }](/{{page.lang}}/3x/api.html) | 0.8.0 | October 2012 | July 2015 |
 | [**v2.x**{: .eol }](/{{page.lang}}/2x/) | 0.4.1 | March 2011 | July 2012 |

--- a/en/support/index.md
+++ b/en/support/index.md
@@ -14,7 +14,7 @@ Versions that are EOL (end-of-life) _may_ receive updates for critical security 
 
 | Major Version | Minimum Node.js Version | Support Start Date | Support End Date |
 | -- | -- | -- | -- |
-| [**v5.x**{: .supported }](/{{page.lang}}/5x/api.html) | 18.0.0 | September 2024 | **ongoing**{: .supported } |
+| [**v5.x**{: .supported }](/{{page.lang}}/5x/api.html) | 18 | September 2024 | **ongoing**{: .supported } |
 | [**v4.x**{: .supported }](/{{page.lang}}/4x/api.html) | 0.10.0 | April 2014 | **ongoing**{: .supported } |
 | [**v3.x**{: .eol }](/{{page.lang}}/3x/api.html) | 0.8.0 | October 2012 | July 2015 |
 | [**v2.x**{: .eol }](/{{page.lang}}/2x/) | 0.4.1 | March 2011 | July 2012 |

--- a/en/support/index.md
+++ b/en/support/index.md
@@ -12,14 +12,14 @@ Only the latest version of any given major release line is supported.
 
 Versions that are EOL (end-of-life) _may_ receive updates for critical security vulnerabilities, but the Express team offers no guarantee and does not plan to address or release fixes for any issues found.
 
-| Major Version | Support Start Date | Support End Date |
-| -- | -- | -- |
-| [**v5.x**{: .supported }](/{{page.lang}}/5x/api.html) | September 2024 | **ongoing**{: .supported } |
-| [**v4.x**{: .supported }](/{{page.lang}}/4x/api.html) | April 2014 | **ongoing**{: .supported } |
-| [**v3.x**{: .eol }](/{{page.lang}}/3x/api.html) | October 2012 | July 2015 |
-| [**v2.x**{: .eol }](/{{page.lang}}/2x/) | March 2011 | July 2012 |
-| **v1.x**{: .eol } | December 2010 | March 2011 |
-| **v0.14.x**{: .eol } | December 2010 | December 2010 |
+| Major Version | Minimum Node.js Version | Support Start Date | Support End Date |
+| -- | -- | -- | -- |
+| [**v5.x**{: .supported }](/{{page.lang}}/5x/api.html) | 18.0.0 | September 2024 | **ongoing**{: .supported } |
+| [**v4.x**{: .supported }](/{{page.lang}}/4x/api.html) | 0.10.0 | April 2014 | **ongoing**{: .supported } |
+| [**v3.x**{: .eol }](/{{page.lang}}/3x/api.html) | 0.8.0 | October 2012 | July 2015 |
+| [**v2.x**{: .eol }](/{{page.lang}}/2x/) | 0.4.1 | March 2011 | July 2012 |
+| **v1.x**{: .eol } | 0.2.0 | December 2010 | March 2011 |
+| **v0.14.x**{: .eol } | 0.1.98 | December 2010 | December 2010 |
 
 ## Commercial Support Options
 

--- a/es/support/index.md
+++ b/es/support/index.md
@@ -11,14 +11,14 @@ Only the latest version of any given major release line is supported.
 
 Versions that are EOL (end-of-life) _may_ receive updates for critical security vulnerabilities, but the Express team offers no guarantee and does not plan to address or release fixes for any issues found.
 
-| Major Version | Support Start Date | Support End Date |
-| -- | -- | -- |
-| [**v5.x**{: .no-release }](/{{page.lang}}/5x/api.html) | **not yet released**{: .no-release } | **not yet released**{: .no-release } |
-| [**v4.x**{: .supported }](/{{page.lang}}/4x/api.html) | April 2014 | **ongoing**{: .supported } |
-| [**v3.x**{: .eol }](/{{page.lang}}/3x/api.html) | October 2012 | July 2015 |
-| [**v2.x**{: .eol }](/{{page.lang}}/2x/) | March 2011 | July 2012 |
-| **v1.x**{: .eol } | December 2010 | March 2011 |
-| **v0.14.x**{: .eol } | December 2010 | December 2010 |
+| Major Version | Minimum Node.js Version | Support Start Date | Support End Date |
+| -- | -- | -- | -- |
+| [**v5.x**{: .supported }](/{{page.lang}}/5x/api.html) | 18.0.0 | September 2024 | **ongoing**{: .supported } |
+| [**v4.x**{: .supported }](/{{page.lang}}/4x/api.html) | 0.10.0 | April 2014 | **ongoing**{: .supported } |
+| [**v3.x**{: .eol }](/{{page.lang}}/3x/api.html) | 0.8.0 | October 2012 | July 2015 |
+| [**v2.x**{: .eol }](/{{page.lang}}/2x/) | 0.4.1 | March 2011 | July 2012 |
+| **v1.x**{: .eol } | 0.2.0 | December 2010 | March 2011 |
+| **v0.14.x**{: .eol } | 0.1.98 | December 2010 | December 2010 |
 
 ## Commercial Support Options
 

--- a/es/support/index.md
+++ b/es/support/index.md
@@ -13,7 +13,7 @@ Versions that are EOL (end-of-life) _may_ receive updates for critical security 
 
 | Major Version | Minimum Node.js Version | Support Start Date | Support End Date |
 | -- | -- | -- | -- |
-| [**v5.x**{: .supported }](/{{page.lang}}/5x/api.html) | 18.0.0 | September 2024 | **ongoing**{: .supported } |
+| [**v5.x**{: .supported }](/{{page.lang}}/5x/api.html) | 18 | September 2024 | **ongoing**{: .supported } |
 | [**v4.x**{: .supported }](/{{page.lang}}/4x/api.html) | 0.10.0 | April 2014 | **ongoing**{: .supported } |
 | [**v3.x**{: .eol }](/{{page.lang}}/3x/api.html) | 0.8.0 | October 2012 | July 2015 |
 | [**v2.x**{: .eol }](/{{page.lang}}/2x/) | 0.4.1 | March 2011 | July 2012 |

--- a/fr/support/index.md
+++ b/fr/support/index.md
@@ -11,14 +11,14 @@ Only the latest version of any given major release line is supported.
 
 Versions that are EOL (end-of-life) _may_ receive updates for critical security vulnerabilities, but the Express team offers no guarantee and does not plan to address or release fixes for any issues found.
 
-| Major Version | Support Start Date | Support End Date |
-| -- | -- | -- |
-| [**v5.x**{: .no-release }](/{{page.lang}}/5x/api.html) | **not yet released**{: .no-release } | **not yet released**{: .no-release } |
-| [**v4.x**{: .supported }](/{{page.lang}}/4x/api.html) | April 2014 | **ongoing**{: .supported } |
-| [**v3.x**{: .eol }](/{{page.lang}}/3x/api.html) | October 2012 | July 2015 |
-| [**v2.x**{: .eol }](/{{page.lang}}/2x/) | March 2011 | July 2012 |
-| **v1.x**{: .eol } | December 2010 | March 2011 |
-| **v0.14.x**{: .eol } | December 2010 | December 2010 |
+| Major Version | Minimum Node.js Version | Support Start Date | Support End Date |
+| -- | -- | -- | -- |
+| [**v5.x**{: .supported }](/{{page.lang}}/5x/api.html) | 18.0.0 | September 2024 | **ongoing**{: .supported } |
+| [**v4.x**{: .supported }](/{{page.lang}}/4x/api.html) | 0.10.0 | April 2014 | **ongoing**{: .supported } |
+| [**v3.x**{: .eol }](/{{page.lang}}/3x/api.html) | 0.8.0 | October 2012 | July 2015 |
+| [**v2.x**{: .eol }](/{{page.lang}}/2x/) | 0.4.1 | March 2011 | July 2012 |
+| **v1.x**{: .eol } | 0.2.0 | December 2010 | March 2011 |
+| **v0.14.x**{: .eol } | 0.1.98 | December 2010 | December 2010 |
 
 ## Commercial Support Options
 

--- a/fr/support/index.md
+++ b/fr/support/index.md
@@ -13,7 +13,7 @@ Versions that are EOL (end-of-life) _may_ receive updates for critical security 
 
 | Major Version | Minimum Node.js Version | Support Start Date | Support End Date |
 | -- | -- | -- | -- |
-| [**v5.x**{: .supported }](/{{page.lang}}/5x/api.html) | 18.0.0 | September 2024 | **ongoing**{: .supported } |
+| [**v5.x**{: .supported }](/{{page.lang}}/5x/api.html) | 18 | September 2024 | **ongoing**{: .supported } |
 | [**v4.x**{: .supported }](/{{page.lang}}/4x/api.html) | 0.10.0 | April 2014 | **ongoing**{: .supported } |
 | [**v3.x**{: .eol }](/{{page.lang}}/3x/api.html) | 0.8.0 | October 2012 | July 2015 |
 | [**v2.x**{: .eol }](/{{page.lang}}/2x/) | 0.4.1 | March 2011 | July 2012 |

--- a/it/support/index.md
+++ b/it/support/index.md
@@ -11,14 +11,14 @@ Only the latest version of any given major release line is supported.
 
 Versions that are EOL (end-of-life) _may_ receive updates for critical security vulnerabilities, but the Express team offers no guarantee and does not plan to address or release fixes for any issues found.
 
-| Major Version | Support Start Date | Support End Date |
-| -- | -- | -- |
-| [**v5.x**{: .no-release }](/{{page.lang}}/5x/api.html) | **not yet released**{: .no-release } | **not yet released**{: .no-release } |
-| [**v4.x**{: .supported }](/{{page.lang}}/4x/api.html) | April 2014 | **ongoing**{: .supported } |
-| [**v3.x**{: .eol }](/{{page.lang}}/3x/api.html) | October 2012 | July 2015 |
-| [**v2.x**{: .eol }](/{{page.lang}}/2x/) | March 2011 | July 2012 |
-| **v1.x**{: .eol } | December 2010 | March 2011 |
-| **v0.14.x**{: .eol } | December 2010 | December 2010 |
+| Major Version | Minimum Node.js Version | Support Start Date | Support End Date |
+| -- | -- | -- | -- |
+| [**v5.x**{: .supported }](/{{page.lang}}/5x/api.html) | 18.0.0 | September 2024 | **ongoing**{: .supported } |
+| [**v4.x**{: .supported }](/{{page.lang}}/4x/api.html) | 0.10.0 | April 2014 | **ongoing**{: .supported } |
+| [**v3.x**{: .eol }](/{{page.lang}}/3x/api.html) | 0.8.0 | October 2012 | July 2015 |
+| [**v2.x**{: .eol }](/{{page.lang}}/2x/) | 0.4.1 | March 2011 | July 2012 |
+| **v1.x**{: .eol } | 0.2.0 | December 2010 | March 2011 |
+| **v0.14.x**{: .eol } | 0.1.98 | December 2010 | December 2010 |
 
 ## Commercial Support Options
 

--- a/it/support/index.md
+++ b/it/support/index.md
@@ -13,7 +13,7 @@ Versions that are EOL (end-of-life) _may_ receive updates for critical security 
 
 | Major Version | Minimum Node.js Version | Support Start Date | Support End Date |
 | -- | -- | -- | -- |
-| [**v5.x**{: .supported }](/{{page.lang}}/5x/api.html) | 18.0.0 | September 2024 | **ongoing**{: .supported } |
+| [**v5.x**{: .supported }](/{{page.lang}}/5x/api.html) | 18 | September 2024 | **ongoing**{: .supported } |
 | [**v4.x**{: .supported }](/{{page.lang}}/4x/api.html) | 0.10.0 | April 2014 | **ongoing**{: .supported } |
 | [**v3.x**{: .eol }](/{{page.lang}}/3x/api.html) | 0.8.0 | October 2012 | July 2015 |
 | [**v2.x**{: .eol }](/{{page.lang}}/2x/) | 0.4.1 | March 2011 | July 2012 |

--- a/ja/support/index.md
+++ b/ja/support/index.md
@@ -11,14 +11,14 @@ Only the latest version of any given major release line is supported.
 
 Versions that are EOL (end-of-life) _may_ receive updates for critical security vulnerabilities, but the Express team offers no guarantee and does not plan to address or release fixes for any issues found.
 
-| Major Version | Support Start Date | Support End Date |
-| -- | -- | -- |
-| [**v5.x**{: .no-release }](/{{page.lang}}/5x/api.html) | **not yet released**{: .no-release } | **not yet released**{: .no-release } |
-| [**v4.x**{: .supported }](/{{page.lang}}/4x/api.html) | April 2014 | **ongoing**{: .supported } |
-| [**v3.x**{: .eol }](/{{page.lang}}/3x/api.html) | October 2012 | July 2015 |
-| [**v2.x**{: .eol }](/{{page.lang}}/2x/) | March 2011 | July 2012 |
-| **v1.x**{: .eol } | December 2010 | March 2011 |
-| **v0.14.x**{: .eol } | December 2010 | December 2010 |
+| Major Version | Minimum Node.js Version | Support Start Date | Support End Date |
+| -- | -- | -- | -- |
+| [**v5.x**{: .supported }](/{{page.lang}}/5x/api.html) | 18.0.0 | September 2024 | **ongoing**{: .supported } |
+| [**v4.x**{: .supported }](/{{page.lang}}/4x/api.html) | 0.10.0 | April 2014 | **ongoing**{: .supported } |
+| [**v3.x**{: .eol }](/{{page.lang}}/3x/api.html) | 0.8.0 | October 2012 | July 2015 |
+| [**v2.x**{: .eol }](/{{page.lang}}/2x/) | 0.4.1 | March 2011 | July 2012 |
+| **v1.x**{: .eol } | 0.2.0 | December 2010 | March 2011 |
+| **v0.14.x**{: .eol } | 0.1.98 | December 2010 | December 2010 |
 
 ## Commercial Support Options
 

--- a/ja/support/index.md
+++ b/ja/support/index.md
@@ -13,7 +13,7 @@ Versions that are EOL (end-of-life) _may_ receive updates for critical security 
 
 | Major Version | Minimum Node.js Version | Support Start Date | Support End Date |
 | -- | -- | -- | -- |
-| [**v5.x**{: .supported }](/{{page.lang}}/5x/api.html) | 18.0.0 | September 2024 | **ongoing**{: .supported } |
+| [**v5.x**{: .supported }](/{{page.lang}}/5x/api.html) | 18 | September 2024 | **ongoing**{: .supported } |
 | [**v4.x**{: .supported }](/{{page.lang}}/4x/api.html) | 0.10.0 | April 2014 | **ongoing**{: .supported } |
 | [**v3.x**{: .eol }](/{{page.lang}}/3x/api.html) | 0.8.0 | October 2012 | July 2015 |
 | [**v2.x**{: .eol }](/{{page.lang}}/2x/) | 0.4.1 | March 2011 | July 2012 |

--- a/ko/support/index.md
+++ b/ko/support/index.md
@@ -11,14 +11,14 @@ Only the latest version of any given major release line is supported.
 
 Versions that are EOL (end-of-life) _may_ receive updates for critical security vulnerabilities, but the Express team offers no guarantee and does not plan to address or release fixes for any issues found.
 
-| Major Version | Support Start Date | Support End Date |
-| -- | -- | -- |
-| [**v5.x**{: .no-release }](/{{page.lang}}/5x/api.html) | **not yet released**{: .no-release } | **not yet released**{: .no-release } |
-| [**v4.x**{: .supported }](/{{page.lang}}/4x/api.html) | April 2014 | **ongoing**{: .supported } |
-| [**v3.x**{: .eol }](/{{page.lang}}/3x/api.html) | October 2012 | July 2015 |
-| [**v2.x**{: .eol }](/{{page.lang}}/2x/) | March 2011 | July 2012 |
-| **v1.x**{: .eol } | December 2010 | March 2011 |
-| **v0.14.x**{: .eol } | December 2010 | December 2010 |
+| Major Version | Minimum Node.js Version | Support Start Date | Support End Date |
+| -- | -- | -- | -- |
+| [**v5.x**{: .supported }](/{{page.lang}}/5x/api.html) | 18.0.0 | September 2024 | **ongoing**{: .supported } |
+| [**v4.x**{: .supported }](/{{page.lang}}/4x/api.html) | 0.10.0 | April 2014 | **ongoing**{: .supported } |
+| [**v3.x**{: .eol }](/{{page.lang}}/3x/api.html) | 0.8.0 | October 2012 | July 2015 |
+| [**v2.x**{: .eol }](/{{page.lang}}/2x/) | 0.4.1 | March 2011 | July 2012 |
+| **v1.x**{: .eol } | 0.2.0 | December 2010 | March 2011 |
+| **v0.14.x**{: .eol } | 0.1.98 | December 2010 | December 2010 |
 
 ## Commercial Support Options
 

--- a/ko/support/index.md
+++ b/ko/support/index.md
@@ -13,7 +13,7 @@ Versions that are EOL (end-of-life) _may_ receive updates for critical security 
 
 | Major Version | Minimum Node.js Version | Support Start Date | Support End Date |
 | -- | -- | -- | -- |
-| [**v5.x**{: .supported }](/{{page.lang}}/5x/api.html) | 18.0.0 | September 2024 | **ongoing**{: .supported } |
+| [**v5.x**{: .supported }](/{{page.lang}}/5x/api.html) | 18 | September 2024 | **ongoing**{: .supported } |
 | [**v4.x**{: .supported }](/{{page.lang}}/4x/api.html) | 0.10.0 | April 2014 | **ongoing**{: .supported } |
 | [**v3.x**{: .eol }](/{{page.lang}}/3x/api.html) | 0.8.0 | October 2012 | July 2015 |
 | [**v2.x**{: .eol }](/{{page.lang}}/2x/) | 0.4.1 | March 2011 | July 2012 |

--- a/pt-br/support/index.md
+++ b/pt-br/support/index.md
@@ -11,14 +11,14 @@ Only the latest version of any given major release line is supported.
 
 Versions that are EOL (end-of-life) _may_ receive updates for critical security vulnerabilities, but the Express team offers no guarantee and does not plan to address or release fixes for any issues found.
 
-| Major Version | Support Start Date | Support End Date |
-| -- | -- | -- |
-| [**v5.x**{: .no-release }](/{{page.lang}}/5x/api.html) | **not yet released**{: .no-release } | **not yet released**{: .no-release } |
-| [**v4.x**{: .supported }](/{{page.lang}}/4x/api.html) | April 2014 | **ongoing**{: .supported } |
-| [**v3.x**{: .eol }](/{{page.lang}}/3x/api.html) | October 2012 | July 2015 |
-| [**v2.x**{: .eol }](/{{page.lang}}/2x/) | March 2011 | July 2012 |
-| **v1.x**{: .eol } | December 2010 | March 2011 |
-| **v0.14.x**{: .eol } | December 2010 | December 2010 |
+| Major Version | Minimum Node.js Version | Support Start Date | Support End Date |
+| -- | -- | -- | -- |
+| [**v5.x**{: .supported }](/{{page.lang}}/5x/api.html) | 18.0.0 | September 2024 | **ongoing**{: .supported } |
+| [**v4.x**{: .supported }](/{{page.lang}}/4x/api.html) | 0.10.0 | April 2014 | **ongoing**{: .supported } |
+| [**v3.x**{: .eol }](/{{page.lang}}/3x/api.html) | 0.8.0 | October 2012 | July 2015 |
+| [**v2.x**{: .eol }](/{{page.lang}}/2x/) | 0.4.1 | March 2011 | July 2012 |
+| **v1.x**{: .eol } | 0.2.0 | December 2010 | March 2011 |
+| **v0.14.x**{: .eol } | 0.1.98 | December 2010 | December 2010 |
 
 ## Commercial Support Options
 

--- a/pt-br/support/index.md
+++ b/pt-br/support/index.md
@@ -13,7 +13,7 @@ Versions that are EOL (end-of-life) _may_ receive updates for critical security 
 
 | Major Version | Minimum Node.js Version | Support Start Date | Support End Date |
 | -- | -- | -- | -- |
-| [**v5.x**{: .supported }](/{{page.lang}}/5x/api.html) | 18.0.0 | September 2024 | **ongoing**{: .supported } |
+| [**v5.x**{: .supported }](/{{page.lang}}/5x/api.html) | 18 | September 2024 | **ongoing**{: .supported } |
 | [**v4.x**{: .supported }](/{{page.lang}}/4x/api.html) | 0.10.0 | April 2014 | **ongoing**{: .supported } |
 | [**v3.x**{: .eol }](/{{page.lang}}/3x/api.html) | 0.8.0 | October 2012 | July 2015 |
 | [**v2.x**{: .eol }](/{{page.lang}}/2x/) | 0.4.1 | March 2011 | July 2012 |

--- a/ru/support/index.md
+++ b/ru/support/index.md
@@ -11,14 +11,14 @@ Only the latest version of any given major release line is supported.
 
 Versions that are EOL (end-of-life) _may_ receive updates for critical security vulnerabilities, but the Express team offers no guarantee and does not plan to address or release fixes for any issues found.
 
-| Major Version | Support Start Date | Support End Date |
-| -- | -- | -- |
-| [**v5.x**{: .no-release }](/{{page.lang}}/5x/api.html) | **not yet released**{: .no-release } | **not yet released**{: .no-release } |
-| [**v4.x**{: .supported }](/{{page.lang}}/4x/api.html) | April 2014 | **ongoing**{: .supported } |
-| [**v3.x**{: .eol }](/{{page.lang}}/3x/api.html) | October 2012 | July 2015 |
-| [**v2.x**{: .eol }](/{{page.lang}}/2x/) | March 2011 | July 2012 |
-| **v1.x**{: .eol } | December 2010 | March 2011 |
-| **v0.14.x**{: .eol } | December 2010 | December 2010 |
+| Major Version | Minimum Node.js Version | Support Start Date | Support End Date |
+| -- | -- | -- | -- |
+| [**v5.x**{: .supported }](/{{page.lang}}/5x/api.html) | 18.0.0 | September 2024 | **ongoing**{: .supported } |
+| [**v4.x**{: .supported }](/{{page.lang}}/4x/api.html) | 0.10.0 | April 2014 | **ongoing**{: .supported } |
+| [**v3.x**{: .eol }](/{{page.lang}}/3x/api.html) | 0.8.0 | October 2012 | July 2015 |
+| [**v2.x**{: .eol }](/{{page.lang}}/2x/) | 0.4.1 | March 2011 | July 2012 |
+| **v1.x**{: .eol } | 0.2.0 | December 2010 | March 2011 |
+| **v0.14.x**{: .eol } | 0.1.98 | December 2010 | December 2010 |
 
 ## Commercial Support Options
 

--- a/ru/support/index.md
+++ b/ru/support/index.md
@@ -13,7 +13,7 @@ Versions that are EOL (end-of-life) _may_ receive updates for critical security 
 
 | Major Version | Minimum Node.js Version | Support Start Date | Support End Date |
 | -- | -- | -- | -- |
-| [**v5.x**{: .supported }](/{{page.lang}}/5x/api.html) | 18.0.0 | September 2024 | **ongoing**{: .supported } |
+| [**v5.x**{: .supported }](/{{page.lang}}/5x/api.html) | 18 | September 2024 | **ongoing**{: .supported } |
 | [**v4.x**{: .supported }](/{{page.lang}}/4x/api.html) | 0.10.0 | April 2014 | **ongoing**{: .supported } |
 | [**v3.x**{: .eol }](/{{page.lang}}/3x/api.html) | 0.8.0 | October 2012 | July 2015 |
 | [**v2.x**{: .eol }](/{{page.lang}}/2x/) | 0.4.1 | March 2011 | July 2012 |

--- a/sk/support/index.md
+++ b/sk/support/index.md
@@ -11,14 +11,14 @@ Only the latest version of any given major release line is supported.
 
 Versions that are EOL (end-of-life) _may_ receive updates for critical security vulnerabilities, but the Express team offers no guarantee and does not plan to address or release fixes for any issues found.
 
-| Major Version | Support Start Date | Support End Date |
-| -- | -- | -- |
-| [**v5.x**{: .no-release }](/{{page.lang}}/5x/api.html) | **not yet released**{: .no-release } | **not yet released**{: .no-release } |
-| [**v4.x**{: .supported }](/{{page.lang}}/4x/api.html) | April 2014 | **ongoing**{: .supported } |
-| [**v3.x**{: .eol }](/{{page.lang}}/3x/api.html) | October 2012 | July 2015 |
-| [**v2.x**{: .eol }](/{{page.lang}}/2x/) | March 2011 | July 2012 |
-| **v1.x**{: .eol } | December 2010 | March 2011 |
-| **v0.14.x**{: .eol } | December 2010 | December 2010 |
+| Major Version | Minimum Node.js Version | Support Start Date | Support End Date |
+| -- | -- | -- | -- |
+| [**v5.x**{: .supported }](/{{page.lang}}/5x/api.html) | 18.0.0 | September 2024 | **ongoing**{: .supported } |
+| [**v4.x**{: .supported }](/{{page.lang}}/4x/api.html) | 0.10.0 | April 2014 | **ongoing**{: .supported } |
+| [**v3.x**{: .eol }](/{{page.lang}}/3x/api.html) | 0.8.0 | October 2012 | July 2015 |
+| [**v2.x**{: .eol }](/{{page.lang}}/2x/) | 0.4.1 | March 2011 | July 2012 |
+| **v1.x**{: .eol } | 0.2.0 | December 2010 | March 2011 |
+| **v0.14.x**{: .eol } | 0.1.98 | December 2010 | December 2010 |
 
 ## Commercial Support Options
 

--- a/sk/support/index.md
+++ b/sk/support/index.md
@@ -13,7 +13,7 @@ Versions that are EOL (end-of-life) _may_ receive updates for critical security 
 
 | Major Version | Minimum Node.js Version | Support Start Date | Support End Date |
 | -- | -- | -- | -- |
-| [**v5.x**{: .supported }](/{{page.lang}}/5x/api.html) | 18.0.0 | September 2024 | **ongoing**{: .supported } |
+| [**v5.x**{: .supported }](/{{page.lang}}/5x/api.html) | 18 | September 2024 | **ongoing**{: .supported } |
 | [**v4.x**{: .supported }](/{{page.lang}}/4x/api.html) | 0.10.0 | April 2014 | **ongoing**{: .supported } |
 | [**v3.x**{: .eol }](/{{page.lang}}/3x/api.html) | 0.8.0 | October 2012 | July 2015 |
 | [**v2.x**{: .eol }](/{{page.lang}}/2x/) | 0.4.1 | March 2011 | July 2012 |

--- a/th/support/index.md
+++ b/th/support/index.md
@@ -11,14 +11,14 @@ Only the latest version of any given major release line is supported.
 
 Versions that are EOL (end-of-life) _may_ receive updates for critical security vulnerabilities, but the Express team offers no guarantee and does not plan to address or release fixes for any issues found.
 
-| Major Version | Support Start Date | Support End Date |
-| -- | -- | -- |
-| [**v5.x**{: .no-release }](/{{page.lang}}/5x/api.html) | **not yet released**{: .no-release } | **not yet released**{: .no-release } |
-| [**v4.x**{: .supported }](/{{page.lang}}/4x/api.html) | April 2014 | **ongoing**{: .supported } |
-| [**v3.x**{: .eol }](/{{page.lang}}/3x/api.html) | October 2012 | July 2015 |
-| [**v2.x**{: .eol }](/{{page.lang}}/2x/) | March 2011 | July 2012 |
-| **v1.x**{: .eol } | December 2010 | March 2011 |
-| **v0.14.x**{: .eol } | December 2010 | December 2010 |
+| Major Version | Minimum Node.js Version | Support Start Date | Support End Date |
+| -- | -- | -- | -- |
+| [**v5.x**{: .supported }](/{{page.lang}}/5x/api.html) | 18.0.0 | September 2024 | **ongoing**{: .supported } |
+| [**v4.x**{: .supported }](/{{page.lang}}/4x/api.html) | 0.10.0 | April 2014 | **ongoing**{: .supported } |
+| [**v3.x**{: .eol }](/{{page.lang}}/3x/api.html) | 0.8.0 | October 2012 | July 2015 |
+| [**v2.x**{: .eol }](/{{page.lang}}/2x/) | 0.4.1 | March 2011 | July 2012 |
+| **v1.x**{: .eol } | 0.2.0 | December 2010 | March 2011 |
+| **v0.14.x**{: .eol } | 0.1.98 | December 2010 | December 2010 |
 
 ## Commercial Support Options
 

--- a/th/support/index.md
+++ b/th/support/index.md
@@ -13,7 +13,7 @@ Versions that are EOL (end-of-life) _may_ receive updates for critical security 
 
 | Major Version | Minimum Node.js Version | Support Start Date | Support End Date |
 | -- | -- | -- | -- |
-| [**v5.x**{: .supported }](/{{page.lang}}/5x/api.html) | 18.0.0 | September 2024 | **ongoing**{: .supported } |
+| [**v5.x**{: .supported }](/{{page.lang}}/5x/api.html) | 18 | September 2024 | **ongoing**{: .supported } |
 | [**v4.x**{: .supported }](/{{page.lang}}/4x/api.html) | 0.10.0 | April 2014 | **ongoing**{: .supported } |
 | [**v3.x**{: .eol }](/{{page.lang}}/3x/api.html) | 0.8.0 | October 2012 | July 2015 |
 | [**v2.x**{: .eol }](/{{page.lang}}/2x/) | 0.4.1 | March 2011 | July 2012 |

--- a/tr/support/index.md
+++ b/tr/support/index.md
@@ -11,14 +11,14 @@ Only the latest version of any given major release line is supported.
 
 Versions that are EOL (end-of-life) _may_ receive updates for critical security vulnerabilities, but the Express team offers no guarantee and does not plan to address or release fixes for any issues found.
 
-| Major Version | Support Start Date | Support End Date |
-| -- | -- | -- |
-| [**v5.x**{: .no-release }](/{{page.lang}}/5x/api.html) | **not yet released**{: .no-release } | **not yet released**{: .no-release } |
-| [**v4.x**{: .supported }](/{{page.lang}}/4x/api.html) | April 2014 | **ongoing**{: .supported } |
-| [**v3.x**{: .eol }](/{{page.lang}}/3x/api.html) | October 2012 | July 2015 |
-| [**v2.x**{: .eol }](/{{page.lang}}/2x/) | March 2011 | July 2012 |
-| **v1.x**{: .eol } | December 2010 | March 2011 |
-| **v0.14.x**{: .eol } | December 2010 | December 2010 |
+| Major Version | Minimum Node.js Version | Support Start Date | Support End Date |
+| -- | -- | -- | -- |
+| [**v5.x**{: .supported }](/{{page.lang}}/5x/api.html) | 18.0.0 | September 2024 | **ongoing**{: .supported } |
+| [**v4.x**{: .supported }](/{{page.lang}}/4x/api.html) | 0.10.0 | April 2014 | **ongoing**{: .supported } |
+| [**v3.x**{: .eol }](/{{page.lang}}/3x/api.html) | 0.8.0 | October 2012 | July 2015 |
+| [**v2.x**{: .eol }](/{{page.lang}}/2x/) | 0.4.1 | March 2011 | July 2012 |
+| **v1.x**{: .eol } | 0.2.0 | December 2010 | March 2011 |
+| **v0.14.x**{: .eol } | 0.1.98 | December 2010 | December 2010 |
 
 ## Commercial Support Options
 

--- a/tr/support/index.md
+++ b/tr/support/index.md
@@ -13,7 +13,7 @@ Versions that are EOL (end-of-life) _may_ receive updates for critical security 
 
 | Major Version | Minimum Node.js Version | Support Start Date | Support End Date |
 | -- | -- | -- | -- |
-| [**v5.x**{: .supported }](/{{page.lang}}/5x/api.html) | 18.0.0 | September 2024 | **ongoing**{: .supported } |
+| [**v5.x**{: .supported }](/{{page.lang}}/5x/api.html) | 18 | September 2024 | **ongoing**{: .supported } |
 | [**v4.x**{: .supported }](/{{page.lang}}/4x/api.html) | 0.10.0 | April 2014 | **ongoing**{: .supported } |
 | [**v3.x**{: .eol }](/{{page.lang}}/3x/api.html) | 0.8.0 | October 2012 | July 2015 |
 | [**v2.x**{: .eol }](/{{page.lang}}/2x/) | 0.4.1 | March 2011 | July 2012 |

--- a/uk/support/index.md
+++ b/uk/support/index.md
@@ -11,14 +11,14 @@ Only the latest version of any given major release line is supported.
 
 Versions that are EOL (end-of-life) _may_ receive updates for critical security vulnerabilities, but the Express team offers no guarantee and does not plan to address or release fixes for any issues found.
 
-| Major Version | Support Start Date | Support End Date |
-| -- | -- | -- |
-| [**v5.x**{: .no-release }](/{{page.lang}}/5x/api.html) | **not yet released**{: .no-release } | **not yet released**{: .no-release } |
-| [**v4.x**{: .supported }](/{{page.lang}}/4x/api.html) | April 2014 | **ongoing**{: .supported } |
-| [**v3.x**{: .eol }](/{{page.lang}}/3x/api.html) | October 2012 | July 2015 |
-| [**v2.x**{: .eol }](/{{page.lang}}/2x/) | March 2011 | July 2012 |
-| **v1.x**{: .eol } | December 2010 | March 2011 |
-| **v0.14.x**{: .eol } | December 2010 | December 2010 |
+| Major Version | Minimum Node.js Version | Support Start Date | Support End Date |
+| -- | -- | -- | -- |
+| [**v5.x**{: .supported }](/{{page.lang}}/5x/api.html) | 18.0.0 | September 2024 | **ongoing**{: .supported } |
+| [**v4.x**{: .supported }](/{{page.lang}}/4x/api.html) | 0.10.0 | April 2014 | **ongoing**{: .supported } |
+| [**v3.x**{: .eol }](/{{page.lang}}/3x/api.html) | 0.8.0 | October 2012 | July 2015 |
+| [**v2.x**{: .eol }](/{{page.lang}}/2x/) | 0.4.1 | March 2011 | July 2012 |
+| **v1.x**{: .eol } | 0.2.0 | December 2010 | March 2011 |
+| **v0.14.x**{: .eol } | 0.1.98 | December 2010 | December 2010 |
 
 ## Commercial Support Options
 

--- a/uk/support/index.md
+++ b/uk/support/index.md
@@ -13,7 +13,7 @@ Versions that are EOL (end-of-life) _may_ receive updates for critical security 
 
 | Major Version | Minimum Node.js Version | Support Start Date | Support End Date |
 | -- | -- | -- | -- |
-| [**v5.x**{: .supported }](/{{page.lang}}/5x/api.html) | 18.0.0 | September 2024 | **ongoing**{: .supported } |
+| [**v5.x**{: .supported }](/{{page.lang}}/5x/api.html) | 18 | September 2024 | **ongoing**{: .supported } |
 | [**v4.x**{: .supported }](/{{page.lang}}/4x/api.html) | 0.10.0 | April 2014 | **ongoing**{: .supported } |
 | [**v3.x**{: .eol }](/{{page.lang}}/3x/api.html) | 0.8.0 | October 2012 | July 2015 |
 | [**v2.x**{: .eol }](/{{page.lang}}/2x/) | 0.4.1 | March 2011 | July 2012 |

--- a/uz/support/index.md
+++ b/uz/support/index.md
@@ -11,14 +11,14 @@ Only the latest version of any given major release line is supported.
 
 Versions that are EOL (end-of-life) _may_ receive updates for critical security vulnerabilities, but the Express team offers no guarantee and does not plan to address or release fixes for any issues found.
 
-| Major Version | Support Start Date | Support End Date |
-| -- | -- | -- |
-| [**v5.x**{: .no-release }](/{{page.lang}}/5x/api.html) | **not yet released**{: .no-release } | **not yet released**{: .no-release } |
-| [**v4.x**{: .supported }](/{{page.lang}}/4x/api.html) | April 2014 | **ongoing**{: .supported } |
-| [**v3.x**{: .eol }](/{{page.lang}}/3x/api.html) | October 2012 | July 2015 |
-| [**v2.x**{: .eol }](/{{page.lang}}/2x/) | March 2011 | July 2012 |
-| **v1.x**{: .eol } | December 2010 | March 2011 |
-| **v0.14.x**{: .eol } | December 2010 | December 2010 |
+| Major Version | Minimum Node.js Version | Support Start Date | Support End Date |
+| -- | -- | -- | -- |
+| [**v5.x**{: .supported }](/{{page.lang}}/5x/api.html) | 18.0.0 | September 2024 | **ongoing**{: .supported } |
+| [**v4.x**{: .supported }](/{{page.lang}}/4x/api.html) | 0.10.0 | April 2014 | **ongoing**{: .supported } |
+| [**v3.x**{: .eol }](/{{page.lang}}/3x/api.html) | 0.8.0 | October 2012 | July 2015 |
+| [**v2.x**{: .eol }](/{{page.lang}}/2x/) | 0.4.1 | March 2011 | July 2012 |
+| **v1.x**{: .eol } | 0.2.0 | December 2010 | March 2011 |
+| **v0.14.x**{: .eol } | 0.1.98 | December 2010 | December 2010 |
 
 ## Commercial Support Options
 

--- a/uz/support/index.md
+++ b/uz/support/index.md
@@ -13,7 +13,7 @@ Versions that are EOL (end-of-life) _may_ receive updates for critical security 
 
 | Major Version | Minimum Node.js Version | Support Start Date | Support End Date |
 | -- | -- | -- | -- |
-| [**v5.x**{: .supported }](/{{page.lang}}/5x/api.html) | 18.0.0 | September 2024 | **ongoing**{: .supported } |
+| [**v5.x**{: .supported }](/{{page.lang}}/5x/api.html) | 18 | September 2024 | **ongoing**{: .supported } |
 | [**v4.x**{: .supported }](/{{page.lang}}/4x/api.html) | 0.10.0 | April 2014 | **ongoing**{: .supported } |
 | [**v3.x**{: .eol }](/{{page.lang}}/3x/api.html) | 0.8.0 | October 2012 | July 2015 |
 | [**v2.x**{: .eol }](/{{page.lang}}/2x/) | 0.4.1 | March 2011 | July 2012 |

--- a/zh-cn/support/index.md
+++ b/zh-cn/support/index.md
@@ -11,14 +11,14 @@ Only the latest version of any given major release line is supported.
 
 Versions that are EOL (end-of-life) _may_ receive updates for critical security vulnerabilities, but the Express team offers no guarantee and does not plan to address or release fixes for any issues found.
 
-| Major Version | Support Start Date | Support End Date |
-| -- | -- | -- |
-| [**v5.x**{: .no-release }](/{{page.lang}}/5x/api.html) | **not yet released**{: .no-release } | **not yet released**{: .no-release } |
-| [**v4.x**{: .supported }](/{{page.lang}}/4x/api.html) | April 2014 | **ongoing**{: .supported } |
-| [**v3.x**{: .eol }](/{{page.lang}}/3x/api.html) | October 2012 | July 2015 |
-| [**v2.x**{: .eol }](/{{page.lang}}/2x/) | March 2011 | July 2012 |
-| **v1.x**{: .eol } | December 2010 | March 2011 |
-| **v0.14.x**{: .eol } | December 2010 | December 2010 |
+| Major Version | Minimum Node.js Version | Support Start Date | Support End Date |
+| -- | -- | -- | -- |
+| [**v5.x**{: .supported }](/{{page.lang}}/5x/api.html) | 18.0.0 | September 2024 | **ongoing**{: .supported } |
+| [**v4.x**{: .supported }](/{{page.lang}}/4x/api.html) | 0.10.0 | April 2014 | **ongoing**{: .supported } |
+| [**v3.x**{: .eol }](/{{page.lang}}/3x/api.html) | 0.8.0 | October 2012 | July 2015 |
+| [**v2.x**{: .eol }](/{{page.lang}}/2x/) | 0.4.1 | March 2011 | July 2012 |
+| **v1.x**{: .eol } | 0.2.0 | December 2010 | March 2011 |
+| **v0.14.x**{: .eol } | 0.1.98 | December 2010 | December 2010 |
 
 ## Commercial Support Options
 

--- a/zh-cn/support/index.md
+++ b/zh-cn/support/index.md
@@ -13,7 +13,7 @@ Versions that are EOL (end-of-life) _may_ receive updates for critical security 
 
 | Major Version | Minimum Node.js Version | Support Start Date | Support End Date |
 | -- | -- | -- | -- |
-| [**v5.x**{: .supported }](/{{page.lang}}/5x/api.html) | 18.0.0 | September 2024 | **ongoing**{: .supported } |
+| [**v5.x**{: .supported }](/{{page.lang}}/5x/api.html) | 18 | September 2024 | **ongoing**{: .supported } |
 | [**v4.x**{: .supported }](/{{page.lang}}/4x/api.html) | 0.10.0 | April 2014 | **ongoing**{: .supported } |
 | [**v3.x**{: .eol }](/{{page.lang}}/3x/api.html) | 0.8.0 | October 2012 | July 2015 |
 | [**v2.x**{: .eol }](/{{page.lang}}/2x/) | 0.4.1 | March 2011 | July 2012 |

--- a/zh-tw/support/index.md
+++ b/zh-tw/support/index.md
@@ -11,14 +11,14 @@ Only the latest version of any given major release line is supported.
 
 Versions that are EOL (end-of-life) _may_ receive updates for critical security vulnerabilities, but the Express team offers no guarantee and does not plan to address or release fixes for any issues found.
 
-| Major Version | Support Start Date | Support End Date |
-| -- | -- | -- |
-| [**v5.x**{: .no-release }](/{{page.lang}}/5x/api.html) | **not yet released**{: .no-release } | **not yet released**{: .no-release } |
-| [**v4.x**{: .supported }](/{{page.lang}}/4x/api.html) | April 2014 | **ongoing**{: .supported } |
-| [**v3.x**{: .eol }](/{{page.lang}}/3x/api.html) | October 2012 | July 2015 |
-| [**v2.x**{: .eol }](/{{page.lang}}/2x/) | March 2011 | July 2012 |
-| **v1.x**{: .eol } | December 2010 | March 2011 |
-| **v0.14.x**{: .eol } | December 2010 | December 2010 |
+| Major Version | Minimum Node.js Version | Support Start Date | Support End Date |
+| -- | -- | -- | -- |
+| [**v5.x**{: .supported }](/{{page.lang}}/5x/api.html) | 18.0.0 | September 2024 | **ongoing**{: .supported } |
+| [**v4.x**{: .supported }](/{{page.lang}}/4x/api.html) | 0.10.0 | April 2014 | **ongoing**{: .supported } |
+| [**v3.x**{: .eol }](/{{page.lang}}/3x/api.html) | 0.8.0 | October 2012 | July 2015 |
+| [**v2.x**{: .eol }](/{{page.lang}}/2x/) | 0.4.1 | March 2011 | July 2012 |
+| **v1.x**{: .eol } | 0.2.0 | December 2010 | March 2011 |
+| **v0.14.x**{: .eol } | 0.1.98 | December 2010 | December 2010 |
 
 ## Commercial Support Options
 

--- a/zh-tw/support/index.md
+++ b/zh-tw/support/index.md
@@ -13,7 +13,7 @@ Versions that are EOL (end-of-life) _may_ receive updates for critical security 
 
 | Major Version | Minimum Node.js Version | Support Start Date | Support End Date |
 | -- | -- | -- | -- |
-| [**v5.x**{: .supported }](/{{page.lang}}/5x/api.html) | 18.0.0 | September 2024 | **ongoing**{: .supported } |
+| [**v5.x**{: .supported }](/{{page.lang}}/5x/api.html) | 18 | September 2024 | **ongoing**{: .supported } |
 | [**v4.x**{: .supported }](/{{page.lang}}/4x/api.html) | 0.10.0 | April 2014 | **ongoing**{: .supported } |
 | [**v3.x**{: .eol }](/{{page.lang}}/3x/api.html) | 0.8.0 | October 2012 | July 2015 |
 | [**v2.x**{: .eol }](/{{page.lang}}/2x/) | 0.4.1 | March 2011 | July 2012 |


### PR DESCRIPTION
Added the minimum supported node.js version to the support page. Please correct me if I'm wrong about the minimum versions for the 3.x, 2.x, 1.x and 0.14.x release lines. 

Preview: https://deploy-preview-1733--expressjscom-preview.netlify.app/en/support/

<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->