### PR TITLE
feat(index page): add express title and show LTS versions on the small screens

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1251,10 +1251,6 @@ h2 a {
     margin-bottom: 35px;
   }
 
-  #description .express {
-    display: none;
-  }
-
   #description .description {
     font-size: 3em;
     line-height: .9em;
@@ -1415,10 +1411,6 @@ h2 a {
 @media all and (max-width: 420px) {
   #app-settings-property {
     width: auto;
-  }
-
-  #description .express {
-    display: none;
   }
 }
 


### PR DESCRIPTION
Hello. This PR adds the title "Express" on the index.md (for al languages) file for  screen size with a viewport less than 1110px, by removing 2 css rules.

### Before:

https://github.com/user-attachments/assets/888e8a7e-b336-4cc3-9da0-621a3ad1f0b3


### After:

https://github.com/user-attachments/assets/e71a7b91-ce51-470c-8e7b-8449f4598fe5


