### PR TITLE
docs(translate): add Chinese localization for Express homepage

### DIFF
--- a/zh-cn/index.md
+++ b/zh-cn/index.md
@@ -11,7 +11,7 @@ redirect_from: "  "
   <div id="homepage-leftpane" class="pane">
     <section id="description">
         <div class="express"><a href="/">Express</a><a href="{{ page.lang }}/changelog/4x.html#{{ site.data.express.current_version }}" id="express-version">{{ site.data.express.current_version }}</a></div>
-        <h1 class="description">Fast, unopinionated, minimalist web framework for <a href='https://nodejs.org/en/'>Node.js</a></h1>
+        <h1 class="description">快速、灵活、极简的 <a href='https://nodejs.org/en/'>Node.js</a> Web 框架</h1>
     </section>
     <pre class="install-command"><code>$ npm install express --save</code></pre>
   </div>
@@ -45,18 +45,22 @@ app.listen(port, () => {
 <section id="intro">
   <div id="boxes" class="clearfix">
     <div id="web-applications">
-      <h2>Web Applications</h2> Express is a minimal and flexible Node.js web application framework that provides a robust set of features for web and mobile applications.
+      <h2>Web 应用开发</h2> 
+      Express 是一个简洁灵活的 Node.js Web 应用框架，为网页和移动应用提供了一套强大的功能特性。
     </div>
     <div id="apis">
-      <h2>APIs</h2> With a myriad of HTTP utility methods and middleware at your disposal, creating a robust API is quick and easy.
+      <h2>API 开发</h2> 
+      借助丰富的 HTTP 工具方法和中间件支持，快速构建健壮的 API 接口易如反掌。
     </div>
     <div id="performance">
-      <h2>Performance</h2> Express provides a thin layer of fundamental web application features, without obscuring Node.js features that you know and love.
+      <h2>性能表现</h2> 
+      Express 提供基础的 Web 应用功能薄层封装，绝不遮蔽您熟悉且喜爱的原生 Node.js 特性。
     </div>
     <div id="middleware">
       <h2>中间件</h2> 
-      Express is a lightweight and flexible routing framework with minimal core features 
-      meant to be augmented through the use of Express <a href="{{ page.lang }}/resources/middleware.html">middleware</a> modules.
+      Express 作为轻量级路由框架，其核心功能精简至极，可通过丰富的 Express 
+      <a href="{{ page.lang }}/resources/middleware.html">中间件</a> 
+      模块进行功能扩展。
     </div>
   </div>
 </section>


### PR DESCRIPTION
Currently, the Chinese version of the Express homepage (https://expressjs.com/zh-cn/) contains only a partial translation—specifically, the term "middleware" is translated as "中间件", while the rest of the content remains in English.

To improve the overall professionalism of the documentation and make Express more accessible and appealing to Chinese-speaking developers, this PR introduces a complete localization of the homepage content.

![image](https://github.com/user-attachments/assets/fbc77cdd-2a7e-4358-af3b-827f7dd80f5e)

This includes:

- Framework introduction and tagline

- Core feature sections (Web Applications, APIs, Performance, Middleware)
