### PR TITLE
fix(blog): added some clarification around dates in blog post

### DIFF
--- a/_posts/2025-03-31-v5-1-latest-release.md
+++ b/_posts/2025-03-31-v5-1-latest-release.md
@@ -114,7 +114,7 @@ only major version for most of the history of Node.js itself. Because of this, w
 provide a bit longer support. We want to do what is best for the ecosystem, so consider these goals not commitments.
 
 *: v4 is a special case, and we may extend MAINTENENCE support
-**: v5 MAINTENENCE and EOL dates are determined by when v6 is released, these dates reflect the earliest datest if we
+**: v5 MAINTENENCE and EOL dates are determined by when v6 is released, these dates reflect the earliest dates if we
 were to ship v6 on 2025-10-01
 ***: v6 work has not been officially started yet, this is simply the earliest date we can ship based on our proposed policy
 

--- a/_posts/2025-03-31-v5-1-latest-release.md
+++ b/_posts/2025-03-31-v5-1-latest-release.md
@@ -104,7 +104,7 @@ For the existing release lines, we will set the following phase dates:
 | ----- | ------- | ------ | ----------- | --- |
 | 4.x   |         |        | 2025-04-01 | *no sooner than 2026-10-01 |
 | 5.x   | 2024-09-11 | 2025-03-31 | **no sooner than 2026-04-01 | **no sooner than 2027-04-01 |
-| 6.x   | ***no sooner than 2025-10-01 | | | |
+| 6.x   | ***no sooner than 2026-01-01 | | | |
 
 </div>
 

--- a/_posts/2025-03-31-v5-1-latest-release.md
+++ b/_posts/2025-03-31-v5-1-latest-release.md
@@ -102,15 +102,21 @@ For the existing release lines, we will set the following phase dates:
 
 | Major | CURRENT | ACTIVE | MAINTENANCE | EOL |
 | ----- | ------- | ------ | ----------- | --- |
-| 4.x   |         |        | 2025-04-01 | 2026-10-01 or later |
-| 5.x   | 2024-09-11 | 2025-03-31 | 2026-04-01 | 2027-04-01 |
-| 6.x   | TBD after 2025-10-01 | | | |
+| 4.x   |         |        | 2025-04-01 | *no sooner than 2026-10-01 |
+| 5.x   | 2024-09-11 | 2025-03-31 | **no sooner than 2026-04-01 | **no sooner than 2027-04-01 |
+| 6.x   | ***no sooner than 2025-10-01 | | | |
 
 </div>
+
 As you can see, this means that v5.1.0 being tagged `latest` indicates that we moved from `CURRENT` to `ACTIVE` which
 starts the clock on EOL for v4 by moving it to `MAINTENANCE`. We recognize that v4 is a special case having been the
 only major version for most of the history of Node.js itself. Because of this, we want to remain flexible and also
 provide a bit longer support. We want to do what is best for the ecosystem, so consider these goals not commitments.
+
+*: v4 is a special case, and we may extend MAINTENENCE support
+**: v5 MAINTENENCE and EOL dates are determined by when v6 is released, these dates reflect the earliest datest if we
+were to ship v6 on 2025-10-01
+***: v6 work has not been officially started yet, this is simply the earliest date we can ship based on our proposed policy
 
 ---
 

--- a/_posts/2025-03-31-v5-1-latest-release.md
+++ b/_posts/2025-03-31-v5-1-latest-release.md
@@ -116,7 +116,7 @@ provide a bit longer support. We want to do what is best for the ecosystem, so c
 *: v4 is a special case, and we may extend MAINTENENCE support
 **: v5 MAINTENENCE and EOL dates are determined by when v6 is released, these dates reflect the earliest dates if we
 were to ship v6 on 2025-10-01
-***: v6 work has not been officially started yet, this is simply the earliest date we can ship based on our proposed policy
+***: v6 work has not officially started yet, this is simply the earliest date we can ship based on our proposed policy
 
 ---
 


### PR DESCRIPTION
I didn't get to these after our meeting yesterday, but we agreed to soften the language around the dates here and then work to get consensus in the LTS ADR. We can circle back and update this as necessary, but this at least addresses the fact I incorrectly had concrete dates listed.

<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
