### PR TITLE
fix: remove obsolete X-UA-Compatible meta tag from head.html

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,7 +1,6 @@
 <head>
     <title>{{ page.title }}</title>
     <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/favicon.png" />
     <script data-cfasync="false" src="/js/theme.js"></script>


### PR DESCRIPTION
Bye, internet explorer

We haven't supported Internet Explorer for quite some time now, and it's really not necessary to maintain that support. We need to move forward, and the people using Internet Explorer also need to move forward and stop using it