### PR TITLE
fix: add horizontal scroller on middleware table to prevent overflow on the small screen

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1438,10 +1438,6 @@ h2 a {
 
 .callout {position: relative;}
 
-.mw-fig-scroll {
-  -webkit-overflow-scrolling: touch;
-  max-width: 100%;
-}
 #mw-fig { 
   border-collapse: separate; 
   padding: 0; 
@@ -1467,12 +1463,6 @@ h2 a {
   padding: 0 0 0 5px;
   border: 0;
   width: 550px;
-}
-
-@media all and (max-width: 800px) {
-  .mw-fig-scroll {
-    overflow-x: auto;
-  }
 }
 
 /* Blog page styles*/

--- a/css/style.css
+++ b/css/style.css
@@ -1210,6 +1210,7 @@ h2 a {
   .table-scroller {
     width: 100%;
     overflow: scroll;
+    scrollbar-width: thin;
   }
 
   code {

--- a/css/style.css
+++ b/css/style.css
@@ -1438,12 +1438,17 @@ h2 a {
 
 .callout {position: relative;}
 
+.mw-fig-scroll {
+  -webkit-overflow-scrolling: touch;
+  max-width: 100%;
+}
 #mw-fig { 
   border-collapse: separate; 
   padding: 0; 
   border: 0; 
   width: 960px; 
-  margin-bottom: 20px;}
+  margin-bottom: 20px;
+}
 #mw-fig-imgcell {
   margin: 0;
   padding: 0px;
@@ -1462,6 +1467,12 @@ h2 a {
   padding: 0 0 0 5px;
   border: 0;
   width: 550px;
+}
+
+@media all and (max-width: 800px) {
+  .mw-fig-scroll {
+    overflow-x: auto;
+  }
 }
 
 /* Blog page styles*/

--- a/en/guide/writing-middleware.md
+++ b/en/guide/writing-middleware.md
@@ -24,6 +24,7 @@ If the current middleware function does not end the request-response cycle, it m
 
 The following figure shows the elements of a middleware function call:
 
+<div class="mw-fig-scroll">
 <table id="mw-fig">
 <tr><td id="mw-fig-imgcell">
 <img src="/images/express-mw.png" alt="Elements of a middleware function call" id="mw-fig-img" />
@@ -42,6 +43,7 @@ The following figure shows the elements of a middleware function call:
 <div class="callout" id="callout6">HTTP <a href="/{{ page.lang }}/4x/api.html#req">request</a> argument to the middleware function, called "req" by convention.</div>
 </td></tr>
 </table>
+</div>
 
 Starting with Express 5, middleware functions that return a Promise will call `next(value)` when they reject or throw an error. `next` will be called with either the rejected value or the thrown Error.
 

--- a/en/guide/writing-middleware.md
+++ b/en/guide/writing-middleware.md
@@ -24,7 +24,7 @@ If the current middleware function does not end the request-response cycle, it m
 
 The following figure shows the elements of a middleware function call:
 
-<div class="mw-fig-scroll">
+<div class="table-scroller">
 <table id="mw-fig">
 <tr><td id="mw-fig-imgcell">
 <img src="/images/express-mw.png" alt="Elements of a middleware function call" id="mw-fig-img" />


### PR DESCRIPTION

<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

## Description
This PR resolve issue: #1967 there middleware guide contains a `table` with an `image and callouts` that exceeds the viewport width on mobile devices, causing horizontal overflow and breaking layout.

## Solve 
- Wrapped the diagram table in a horizontally scrollable div (.mw-fig-scroll) with overflow-x: auto  based on media-query

https://github.com/user-attachments/assets/bbc407d0-1ea5-4aeb-af0e-37af2c191df2



This preserves the readability of the middleware diagram without distorting the layout on mobile.

Closes #1967 

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
