### PR TITLE
Update link to HTTP status code documentation

### DIFF
--- a/_includes/api/en/4x/res-redirect.md
+++ b/_includes/api/en/4x/res-redirect.md
@@ -1,7 +1,7 @@
 <h3 id='res.redirect'>res.redirect([status,] path)</h3>
 
 Redirects to the URL derived from the specified `path`, with specified `status`, a positive integer
-that corresponds to an [HTTP status code](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html) .
+that corresponds to an [HTTP status code](https://www.rfc-editor.org/rfc/rfc9110.html#name-status-codes) .
 If not specified, `status` defaults to "302 "Found".
 
 ```js

--- a/_includes/api/en/5x/res-redirect.md
+++ b/_includes/api/en/5x/res-redirect.md
@@ -1,7 +1,7 @@
 <h3 id='res.redirect'>res.redirect([status,] path)</h3>
 
 Redirects to the URL derived from the specified `path`, with specified `status`, a positive integer
-that corresponds to an [HTTP status code](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html).
+that corresponds to an [HTTP status code](https://www.rfc-editor.org/rfc/rfc9110.html#name-status-codes).
 If not specified, `status` defaults to `302 "Found"`.
 
 ```js


### PR DESCRIPTION
closes #1737

This updates the link to the documentation for HTTP Status Codes referenced in the res.redirect documentation.

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->