### PR TITLE
docs: add router debug log change to v5 migration guide

### DIFF
--- a/en/guide/migrating-5.md
+++ b/en/guide/migrating-5.md
@@ -39,6 +39,7 @@ You can then run your automated tests to see what fails, and fix problems accord
   <li><a href="#res.send.status">res.send(status)</a></li>
   <li><a href="#res.sendfile">res.sendfile()</a></li>
   <li><a href="#express.static.mime">express.static.mime</a></li>
+  <li><a href="#express:router-debug-logs">express:router debug logs</a></li>
 </ul>
 
 **Changed**
@@ -276,6 +277,25 @@ express.static.mime.lookup('json')
 // v5
 const mime = require('mime-types')
 mime.lookup('json')
+```
+
+<h4 id="express:router-debug-logs">express:router debug logs</h4>
+
+In Express 5, router handling logic is performed by a dependency. Therefore, the
+debug logs for the router are no longer available under the `express:` namespace.
+In v4, the logs were available under the namespaces `express:router`, `express:router:layer`,
+and `express:router:route`. All of these were included under the namespace `express:*`.
+In v5.1+, the logs are available under the namespaces `router`, `router:layer`, and `router:route`.
+The logs from `router:layer` and `router:route` are included in the namespace `router:*`.
+To achieve the same detail of debug logging when using `express:*` in v4, use a conjunction of
+`express:*`, `router`, and `router:*`.
+
+```sh
+# v4
+DEBUG=express:* node index.js
+
+# v5
+DEBUG=express:*,router,router:* node index.js
 ```
 
 <h3>Changed</h3>


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

The debug logs are not yet available again in the `router` package, so this PR is dependent on https://github.com/pillarjs/router/pull/151 being merged first. I'll mark this as a draft until that PR is merged.

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->