### PR TITLE
fix: changelog link in v5.1.0 blog post

### DIFF
--- a/_posts/2025-03-31-v5-1-latest-release.md
+++ b/_posts/2025-03-31-v5-1-latest-release.md
@@ -126,9 +126,7 @@ This release primarily focused on tech debt from supporting so many old Node.js 
 * Added support for ETag option in `res.sendFile()`
 * Added support for adding multiple links with the same rel with `res.links()`
 * Performance: Use loop for acceptParams
-
-[Changelog v5.1.0](https://github.com/expressjs/express/releases/tag/5.1.0)
-
+* See [Changelog v5.1.0](https://github.com/expressjs/express/releases/tag/v5.1.0)
 
 ### Dependencies updated
 


### PR DESCRIPTION
I just found this while reading the blog

cc @bjohansebas 