### PR TITLE
Adjust code background colour to improve clarity in dark mode

### DIFF
--- a/css/variables.css
+++ b/css/variables.css
@@ -45,7 +45,7 @@
   --notice-accent: #f9e8c3;
   --warn-bg: #4e2232;
   --warn-accent: #f9c3d6;
-  --code-bg: #181818;
+  --code-bg: #2b2b2b;
     /* support page related */
   --supported-fg:#299009;
   --eol-fg: #ff1a1a;


### PR DESCRIPTION
---
labels: require-triage
---

[Issue #1827](https://github.com/expressjs/expressjs.com/issues/1827): Code Box Colours on Dark Mode Need Better Highlighting 

- Previously the code blocks for text in dark mode were too close to the background colour, making them indistinguishable
- Improved visual clarity by slightly brightening the css variable colour value for code-bg in dark mode
- Code blocks are more visible now compared to the regular text. i.e. /app in comparison to the rest of the sentence

Screenshot for reference:

<img width="441" alt="Screenshot 2025-03-08 at 4 31 59 AM" src="https://github.com/user-attachments/assets/993eead3-95ab-48fa-a542-85668584f1d9" />

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->