### PR TITLE
fix code padding

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -353,6 +353,10 @@ pre {
   background-color: var(--code-bg);
 }
 
+pre code {
+  padding: 0;
+}
+
 /* top button */
 
 .scroll #top {


### PR DESCRIPTION
before:
![image](https://github.com/user-attachments/assets/796fd735-6aeb-4db4-a3a2-906ad902ba3e)

after:
![image](https://github.com/user-attachments/assets/bc9cc597-40c7-4b8b-99cf-cdf97341f5d7)

closes #1772