### PR TITLE
feat: add copy button to install command on homepage

### DIFF
--- a/index.md
+++ b/index.md
@@ -13,7 +13,13 @@ redirect_from: "/en/index.html"
         <div class="express"><a href="/">Express</a><a href="{{ page.lang }}/changelog/4x.html#{{ site.data.express.current_version }}" id="express-version">{{ site.data.express.current_version }}</a></div>
         <h1 class="description">Fast, unopinionated, minimalist web framework for <a href='https://nodejs.org/en/'>Node.js</a></h1>
     </section>
-    <div id="install-command">$ npm install express --save</div>
+    <div id="install-container" style="display: flex; align-items: center; gap: 10px;">
+  <code id="install-command">npm install express --save</code>
+  <button onclick="copyInstallCommand()" style="padding: 5px 10px; background-color: #333; color: white; border: none; border-radius: 4px; cursor: pointer;">
+    📋 Copy
+  </button>
+</div>
+
   </div>
 
   <div id="homepage-rightpane" class="pane" markdown="1">
@@ -62,5 +68,13 @@ app.listen(port, () => {
       meant to be augmented through the use of Express <a href="{{ page.lang }}/resources/middleware.html">middleware</a> modules.
     </div>
   </div>
-
 </section>
+<script>
+  function copyInstallCommand() {
+    const text = document.getElementById("install-command").innerText;
+    navigator.clipboard.writeText(text)
+      .then(() => alert("✅ Copied to clipboard!"))
+      .catch(() => alert("❌ Failed to copy"));
+  }
+</script>
+

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "test": "eslint --ignore-path .gitignore --ignore-pattern _includes/readmes/ \"**/*.md\""
+    "test": "eslint --ignore-path .gitignore --ignore-pattern _includes/readmes/ \"**/*.md\"",
+    "start": "jekyll serve"
   },
   "devDependencies": {
     "eslint": "^8.54.0",


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

This pull request introduces a new feature to improve user experience by adding a "Copy" button next to the npm install express --save command on the homepage of the Express.js website.
Changes include:
1. Added a "Copy" Button:

A button labeled copy has been added next to the install command on the homepage (index.md), allowing users to easily copy the installation command to their clipboard with a single click.

2. JavaScript Functionality:

A simple JavaScript function (copyInstallCommand()) has been implemented to copy the installation command when the button is clicked. This improves accessibility by offering a quick way to copy the command without the need to manually select and copy text.

3. Improved User Experience:

This change helps developers by saving time when they are trying to quickly set up the Express framework in their projects. It provides a more intuitive and streamlined process for copying the install command.

Signed-off-by: prajun Budhathoki email: prajunbudhathoki10@gmail.com

