### PR TITLE
ci: remove CI on review submission

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,16 +7,10 @@ on:
   push:
     branches:
     - gh-pages
-  pull_request_review:
-      types: [submitted]
 
 jobs:
   test:
     runs-on: ubuntu-latest
-    if: |
-      github.event.pull_request.draft != true &&
-      (github.event_name == 'pull_request_review' && github.event.review.state == 'approved') ||
-      github.event_name != 'pull_request_review'
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
This change was made in #1463, I think we can remove this change now, as it was supposed to be temporary.