### PR TITLE
feat: add feeds for the blog and vulnerabilities

### DIFF
--- a/_includes/feed-entry.xml
+++ b/_includes/feed-entry.xml
@@ -11,7 +11,7 @@
   <published>{{ entry.date | date_to_xmlschema }}</published>
   <updated>{{ entry.last_modified_at | default: post.date | date_to_xmlschema }}</updated>
   {%- for tag in post.tags %}
-  <category term="{{ tag | replace: ',', '' | xml_escape }}" />
+  <category term="{{ tag | xml_escape }}" />
   {%- endfor %}
   <content type="html"><![CDATA[ <a href="{{ site.url }}{{ entry.url }}">Read {{ entry.title }}</a> ]]></content>
 </entry>

--- a/_includes/feed-entry.xml
+++ b/_includes/feed-entry.xml
@@ -1,0 +1,17 @@
+{%- assign entry = include.entry -%}
+<entry>
+  <id>{{ site.url }}{{ entry.url }}</id>
+  <link href="{{ site.url }}{{ entry.url }}" rel="alternate" type="text/html" />
+  <title type="text">{{ entry.title }}</title>
+  {%- if entry.author %}
+  <author>
+    <name>{{ entry.author }}</name>
+  </author>
+  {%- endif %}
+  <published>{{ entry.date | date_to_xmlschema }}</published>
+  <updated>{{ entry.last_modified_at | default: post.date | date_to_xmlschema }}</updated>
+  {%- for tag in post.tags %}
+  <category term="{{ tag | replace: ',', '' | xml_escape }}" />
+  {%- endfor %}
+  <content type="html"><![CDATA[ <a href="{{ site.url }}{{ entry.url }}">Read {{ entry.title }}</a> ]]></content>
+</entry>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -47,4 +47,6 @@
     <script data-cfasync="false" defer src="/js/menu.js"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
 
+    <link rel="alternate" type="application/atom+xml" href="/feed.xml" title="Express Blog" />
+    <link rel="alternate" type="application/atom+xml" href="/vulnerabilities.xml" title="Express Vulnerabilities" />
 </head>

--- a/_layouts/feed.xml
+++ b/_layouts/feed.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom" xml:lang="en">
+  <title type="text">{{ page.title }}</title>
+  <link href="{{ site.url }}{{ page.html_url }}" rel="alternate" type="text/html" />
+  <link href="{{ site.url }}{{ page.url }}" rel="self" type="application/atom+xml" />
+  <id>{{ site.url }}{{ page.url }}</id>
+  <rights>Copyright The Express Contributors</rights>
+  <updated>{{ site.time | date_to_xmlschema }}</updated>
+  {{ content }}
+</feed>

--- a/_posts/2024-09-29-security-releases.md
+++ b/_posts/2024-09-29-security-releases.md
@@ -1,7 +1,7 @@
 ---
 title: September 2024 Security Releases
 description: Security releases for Express, body-parser, send, serve-static, and path-to-regexp have been published. We recommend that all users upgrade as soon as possible.
-tags: security, vulnerabilities
+tags: security vulnerabilities
 author: Ulises Gascón
 ---
 

--- a/_posts/2024-10-01-HeroDevs-partnership-announcement.md
+++ b/_posts/2024-10-01-HeroDevs-partnership-announcement.md
@@ -1,7 +1,7 @@
 ---
 title: Express Never Ending Support Launched by HeroDevs and Express.js
 description: The Express.js team is pleased to announce a partnership with HeroDevs to launch Express Never-Ending Support (NES), providing long-term support for applications built with legacy Express. This collaboration ensures that developers relying on older versions of the framework will continue to receive critical security and compatibility updates, allowing them to maintain and scale their applications securely, even after the framework's official end-of-life.
-tags: partnerships, announcements
+tags: partnerships announcements
 author: Express Technical Committee
 ---
 

--- a/_posts/2024-10-22-security-audit-milestone-achievement.md
+++ b/_posts/2024-10-22-security-audit-milestone-achievement.md
@@ -1,6 +1,6 @@
 ---
 title: "Express.js Security Audit: A Milestone Achievement"
-tags: security, audit, releases
+tags: security audit releases
 author: Express Technical Committee
 description: Celebrating the successful completion of the Express.js security audit conducted by Ada Logics and facilitated by OSTIF.
 ---

--- a/_posts/2025-01-09-rewind-2024-triumphs-and-2025-vision.md
+++ b/_posts/2025-01-09-rewind-2024-triumphs-and-2025-vision.md
@@ -1,6 +1,6 @@
 ---
 title: "A New Chapter for Express.js: Triumphs of 2024 and an ambitious 2025"
-tags: news, rewind, 2024
+tags: news rewind 2024
 author: Express Technical Committee
 description: Explore the transformative journey of Express.js in 2024, marked by governance improvements, the long-awaited release of Express 5.0, and heightened security measures. Look into the ambitious plans for 2025, including performance optimizations, scoped packages, and a bold roadmap for sustained growth in the Node.js ecosystem.
 ---

--- a/_posts/2025-03-31-v5-1-latest-release.md
+++ b/_posts/2025-03-31-v5-1-latest-release.md
@@ -1,6 +1,6 @@
 ---
 title: "Express@5.1.0: Now the Default on npm with LTS Timeline"
-tags: news, release 
+tags: news release
 author: Express Technical Committee
 description: Express 5.1.0 is now the default on npm, and we're introducing an official LTS schedule for the v4 and v5 release lines.
 ---

--- a/feed.xml
+++ b/feed.xml
@@ -1,0 +1,10 @@
+---
+layout: feed
+sitemap: false
+title: Express Blog
+html_url: /en/blog/posts.html
+---
+{% assign posts = site.posts | sort: "date" | reverse %}
+{% for post in posts %}
+{% include feed-entry.xml entry=post %}
+{% endfor %}

--- a/vulnerabilities.xml
+++ b/vulnerabilities.xml
@@ -1,0 +1,10 @@
+---
+layout: feed
+sitemap: false
+title: Express Vulnerabilities
+html_url: /en/blog/posts.html
+---
+{% assign posts = site.posts | sort: "date" | reverse %}
+{% for post in posts %}
+{% if post.tags contains "vulnerabilities" %}{% include feed-entry.xml entry=post %}{% endif %}
+{% endfor %}


### PR DESCRIPTION
This adds two new feeds to the site: `feed.xml` includes all blog posts, and `vulnerabilities.xml` includes all posts tagged with `vulnerabilities`.

You can validate the feeds via the [W3C Feed Validation Service](https://validator.w3.org/feed/). I also tried subscribing via Feedbin and all the posts appear as expected.

Resolves #1763

<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
