### PR TITLE
fix: remove code block rendering in the note section Closes #1949

### DIFF
--- a/_includes/admonitions/note.html
+++ b/_includes/admonitions/note.html
@@ -1,5 +1,5 @@
-<div class="doc-box doc-info">
-  <p class="doc-title">
+<div class="doc-box doc-info" markdown="1">
+  <p class="doc-title" markdown="1">
     {% include icons/note.svg %} {{ site.data[page.lang].general.note }}
   </p>
   {{include.content}}

--- a/_includes/admonitions/note.html
+++ b/_includes/admonitions/note.html
@@ -1,3 +1,6 @@
-<div class="doc-box doc-info"><p class="doc-title">{% include icons/note.svg %} {{ site.data[page.lang].general.note }}</p>
-{{include.content}}
+<div class="doc-box doc-info">
+  <p class="doc-title">
+    {% include icons/note.svg %} {{ site.data[page.lang].general.note }}
+  </p>
+  {{include.content}}
 </div>

--- a/_includes/admonitions/note.html
+++ b/_includes/admonitions/note.html
@@ -1,3 +1,3 @@
-<div class="doc-box doc-info" markdown="1"><p class="doc-title" markdown="1">{% include icons/note.svg %} {{ site.data[page.lang].general.note }}</p>
+<div class="doc-box doc-info"><p class="doc-title">{% include icons/note.svg %} {{ site.data[page.lang].general.note }}</p>
 {{include.content}}
 </div>

--- a/de/4x/api.md
+++ b/de/4x/api.md
@@ -13,9 +13,7 @@ redirect_from: "  "
 
 {% capture node-version %}
 
-```
 Express 4.0 requires Node.js 0.10 or higher.
-```
 
 {% endcapture %}
 

--- a/de/5x/api.md
+++ b/de/5x/api.md
@@ -13,9 +13,7 @@ redirect_from: "  "
 
 {% capture node-version %}
 
-```
 Express 5.0 requires Node.js 18 or higher.
-```
 
 {% endcapture %}
 

--- a/en/4x/api.md
+++ b/en/4x/api.md
@@ -10,8 +10,14 @@ redirect_from: "/4x/api.html"
 
   <h1>4.x API</h1>
 
-  {% include admonitions/note.html content="Express 4.0 requires Node.js 0.10 or higher." %}
+  {% capture node-version %}
 
+  Express 4.0 requires Node.js 0.10 or higher.
+
+  {% endcapture %}
+  
+  {% include admonitions/note.html content=node-version %}
+  
   {% include api/en/4x/express.md %}
   {% include api/en/4x/app.md %}
   {% include api/en/4x/req.md %}

--- a/en/4x/api.md
+++ b/en/4x/api.md
@@ -10,13 +10,7 @@ redirect_from: "/4x/api.html"
 
   <h1>4.x API</h1>
 
-  {% capture node-version %}
-
-    Express 4.0 requires Node.js 0.10 or higher.
-
-  {% endcapture %}
-
-  {% include admonitions/note.html content=node-version %}
+  {% include admonitions/note.html content="Express 4.0 requires Node.js 0.10 or higher." %}
 
   {% include api/en/4x/express.md %}
   {% include api/en/4x/app.md %}

--- a/en/5x/api.md
+++ b/en/5x/api.md
@@ -10,7 +10,13 @@ redirect_from: "/5x/api.html"
 
   <h1>5.x API</h1>
 
-  {% include admonitions/note.html content= "Express 5.0 requires Node.js 18 or higher." %}
+  {% capture node-version %}
+
+  Express 5.0 requires Node.js 18 or higher.
+
+  {% endcapture %}
+
+  {% include admonitions/note.html content=node-version %}
 
   {% include api/en/5x/express.md %}
   {% include api/en/5x/app.md %}

--- a/en/5x/api.md
+++ b/en/5x/api.md
@@ -10,13 +10,7 @@ redirect_from: "/5x/api.html"
 
   <h1>5.x API</h1>
 
-  {% capture node-version %}
-
-    Express 5.0 requires Node.js 18 or higher.
-
-  {% endcapture %}
-
-  {% include admonitions/note.html content=node-version %}
+  {% include admonitions/note.html content= "Express 5.0 requires Node.js 18 or higher." %}
 
   {% include api/en/5x/express.md %}
   {% include api/en/5x/app.md %}

--- a/es/4x/api.md
+++ b/es/4x/api.md
@@ -13,9 +13,7 @@ redirect_from: "  "
 
 {% capture node-version %}
 
-```
 Express 4.0 requires Node.js 0.10 or higher.
-```
 
 {% endcapture %}
 

--- a/es/5x/api.md
+++ b/es/5x/api.md
@@ -13,9 +13,7 @@ redirect_from: "  "
 
 {% capture node-version %}
 
-```
 Express 5.0 requires Node.js 18 or higher.
-```
 
 {% endcapture %}
 

--- a/fr/4x/api.md
+++ b/fr/4x/api.md
@@ -13,9 +13,7 @@ redirect_from: "  "
 
 {% capture node-version %}
 
-```
 Express 4.0 requires Node.js 0.10 or higher.
-```
 
 {% endcapture %}
 

--- a/fr/5x/api.md
+++ b/fr/5x/api.md
@@ -13,9 +13,7 @@ redirect_from: "  "
 
 {% capture node-version %}
 
-```
 Express 5.0 requires Node.js 18 or higher.
-```
 
 {% endcapture %}
 

--- a/it/4x/api.md
+++ b/it/4x/api.md
@@ -13,9 +13,7 @@ redirect_from: "  "
 
 {% capture node-version %}
 
-```
 Express 4.0 requires Node.js 0.10 or higher.
-```
 
 {% endcapture %}
 

--- a/it/5x/api.md
+++ b/it/5x/api.md
@@ -13,9 +13,7 @@ redirect_from: "  "
 
 {% capture node-version %}
 
-```
 Express 5.0 requires Node.js 18 or higher.
-```
 
 {% endcapture %}
 

--- a/ja/4x/api.md
+++ b/ja/4x/api.md
@@ -13,9 +13,7 @@ redirect_from: "  "
 
 {% capture node-version %}
 
-```
 Express 4.0 requires Node.js 0.10 or higher.
-```
 
 {% endcapture %}
 

--- a/ja/5x/api.md
+++ b/ja/5x/api.md
@@ -13,9 +13,7 @@ redirect_from: "  "
 
 {% capture node-version %}
 
-```
 Express 5.0 requires Node.js 18 or higher.
-```
 
 {% endcapture %}
 

--- a/ko/4x/api.md
+++ b/ko/4x/api.md
@@ -13,9 +13,7 @@ redirect_from: "  "
 
 {% capture node-version %}
 
-```
 Express 4.0 requires Node.js 0.10 or higher.
-```
 
 {% endcapture %}
 

--- a/ko/5x/api.md
+++ b/ko/5x/api.md
@@ -13,9 +13,7 @@ redirect_from: "  "
 
 {% capture node-version %}
 
-```
 Express 5.0 requires Node.js 18 or higher.
-```
 
 {% endcapture %}
 

--- a/pt-br/4x/api.md
+++ b/pt-br/4x/api.md
@@ -13,9 +13,7 @@ redirect_from: "  "
 
 {% capture node-version %}
 
-```
 Express 4.0 requires Node.js 0.10 or higher.
-```
 
 {% endcapture %}
 

--- a/pt-br/5x/api.md
+++ b/pt-br/5x/api.md
@@ -13,9 +13,7 @@ redirect_from: "  "
 
 {% capture node-version %}
 
-```
 Express 5.0 requires Node.js 18 or higher.
-```
 
 {% endcapture %}
 

--- a/zh-cn/4x/api.md
+++ b/zh-cn/4x/api.md
@@ -13,9 +13,7 @@ redirect_from: "  "
 
 {% capture node-version %}
 
-```
 Express 4.0 requires Node.js 0.10 or higher.
-```
 
 {% endcapture %}
 

--- a/zh-cn/5x/api.md
+++ b/zh-cn/5x/api.md
@@ -13,9 +13,7 @@ redirect_from: "  "
 
 {% capture node-version %}
 
-```
 Express 5.0 requires Node.js 18 or higher.
-```
 
 {% endcapture %}
 

--- a/zh-tw/4x/api.md
+++ b/zh-tw/4x/api.md
@@ -13,9 +13,7 @@ redirect_from: "  "
 
 {% capture node-version %}
 
-```
 Express 4.0 requires Node.js 0.10 or higher.
-```
 
 {% endcapture %}
 

--- a/zh-tw/5x/api.md
+++ b/zh-tw/5x/api.md
@@ -13,9 +13,7 @@ redirect_from: "  "
 
 {% capture node-version %}
 
-```
 Express 5.0 requires Node.js 18 or higher.
-```
 
 {% endcapture %}
 


### PR DESCRIPTION
Hii, This PR removes unnecessary code block rendering from the Express 5.0 Node.js requirement note in the 5.x api docs.
I removed backticks (```) from note sections. 

Fixes #1949 

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
