### PR TITLE
docs: update documentation for res.type()

### DIFF
--- a/_includes/api/en/4x/res-type.md
+++ b/_includes/api/en/4x/res-type.md
@@ -14,3 +14,5 @@ res.type('application/json')
 res.type('png')
 // => 'image/png'
 ```
+
+Aliased as `res.contentType(type)`.

--- a/_includes/api/en/5x/res-type.md
+++ b/_includes/api/en/5x/res-type.md
@@ -1,6 +1,6 @@
 <h3 id='res.type'>res.type(type)</h3>
 
-Sets the `Content-Type` HTTP header to the MIME type as determined by the specified `type`. If `type` contains the "/" character, then it sets the `Content-Type` to the exact value of `type`, otherwise it is assumed to be a file extension and the MIME type is looked up in a mapping using the `express.static.mime.lookup()` method.
+Sets the `Content-Type` HTTP header to the MIME type as determined by the specified `type`. If `type` contains the "/" character, then it sets the `Content-Type` to the exact value of `type`, otherwise it is assumed to be a file extension and the MIME type is looked up using the `contentType()` method of the `mime-types` package.
 
 ```js
 res.type('.html') // => 'text/html'
@@ -9,3 +9,5 @@ res.type('json') // => 'application/json'
 res.type('application/json') // => 'application/json'
 res.type('png') // => image/png:
 ```
+
+Aliased as `res.contentType(type)`.

--- a/en/guide/migrating-5.md
+++ b/en/guide/migrating-5.md
@@ -270,11 +270,11 @@ Use the [`mime-types` package](https://github.com/jshttp/mime-types) to work wit
 
 ```js
 // v4
-const mimeType = express.static.mime.lookup('json')
+express.static.mime.lookup('json')
 
 // v5
 const mime = require('mime-types')
-const mimeType = mime.lookup('json')
+mime.lookup('json')
 ```
 
 <h3>Changed</h3>

--- a/en/guide/migrating-5.md
+++ b/en/guide/migrating-5.md
@@ -37,6 +37,7 @@ You can then run your automated tests to see what fails, and fix problems accord
   <li><a href="#res.send.body">res.send(body, status)</a></li>
   <li><a href="#res.send.status">res.send(status)</a></li>
   <li><a href="#res.sendfile">res.sendfile()</a></li>
+  <li><a href="#express.static.mime">express.static.mime</a></li>
 </ul>
 
 **Changed**
@@ -260,6 +261,20 @@ app.get('/user', (req, res) => {
 app.get('/user', (req, res) => {
   res.sendFile('/path/to/file')
 })
+```
+
+<h4 id="express.static.mime">express.static.mime</h4>
+
+In Express 5, `mime` is no longer an exported property of the `static` field.
+Use the [`mime-types` package](https://github.com/jshttp/mime-types) to work with MIME type values.
+
+```js
+// v4
+const mimeType = express.static.mime.lookup('json')
+
+// v5
+const mime = require('mime-types')
+const mimeType = mime.lookup('json')
 ```
 
 <h3>Changed</h3>


### PR DESCRIPTION
Corrects information about the internal behavior that is no longer valid and re-adds documentation for the alias `res.contentType()`.

Resolves https://github.com/expressjs/express/issues/6330

<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->