### PR TITLE
Use 5.x path syntax in API examples

### DIFF
--- a/_includes/api/en/5x/app-all.md
+++ b/_includes/api/en/5x/app-all.md
@@ -25,14 +25,14 @@ can perform a task, then call `next()` to continue matching subsequent
 routes.
 
 ```js
-app.all('(.*)', requireAuthentication, loadUser)
+app.all('{*splat}', requireAuthentication, loadUser)
 ```
 
 Or the equivalent:
 
 ```js
-app.all('(.*)', requireAuthentication)
-app.all('(.*)', loadUser)
+app.all('{*splat}', requireAuthentication)
+app.all('{*splat}', loadUser)
 ```
 
 Another example is white-listed "global" functionality.
@@ -40,5 +40,5 @@ The example is similar to the ones above, but it only restricts paths that start
 "/api":
 
 ```js
-app.all('/api/(.*)', requireAuthentication)
+app.all('/api/{*splat}', requireAuthentication)
 ```

--- a/_includes/api/en/5x/app-mountpath.md
+++ b/_includes/api/en/5x/app-mountpath.md
@@ -30,16 +30,16 @@ patterns it is mounted on, as shown in the following example.
 const admin = express()
 
 admin.get('/', (req, res) => {
-  console.log(admin.mountpath) // [ '/adm*n', '/manager' ]
+  console.log(admin.mountpath) // [ '/adm{*splat}n', '/manager' ]
   res.send('Admin Homepage')
 })
 
 const secret = express()
 secret.get('/', (req, res) => {
-  console.log(secret.mountpath) // /secr*t
+  console.log(secret.mountpath) // /secr{*splat}t
   res.send('Admin Secret')
 })
 
-admin.use('/secr*t', secret) // load the 'secret' router on '/secr*t', on the 'admin' sub app
-app.use(['/adm*n', '/manager'], admin) // load the 'admin' router on '/adm*n' and '/manager', on the parent app
+admin.use('/secr{*splat}t', secret) // load the 'secret' router on '/secr{*splat}t', on the 'admin' sub app
+app.use(['/adm{*splat}n', '/manager'], admin) // load the 'admin' router on '/adm{*splat}n' and '/manager', on the parent app
 ```

--- a/_includes/api/en/5x/app-use.md
+++ b/_includes/api/en/5x/app-use.md
@@ -97,7 +97,7 @@ app.use('/abcd', (req, res, next) => {
 This will match paths starting with `/abcd` and `/abd`:
 
 ```js
-app.use('/ab(c?)d', (req, res, next) => {
+app.use('/ab{c}d', (req, res, next) => {
   next()
 })
 ```

--- a/_includes/api/en/5x/req-baseUrl.md
+++ b/_includes/api/en/5x/req-baseUrl.md
@@ -23,7 +23,7 @@ the `baseUrl` property returns the matched string, not the pattern(s). In the
 following example, the `greet` router is loaded on two path patterns.
 
 ```js
-app.use(['/gre+t', '/hel{2}o'], greet) // load the router on '/gre+t' and '/hel{2}o'
+app.use(['/gre:"param"t', '/hel{l}o'], greet) // load the router on '/gre:"param"t' and '/hel{l}o'
 ```
 
 When a request is made to `/greet/jp`, `req.baseUrl` is "/greet". When a request is

--- a/_includes/api/en/5x/req-params.md
+++ b/_includes/api/en/5x/req-params.md
@@ -8,12 +8,14 @@ console.dir(req.params.name)
 // => "tj"
 ```
 
-When you use a regular expression for the route definition, capture groups are provided in the array using `req.params[n]`, where `n` is the n<sup>th</sup> capture group. This rule is applied to unnamed wild card matches with string routes such as `/file/*`:
+When you use a regular expression for the route definition, capture groups are provided in the array using `req.params[n]`, where `n` is the n<sup>th</sup> capture group.
 
 ```js
-// GET /file/javascripts/jquery.js
-console.dir(req.params[0])
-// => "javascripts/jquery.js"
+app.use(/^\/file\/(.*)$/, (req, res) => {
+  // GET /file/javascripts/jquery.js
+  console.dir(req.params[0])
+  // => "javascripts/jquery.js"
+})
 ```
 
 If you need to make changes to a key in `req.params`, use the [app.param](/{{ page.lang }}/5x/api.html#app.param) handler. Changes are applicable only to [parameters](/{{ page.lang }}/guide/routing.html#route-parameters) already defined in the route path.

--- a/_includes/api/en/5x/req-route.md
+++ b/_includes/api/en/5x/req-route.md
@@ -3,7 +3,7 @@
 Contains the currently-matched route, a string. For example:
 
 ```js
-app.get('/user/{:id}', function userIdHandler (req, res) {
+app.get('/user/{:id}', (req, res) => {
   console.dir(req.route, { depth: null })
   res.send('GET')
 })
@@ -16,9 +16,9 @@ Route {
   path: '/user/{:id}',
   stack: [
     Layer {
-      handle: [Function: userIdHandler],
+      handle: [Function (anonymous)],
       keys: [],
-      name: 'userIdHandler',
+      name: '<anonymous>',
       params: undefined,
       path: undefined,
       slash: false,

--- a/_includes/api/en/5x/req-route.md
+++ b/_includes/api/en/5x/req-route.md
@@ -3,8 +3,8 @@
 Contains the currently-matched route, a string. For example:
 
 ```js
-app.get('/user/:id?', (req, res) => {
-  console.log(req.route)
+app.get('/user/{:id}', function userIdHandler (req, res) {
+  console.dir(req.route, { depth: null })
   res.send('GET')
 })
 ```
@@ -12,15 +12,20 @@ app.get('/user/:id?', (req, res) => {
 Example output from the previous snippet:
 
 ```
-{ path: '/user/:id?',
-  stack:
-   [ { handle: [Function: userIdHandler],
-       name: 'userIdHandler',
-       params: undefined,
-       path: undefined,
-       keys: [],
-       regexp: /^\/?$/i,
-       method: 'get' } ],
-  methods: { get: true }
+Route {
+  path: '/user/{:id}',
+  stack: [
+    Layer {
+      handle: [Function: userIdHandler],
+      keys: [],
+      name: 'userIdHandler',
+      params: undefined,
+      path: undefined,
+      slash: false,
+      matchers: [ [Function: match] ],
+      method: 'get'
+    }
+  ],
+  methods: [Object: null prototype] { get: true }
 }
 ```

--- a/_includes/api/en/5x/router-all.md
+++ b/_includes/api/en/5x/router-all.md
@@ -12,14 +12,14 @@ can perform a task, then call `next()` to continue matching subsequent
 routes.
 
 ```js
-router.all('(.*)', requireAuthentication, loadUser)
+router.all('{*splat}', requireAuthentication, loadUser)
 ```
 
 Or the equivalent:
 
 ```js
-router.all('(.*)', requireAuthentication)
-router.all('(.*)', loadUser)
+router.all('{*splat}', requireAuthentication)
+router.all('{*splat}', loadUser)
 ```
 
 Another example of this is white-listed "global" functionality. Here,
@@ -27,5 +27,5 @@ the example is much like before, but it only restricts paths prefixed with
 "/api":
 
 ```js
-router.all('/api/(.*)', requireAuthentication)
+router.all('/api/{*splat}', requireAuthentication)
 ```


### PR DESCRIPTION
@infuzz in https://github.com/expressjs/express/issues/6468#issuecomment-2816045469 pointed that the documentation for `app.all()` and `router.all()` uses old path syntax (from beta versions) that is no longer working.

After some searching I found 5 more examples that would not work in Express 5, because of old path syntax.

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
