### PR TITLE
fix: dark/light mode theme regression

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1568,7 +1568,7 @@ strong.eol {
 }
 
 .hidden-dark {
-  display: flex;
+  display: block;
 }
 
 .hidden-light {

--- a/css/themes/dark-theme.css
+++ b/css/themes/dark-theme.css
@@ -9,7 +9,7 @@ html.dark-mode {
   }
 
   .hidden-light {
-    display: flex;
+    display: block;
   }
 
   .hidden-dark {


### PR DESCRIPTION
This fixes an issue where social icons were uncentered because of a regression in #1839. The implementation of #1839 was changed in #1887, so it's now safe to switch the `display` type back from `flex` to `block`.

### Before
<img width="373" alt="Screenshot 2025-04-05 at 12 11 59 AM" src="https://github.com/user-attachments/assets/4a375d7d-449d-435d-9fc7-d48d738f2d3d" />

<img width="358" alt="Screenshot 2025-04-05 at 12 22 16 AM" src="https://github.com/user-attachments/assets/b384109e-5781-49c8-b2a0-471ac93d0fb0" />
<img width="440" alt="Screenshot 2025-04-05 at 12 26 54 AM" src="https://github.com/user-attachments/assets/c3e2f640-f4a0-4596-a345-fd7a10d5472f" />

### After
<img width="372" alt="Screenshot 2025-04-05 at 12 12 09 AM" src="https://github.com/user-attachments/assets/affce166-7b2e-4a1b-8fe1-baf5c6e5a74d" />

<img width="364" alt="Screenshot 2025-04-05 at 12 23 13 AM" src="https://github.com/user-attachments/assets/b7b29c76-aee6-4db3-949a-b532ad076764" />
<img width="435" alt="Screenshot 2025-04-05 at 12 26 29 AM" src="https://github.com/user-attachments/assets/eda24a28-6824-457a-95eb-a5b2f2c37209" />