### PR TITLE
remove license link from footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -36,9 +36,6 @@
         <a id="security" href="https://github.com/expressjs/express/security/policy">
           {{ site.data[page.lang].footer.security_policy }}
         </a>
-        <a id="license" href="https://github.com/expressjs/express/blob/master/LICENSE">
-          {{ site.data[page.lang].footer.license }}
-        </a>
       </div>
     </div>
     <div id="footer-links">


### PR DESCRIPTION
the footer recommended by the foundation doesn't include a link to the license (https://github.com/openjs-foundation/artwork?tab=readme-ov-file#copyright-notices-for-project-website-footers)