### PR TITLE
Fix unclickable submenus on touchscreen tablet

### DIFF
--- a/js/menu.js
+++ b/js/menu.js
@@ -20,7 +20,10 @@ let activeDrawer // active dropdown nav link
 
 
 for (const el of itemsMenu) {
-	el.addEventListener("click", () => {
+	el.addEventListener("click", (e) => {
+		if (e.target.parentNode === el && e.pointerType === "touch" && el.querySelector("a.active")) {
+			e.preventDefault(); // Tapping active menu on touchscreen tablet should open menu, not click
+		}
 		if (isSmallScreen || 'ontouchstart' in document.documentElement) {
 		// HANDLE ACTIVE LINKS IN DROPDOWN NAV	
 		// if no activeDrawer set then page was set in md logic


### PR DESCRIPTION
Fixes: #1170

It works by cancelling the onclick URL change for the current (bold) parent menu item. This matches the mobile experience. Touchscreens can now tap a menu to go there (preserving current UX), tap again to open the submenu, then tap the submenu item. Previous behavior with mice is unchanged.

# Before

![before](https://github.com/user-attachments/assets/3a6b76c6-674c-4aa6-8371-dc36fe9a444e)

# After

![after](https://github.com/user-attachments/assets/2597c1a7-9179-4155-9ead-7d1e243e05e3)

<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
