### PR TITLE
docs: Correct Korean menu translation for guide entry

### DIFF
--- a/_data/ko/menu.yml
+++ b/_data/ko/menu.yml
@@ -12,7 +12,7 @@ examples: More examples
 faq: 자주 묻는 질문(FAQ)
 
 # Guide
-guide: Gu안내서ide
+guide: 안내서
 routing: 라우팅
 writing_middleware: 미들웨어 작성
 using_middleware: 미들웨어 사용


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

Corrected a typo in the Korean menu translation for the guide entry.

[as-is]
![image](https://github.com/user-attachments/assets/7a8cbc47-f185-4244-b07b-5328744e6f10)

[to-be]
![image](https://github.com/user-attachments/assets/e858ea8b-555f-4bd2-9519-d8493c3dea87)
