### PR TITLE
Fix formatting of *s in v5-1-latest-release

### DIFF
--- a/_posts/2025-03-31-v5-1-latest-release.md
+++ b/_posts/2025-03-31-v5-1-latest-release.md
@@ -113,10 +113,10 @@ starts the clock on EOL for v4 by moving it to `MAINTENANCE`. We recognize that 
 only major version for most of the history of Node.js itself. Because of this, we want to remain flexible and also
 provide a bit longer support. We want to do what is best for the ecosystem, so consider these goals not commitments.
 
-*: v4 is a special case, and we may extend MAINTENENCE support
-**: v5 MAINTENENCE and EOL dates are determined by when v6 is released, these dates reflect the earliest dates if we
-were to ship v6 on 2025-10-01
-***: v6 work has not officially started yet, this is simply the earliest date we can ship based on our proposed policy
+\*: v4 is a special case, and we may extend MAINTENENCE support  
+\*\*: v5 MAINTENENCE and EOL dates are determined by when v6 is released, these dates reflect the earliest dates if we
+were to ship v6 on 2025-10-01  
+\*\*\* : v6 work has not officially started yet, this is simply the earliest date we can ship based on our proposed policy
 
 ---
 


### PR DESCRIPTION
Problem: instead of showing asterisks on each line, the website has the text formatted bold and no line breaks.

Solution: add `  ` at the end of the line to break the lines.
Solution: escape the `*` as `\*` to avoid that they are interpreted as formatting commands.

Before
![image](https://github.com/user-attachments/assets/15385e49-7a72-4aa8-b785-4b9945cad6db)

After
![image](https://github.com/user-attachments/assets/2d22f197-bfd9-4484-9581-bb4934ab9a92)


<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
