### PR TITLE
Eliminate layout shift in menu toggle arrow with CSS-only solution

### DIFF
--- a/_includes/api/en/3x/menu.md
+++ b/_includes/api/en/3x/menu.md
@@ -1,4 +1,4 @@
-<button id="menu-toggle" title="show table of content">On this page <span>&#x25BA;</span></button>
+<button id="menu-toggle" title="show table of content">On this page</button>
 <ul id="menu">
     <li><a href="#express">express()</a></li>
     <li id="app-api"> <a href="#application">Application</a>

--- a/_includes/api/en/4x/menu.md
+++ b/_includes/api/en/4x/menu.md
@@ -1,4 +1,4 @@
-<button id="menu-toggle" title="show table of content">On this page <span>&#x25BA;</span></button>
+<button id="menu-toggle" title="show table of content">On this page</button>
 <ul id="menu">
     <li id="express-api"><a href="#express">express()</a>
     <ul id="express-menu">

--- a/_includes/api/en/5x/menu.md
+++ b/_includes/api/en/5x/menu.md
@@ -1,4 +1,4 @@
-<button id="menu-toggle" title="show table of content">On this page <span>&#x25BA;</span></button>
+<button id="menu-toggle" title="show table of content">On this page</button>
 <ul id="menu">
     <li id="express-api"><a href="#express">express()</a>
     <ul id="express-menu">

--- a/_includes/blog/posts-menu.md
+++ b/_includes/blog/posts-menu.md
@@ -1,4 +1,4 @@
-<button id="menu-toggle" title="show blogs list">All Blogs <span>&#x25BA;</span></button>
+<button id="menu-toggle" title="show blogs list">All Blogs</button>
 <ul id="menu" class="blog-side-menu">
   <li>
     <ul id="side-menu" class="active">

--- a/css/style.css
+++ b/css/style.css
@@ -1130,6 +1130,19 @@ h2 a {
   color: #000;
   background-color: #fff;
 
+   &::after {
+    content: "";
+    display: block;
+    width: 0.8em;
+    height: 0.5em;
+    background-color: var(--card-bg);
+    clip-path: polygon(100% 0%, 0 0%, 50% 100%);
+    cursor: pointer;
+    pointer-events: none;
+    transition: transform 0.2s ease-in-out;
+    transform: rotate(-90deg);
+  }
+
   &:is(:hover, :active, :focus) {
     background-color: #ebf2f5;
   }
@@ -1331,8 +1344,14 @@ h2 a {
   }
 
   #menu-toggle.show {
-    display: block;
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
     opacity: 1;
+  }
+
+  #menu-toggle.show.rotate::after {
+    transform: rotate(0deg);
   }
 
   #menu > li > a,

--- a/js/menu.js
+++ b/js/menu.js
@@ -172,11 +172,10 @@ tocScreen.addEventListener("change", (event) => {
 
 // Toggle toc menu on button click
 toggleBtn?.addEventListener("click", (e) => {
+	toggleBtn.classList.toggle("rotate");
   if(tocList?.classList.contains("open")) {
-	toggleBtn.children[0].innerHTML = "&#x25BA;";
 	tocList.classList.remove("open");
   } else {
-	toggleBtn.children[0].innerHTML = "&#x25BC;";
 	tocList.classList.add("open");
   }
 });


### PR DESCRIPTION
### Problem 
Previously, the menu toggle arrow in the Table of Contents was implemented by updating the button’s inner HTML with different Unicode arrow entities (e.g., &#x25BA; for closed and &#x25BC; for open) via JavaScript. This approach caused a layout shift when toggling the menu, because the two Unicode arrow characters have different widths and font rendering. As a result, the button size and surrounding layout would visibly jump when the menu was opened or closed, negatively impacting user experience and visual stability.

### Solution
This PR refactors the arrow indicator to use a CSS-only solution. The arrow is now rendered using a CSS ::after pseudo-element on the toggle button, with its direction controlled by toggling a class and applying a transform: rotate() property. This ensures the arrow always occupies the same space, eliminating layout shifts and providing a smoother, more consistent UI. The button’s HTML remains static, and all visual changes are handled via CSS transitions.

### Mobile screens specific issue
|before|after|
|-------|------|
|![Edited_20250531_175842](https://github.com/user-attachments/assets/03c5cca1-8f35-4e22-b6c6-3d53ee9b7e96)|![Edited_20250531_183603](https://github.com/user-attachments/assets/9a094a75-4f8d-408f-960f-ef98873cc805)|

