### PR TITLE
Fix broken links on the middleware page

### DIFF
--- a/en/resources/middleware.md
+++ b/en/resources/middleware.md
@@ -15,23 +15,23 @@ The Express middleware modules listed here are maintained by the
 
 | Middleware module                                                         | Description                                                                                         |
 | ------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
-| [body-parser](/{page.lang}/resources/middleware/body-parser.html)         | Parse HTTP request body.                                                                            |
-| [compression](/{page.lang}/resources/middleware/compression.html)         | Compress HTTP responses.                                                                            |
-| [connect-rid](/{page.lang}/resources/middleware/connect-rid.html)         | Generate unique request ID.                                                                         |
-| [cookie-parser](/{page.lang}/resources/middleware/cookie-parser.html)     | Parse cookie header and populate `req.cookies`. See also [cookies](https://github.com/jed/cookies). |
-| [cookie-session](/{page.lang}/resources/middleware/cookie-session.html)   | Establish cookie-based sessions.                                                                    |
-| [cors](/{page.lang}/resources/middleware/cors.html)                       | Enable cross-origin resource sharing (CORS) with various options.                                   |
-| [errorhandler](/{page.lang}/resources/middleware/errorhandler.html)       | Development error-handling/debugging.                                                               |
-| [method-override](/{page.lang}/resources/middleware/method-override.html) | Override HTTP methods using header.                                                                 |
-| [morgan](/{page.lang}/resources/middleware/morgan.html)                   | HTTP request logger.                                                                                |
-| [multer](/{page.lang}/resources/middleware/multer.html)                   | Handle multi-part form data.                                                                        |
-| [response-time](/{page.lang}/resources/middleware/response-time.html)     | Record HTTP response time.                                                                          |
-| [serve-favicon](/{page.lang}/resources/middleware/serve-favicon.html)     | Serve a favicon.                                                                                    |
-| [serve-index](/{page.lang}/resources/middleware/serve-index.html)         | Serve directory listing for a given path.                                                           |
-| [serve-static](/{page.lang}/resources/middleware/serve-static.html)       | Serve static files.                                                                                 |
-| [session](/{page.lang}/resources/middleware/session.html)                 | Establish server-based sessions (development only).                                                 |
-| [timeout](/{page.lang}/resources/middleware/timeout.html)                 | Set a timeout perioHTTP request processing.                                                         |
-| [vhost](/{page.lang}/resources/middleware/vhost.html)                     | Create virtual domains.                                                                             |
+| [body-parser](/{{page.lang}}/resources/middleware/body-parser.html)         | Parse HTTP request body.                                                                            |
+| [compression](/{{page.lang}}/resources/middleware/compression.html)         | Compress HTTP responses.                                                                            |
+| [connect-rid](/{{page.lang}}/resources/middleware/connect-rid.html)         | Generate unique request ID.                                                                         |
+| [cookie-parser](/{{page.lang}}/resources/middleware/cookie-parser.html)     | Parse cookie header and populate `req.cookies`. See also [cookies](https://github.com/jed/cookies). |
+| [cookie-session](/{{page.lang}}/resources/middleware/cookie-session.html)   | Establish cookie-based sessions.                                                                    |
+| [cors](/{{page.lang}}/resources/middleware/cors.html)                       | Enable cross-origin resource sharing (CORS) with various options.                                   |
+| [errorhandler](/{{page.lang}}/resources/middleware/errorhandler.html)       | Development error-handling/debugging.                                                               |
+| [method-override](/{{page.lang}}/resources/middleware/method-override.html) | Override HTTP methods using header.                                                                 |
+| [morgan](/{{page.lang}}/resources/middleware/morgan.html)                   | HTTP request logger.                                                                                |
+| [multer](/{{page.lang}}/resources/middleware/multer.html)                   | Handle multi-part form data.                                                                        |
+| [response-time](/{{page.lang}}/resources/middleware/response-time.html)     | Record HTTP response time.                                                                          |
+| [serve-favicon](/{{page.lang}}/resources/middleware/serve-favicon.html)     | Serve a favicon.                                                                                    |
+| [serve-index](/{{page.lang}}/resources/middleware/serve-index.html)         | Serve directory listing for a given path.                                                           |
+| [serve-static](/{{page.lang}}/resources/middleware/serve-static.html)       | Serve static files.                                                                                 |
+| [session](/{{page.lang}}/resources/middleware/session.html)                 | Establish server-based sessions (development only).                                                 |
+| [timeout](/{{page.lang}}/resources/middleware/timeout.html)                 | Set a timeout perioHTTP request processing.                                                         |
+| [vhost](/{{page.lang}}/resources/middleware/vhost.html)                     | Create virtual domains.                                                                             |
 
 ## Additional middleware modules
 


### PR DESCRIPTION
This fixes the broken links on the middleware page introduced in 6c3cfbb8d8766e030c56bad3c8f6f48845c054b5.

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->