### PR TITLE
fix(1815): colour contrast adjusted for comments in code blocks

### DIFF
--- a/css/sintax.css
+++ b/css/sintax.css
@@ -87,6 +87,7 @@
 .highlight .ow,
 .highlight .gh,
 .highlight .gu,
+.highlight .s2,
 .highlight .dl   {
   color: var(--blue-light);
 }
@@ -97,7 +98,7 @@
 .highlight .gu {
   font-weight: bold;
 }
-.highlight .s, .highlight .sa, .highlight .sc, .highlight .sd, .highlight .s2, .highlight .se, .highlight .sh, .highlight .sx, .highlight .ss {
+.highlight .s, .highlight .sa, .highlight .sc, .highlight .sd,  .highlight .se, .highlight .sh, .highlight .sx, .highlight .ss {
   color: var(--blue-darker);
 }
 .highlight .nd, .highlight .nf, .highlight .fm {

--- a/css/sintax.css
+++ b/css/sintax.css
@@ -115,10 +115,13 @@
 .highlight .cm, 
 .highlight .cp, 
 .highlight .cpf, 
-.highlight .c1, 
 .highlight .cs,
 .highlight .gt {
   color: var(--gray);
+}
+
+.highlight .c1 {
+  color: var(--green);
 }
 
 .highlight .ni,

--- a/css/style.css
+++ b/css/style.css
@@ -15,6 +15,10 @@ body.no-scroll{
   overflow: hidden;
 }
 
+body .language-js .highlight .c1 {
+  color: green;
+}
+
 h1 {
   font-size: 30px;
   line-height: 36px;

--- a/css/style.css
+++ b/css/style.css
@@ -15,10 +15,6 @@ body.no-scroll{
   overflow: hidden;
 }
 
-body .language-js .highlight .c1 {
-  color: green;
-}
-
 h1 {
   font-size: 30px;
   line-height: 36px;


### PR DESCRIPTION
- To fix colour contrast accessibility issue, I turned comment sections green in code blocks
- Texted fix using axe core dev tools
- Given screens before and after fix

**Before Fix**

<img width="707" alt="Screenshot 2025-02-25 at 9 23 30 PM" src="https://github.com/user-attachments/assets/107bf507-c715-400d-850f-1d03a1f80635" />

**After Fix**

<img width="705" alt="Screenshot 2025-02-25 at 9 22 52 PM" src="https://github.com/user-attachments/assets/a06df340-6e9a-4daa-bcf1-5f91b4fbdd7a" />
