### PR TITLE
fix accessibility issue related to image alt text

### DIFF
--- a/de/guide/writing-middleware.md
+++ b/de/guide/writing-middleware.md
@@ -25,7 +25,7 @@ Das folgende Beispiel zeigt die Elemente eines Middlewarefunktionsaufrufs:
 
 <table style="padding: 0; border: 0; width: 960px; margin-bottom: 10px;">
 <tr><td style="margin: 0; padding: 0px; border: 0; width: 410px;">
-<img src="/images/express-mw.png" style="margin: 0px; padding: 0px; width: 410px; height: 308px;" />
+<img src="/images/express-mw.png" alt="Elements of a middleware function call" style="margin: 0px; padding: 0px; width: 410px; height: 308px;" />
 </td>
 <td style="margin: 0; padding: 0 0 0 5px; border: 0; width: 550px;">
 <div class="callout" id="callout1">HTTP-Methode, für die die Middlewarefunktion angewendet wird.</div>

--- a/en/guide/writing-middleware.md
+++ b/en/guide/writing-middleware.md
@@ -25,7 +25,7 @@ The following figure shows the elements of a middleware function call:
 
 <table id="mw-fig">
 <tr><td id="mw-fig-imgcell">
-<img src="/images/express-mw.png" id="mw-fig-img" />
+<img src="/images/express-mw.png" alt="Elements of a middleware function call" id="mw-fig-img" />
 </td>
 <td class="mw-fig-callouts">
 <div class="callout" id="callout1">HTTP method for which the middleware function applies.</div>

--- a/en/resources/community.md
+++ b/en/resources/community.md
@@ -76,19 +76,19 @@ Express is a project of the OpenJS Foundation. Please review the [trademark poli
     <div>
         <h3>Logotype</h3>
         <a href="/images/brand/logotype-light.svg" class="hidden-dark">
-            <img src="/images/brand/logotype-light.svg" width="250" height="56"/>
+            <img src="/images/brand/logotype-light.svg" alt="Express.js logo" width="250" height="56"/>
         </a>
         <a href="/images/brand/logotype-dark.svg" class="hidden-light">
-            <img src="/images/brand/logotype-dark.svg" width="250" height="56"/>
+            <img src="/images/brand/logotype-dark.svg" alt="Express.js logo" width="250" height="56"/>
         </a>
     </div>
     <div>
         <h3>Logomark</h3>
         <a href="/images/brand/logo-light.svg" class="hidden-dark">
-            <img src="/images/brand/logo-light.svg" width="96.5" height="56"/>
+            <img src="/images/brand/logo-light.svg" alt="Express.js mark" width="96.5" height="56"/>
         </a>
         <a href="/images/brand/logo-dark.svg" class="hidden-light">
-            <img src="/images/brand/logo-dark.svg" width="96.5" height="56"/>
+            <img src="/images/brand/logo-dark.svg"  alt="Express.js mark" width="96.5" height="56"/>
         </a>
     </div>
 <div>

--- a/es/guide/writing-middleware.md
+++ b/es/guide/writing-middleware.md
@@ -26,7 +26,7 @@ El siguiente ejemplo muestra los elementos de una llamada a función de middlewa
 
 <table id="mw-fig">
 <tr><td id="mw-fig-imgcell">
-<img src="/images/express-mw.png" id="mw-fig-img" />
+<img src="/images/express-mw.png" alt="Elements of a middleware function call" id="mw-fig-img" />
 </td>
 <td class="mw-fig-callouts">
 <div class="callout" id="callout1">Método HTTP para el que se aplica la función de middleware.</div>

--- a/es/resources/community.md
+++ b/es/resources/community.md
@@ -70,19 +70,19 @@ Express es un proyecto de la Fundación OpenJS. Por favor, revise la [política 
     <div>
         <h3>Logotipo</h3>
         <a href="/images/brand/logotype-light.svg" class="hidden-dark">
-            <img src="/images/brand/logotype-light.svg" width="250" height="56"/>
+            <img src="/images/brand/logotype-light.svg" alt="Express.js logo" width="250" height="56"/>
         </a>
         <a href="/images/brand/logotype-dark.svg" class="hidden-light">
-            <img src="/images/brand/logotype-dark.svg" width="250" height="56"/>
+            <img src="/images/brand/logotype-dark.svg" alt="Express.js logo" width="250" height="56"/>
         </a>
     </div>
     <div>
         <h3>Logo de Marca</h3>
         <a href="/images/brand/logo-light.svg" class="hidden-dark">
-            <img src="/images/brand/logo-light.svg" width="96.5" height="56"/>
+            <img src="/images/brand/logo-light.svg" alt="Express.js mark" width="96.5" height="56"/>
         </a>
         <a href="/images/brand/logo-dark.svg" class="hidden-light">
-            <img src="/images/brand/logo-dark.svg" width="96.5" height="56"/>
+            <img src="/images/brand/logo-dark.svg" alt="Express.js mark" width="96.5" height="56"/>
         </a>
     </div>
 <div>

--- a/fr/guide/writing-middleware.md
+++ b/fr/guide/writing-middleware.md
@@ -26,7 +26,7 @@ L'exemple suivant montre les éléments d'un appel de fonction middleware:
 
 <table style="padding: 0; border: 0; width: 960px; margin-bottom: 10px;">
 <tr><td style="margin: 0; padding: 0px; border: 0; width: 410px;">
-<img src="/images/express-mw.png" style="margin: 0px; padding: 0px; width: 410px; height: 308px;" />
+<img src="/images/express-mw.png" alt="Elements of a middleware function call" style="margin: 0px; padding: 0px; width: 410px; height: 308px;" />
 </td>
 <td style="margin: 0; padding: 0 0 0 5px; border: 0; width: 550px;">
 <div class="callout" id="callout1">Méthode HTTP à laquelle la fonction middleware s'applique.</div>

--- a/id/guide/writing-middleware.md
+++ b/id/guide/writing-middleware.md
@@ -25,7 +25,7 @@ The following figure shows the elements of a middleware function call:
 
 <table id="mw-fig">
 <tr><td id="mw-fig-imgcell">
-<img src="/images/express-mw.png" id="mw-fig-img" />
+<img src="/images/express-mw.png" alt="Elements of a middleware function call" id="mw-fig-img" />
 </td>
 <td class="mw-fig-callouts">
 <div class="callout" id="callout1">HTTP method for which the middleware function applies.</div>

--- a/it/guide/writing-middleware.md
+++ b/it/guide/writing-middleware.md
@@ -26,7 +26,7 @@ I seguenti esempi mostrano gli elementi di una chiamata alla funzione middleware
 
 <table style="padding: 0; border: 0; width: 960px; margin-bottom: 10px;">
 <tr><td style="margin: 0; padding: 0px; border: 0; width: 410px;">
-<img src="/images/express-mw.png" style="margin: 0px; padding: 0px; width: 410px; height: 308px;" />
+<img src="/images/express-mw.png" alt="Elements of a middleware function call" style="margin: 0px; padding: 0px; width: 410px; height: 308px;" />
 </td>
 <td style="margin: 0; padding: 0 0 0 5px; border: 0; width: 550px;">
 <div class="callout" id="callout1">Metodo HTTP per cui si applica la funzione middleware.</div>

--- a/ja/guide/writing-middleware.md
+++ b/ja/guide/writing-middleware.md
@@ -26,7 +26,7 @@ description: Learn how to write custom middleware functions for Express.js appli
 
 <table id="mw-fig">
 <tr><td id="mw-fig-imgcell">
-<img src="/images/express-mw.png" id="mw-fig-img" />
+<img src="/images/express-mw.png" alt="Elements of a middleware function call" id="mw-fig-img" />
 </td>
 <td class="mw-fig-callouts">
 <div class="callout" id="callout1">ミドルウェア関数が適用される HTTP メソッド。</div>

--- a/ko/guide/writing-middleware.md
+++ b/ko/guide/writing-middleware.md
@@ -26,7 +26,7 @@ description: Learn how to write custom middleware functions for Express.js appli
 
 <table id="mw-fig">
 <tr><td id="mw-fig-imgcell">
-<img src="/images/express-mw.png" id="mw-fig-img" />
+<img src="/images/express-mw.png" alt="Elements of a middleware function call" id="mw-fig-img" />
 </td>
 <td class="mw-fig-callouts">
 <div class="callout" id="callout1">미들웨어 함수가 적용되는 HTTP 메소드.</div>

--- a/pt-br/guide/writing-middleware.md
+++ b/pt-br/guide/writing-middleware.md
@@ -34,7 +34,7 @@ O exemplo a seguir mostra os elementos de uma chamada de função de middleware:
 
 <table id="mw-fig"> 
 <tr><td id="mw-fig-imgcell">
-<img src="/images/express-mw.png" id="mw-fig-img" />
+<img src="/images/express-mw.png" alt="Elements of a middleware function call" id="mw-fig-img" />
 </td>
 <td class="mw-fig-callouts">
 <div class="callout" id="callout1">O método HTTP para o qual a função de middleware é aplicada.</div>

--- a/ru/guide/writing-middleware.md
+++ b/ru/guide/writing-middleware.md
@@ -26,7 +26,7 @@ description: Learn how to write custom middleware functions for Express.js appli
 
 <table id="mw-fig">
 <tr><td id="mw-fig-imgcell">
-<img src="/images/express-mw.png" id="mw-fig-img" />
+<img src="/images/express-mw.png" alt="Elements of a middleware function call" id="mw-fig-img" />
 </td>
 <td class="mw-fig-callouts">
 <div class="callout" id="callout1">Метод HTTP, к которому применяется данный промежуточный обработчик.</div>

--- a/sk/guide/writing-middleware.md
+++ b/sk/guide/writing-middleware.md
@@ -26,7 +26,7 @@ Nasledujúci diagram ukazuje jednotlivé časti volania middleware funkcie:
 
 <table id="mw-fig">
 <tr><td id="mw-fig-imgcell">
-<img src="/images/express-mw.png" id="mw-fig-img" />
+<img src="/images/express-mw.png" alt="Elements of a middleware function call" id="mw-fig-img" />
 </td>
 <td class="mw-fig-callouts">
 <div class="callout" id="callout1">HTTP metóda pre ktorú je middleware funkcia aplikovateľná.</div>

--- a/th/guide/writing-middleware.md
+++ b/th/guide/writing-middleware.md
@@ -25,7 +25,7 @@ The following figure shows the elements of a middleware function call:
 
 <table id="mw-fig">
 <tr><td id="mw-fig-imgcell">
-<img src="/images/express-mw.png" id="mw-fig-img" />
+<img src="/images/express-mw.png" alt="Elements of a middleware function call" id="mw-fig-img" />
 </td>
 <td class="mw-fig-callouts">
 <div class="callout" id="callout1">HTTP method for which the middleware function applies.</div>

--- a/tr/guide/writing-middleware.md
+++ b/tr/guide/writing-middleware.md
@@ -26,7 +26,7 @@ Aşağıdaki şekil bir ara yazılım fonksiyon çağrısının öğelerini gös
 
 <table id="mw-fig">
 <tr><td id="mw-fig-imgcell">
-<img src="/images/express-mw.png" id="mw-fig-img" />
+<img src="/images/express-mw.png" alt="Elements of a middleware function call" id="mw-fig-img" />
 </td>
 <td class="mw-fig-callouts">
 <div class="callout" id="callout1">Ara yazılım fonsiyonunu uyglandığı HTTP metodu.</div>

--- a/uk/guide/writing-middleware.md
+++ b/uk/guide/writing-middleware.md
@@ -26,7 +26,7 @@ The following figure shows the elements of a middleware function call:
 
 <table id="mw-fig">
 <tr><td id="mw-fig-imgcell">
-<img src="/images/express-mw.png" id="mw-fig-img" />
+<img src="/images/express-mw.png" alt="Elements of a middleware function call" id="mw-fig-img" />
 </td>
 <td class="mw-fig-callouts">
 <div class="callout" id="callout1">HTTP method for which the middleware function applies.</div>

--- a/uk/resources/community.md
+++ b/uk/resources/community.md
@@ -70,19 +70,19 @@ Express — це проєкт OpenJS Foundation. Будь-ласка, ознай
     <div>
         <h3>Логотип</h3>
         <a href="/images/brand/logotype-light.svg" class="hidden-dark">
-            <img src="/images/brand/logotype-light.svg" width="250" height="56"/>
+            <img src="/images/brand/logotype-light.svg" alt="Express.js logo" width="250" height="56"/>
         </a>
         <a href="/images/brand/logotype-dark.svg" class="hidden-light">
-            <img src="/images/brand/logotype-dark.svg" width="250" height="56"/>
+            <img src="/images/brand/logotype-dark.svg" alt="Express.js logo" width="250" height="56"/>
         </a>
     </div>
     <div>
         <h3>Логомарка</h3>
         <a href="/images/brand/logo-light.svg" class="hidden-dark">
-            <img src="/images/brand/logo-light.svg" width="96.5" height="56"/>
+            <img src="/images/brand/logo-light.svg" alt="Express.js mark" width="96.5" height="56"/>
         </a>
         <a href="/images/brand/logo-dark.svg" class="hidden-light">
-            <img src="/images/brand/logo-dark.svg" width="96.5" height="56"/>
+            <img src="/images/brand/logo-dark.svg" alt="Express.js mark" width="96.5" height="56"/>
         </a>
     </div>
 <div>

--- a/zh-cn/guide/writing-middleware.md
+++ b/zh-cn/guide/writing-middleware.md
@@ -26,7 +26,7 @@ description: Learn how to write custom middleware functions for Express.js appli
 
 <table id="mw-fig"> 
 <tr><td id="mw-fig-imgcell">
-<img src="/images/express-mw.png" id="mw-fig-img" />
+<img src="/images/express-mw.png" alt="Elements of a middleware function call" id="mw-fig-img" />
 </td>
 <td class="mw-fig-callouts">
 <div class="callout" id="callout1">中间件函数适用的 HTTP 方法。</div>

--- a/zh-tw/guide/writing-middleware.md
+++ b/zh-tw/guide/writing-middleware.md
@@ -26,7 +26,7 @@ description: Learn how to write custom middleware functions for Express.js appli
 
 <table id="mw-fig">
 <tr><td id="mw-fig-imgcell">
-<img src="/images/express-mw.png" id="mw-fig-img" />
+<img src="/images/express-mw.png" alt="Elements of a middleware function call" id="mw-fig-img" />
 </td>
 <td class="mw-fig-callouts">
 <div class="callout" id="callout1">要套用中介軟體函數的 HTTP 方法。</div>


### PR DESCRIPTION
- Image alt text provided for **guide/writing-middleware** page
- Image alt text provided for black & white logo and mark on **resources/community** page affected 3 markets only (en, es, uk)
- middleware section affected following markets

1. de
2. en
3. es
4. fr
5. id
6. it
7. ja
8. ko
9. pt-br
10. ru
11. sk
12. th
13. tr
14. uk
15. zh-cn
16. zh-tw

- Issue Reference: https://github.com/expressjs/expressjs.com/issues/1808
- Require translations for different markets for given alt text **"Elements of a middleware function call"**
