### PR TITLE
Fix API reference nav missing bold

### DIFF
--- a/de/3x/api.md
+++ b/de/3x/api.md
@@ -3,6 +3,7 @@ layout: api
 version: 3x
 title: Express 3.x - API-Referenz
 description: Access the API reference for Express.js version 3.x, noting that this version is end-of-life and no longer maintained - includes details on modules and methods.
+menu: api
 redirect_from: "  "
 ---
 

--- a/de/4x/api.md
+++ b/de/4x/api.md
@@ -3,6 +3,7 @@ layout: api
 version: 4x
 title: Express 4.x - API-Referenz
 description: Access the API reference for Express.js 4.x, detailing all modules, methods, and properties for building web applications with this version.
+menu: api
 redirect_from: "  "
 ---
 

--- a/de/5x/api.md
+++ b/de/5x/api.md
@@ -3,6 +3,7 @@ layout: api
 version: 5x
 title: Express 5.x - API-Referenz
 description: Access the API reference for Express.js 5.x, detailing all modules, methods, and properties for building web applications with this latest version.
+menu: api
 redirect_from: "  "
 ---
 

--- a/de/api.md
+++ b/de/api.md
@@ -3,6 +3,7 @@ layout: api
 version: 5x
 title: Express 5.x - API-Referenz
 description: Access the API reference for Express.js detailing all modules, methods, and properties for building web applications with this version.
+menu: api
 redirect_from: "  "
 ---
 

--- a/en/3x/api.md
+++ b/en/3x/api.md
@@ -3,6 +3,7 @@ layout: api
 version: 3x
 title: Express 3.x - API Reference
 description: Access the API reference for Express.js version 3.x, noting that this version is end-of-life and no longer maintained - includes details on modules and methods.
+menu: api
 redirect_from: "/3x/api.html"
 ---
 <div id="api-doc" markdown="1">

--- a/en/4x/api.md
+++ b/en/4x/api.md
@@ -3,6 +3,7 @@ layout: api
 version: 4x
 title: Express 4.x - API Reference
 description: Access the API reference for Express.js 4.x, detailing all modules, methods, and properties for building web applications with this version.
+menu: api
 redirect_from: "/4x/api.html"
 ---
 <div id="api-doc" markdown="1">

--- a/en/5x/api.md
+++ b/en/5x/api.md
@@ -3,6 +3,7 @@ layout: api
 version: 5x
 title: Express 5.x - API Reference
 description: Access the API reference for Express.js 5.x, detailing all modules, methods, and properties for building web applications with this latest version.
+menu: api
 redirect_from: "/5x/api.html"
 ---
 <div id="api-doc" markdown="1">

--- a/en/api.md
+++ b/en/api.md
@@ -3,6 +3,7 @@ layout: api
 version: 5x
 title: Express 5.x - API Reference
 description: Access the API reference for Express.js detailing all modules, methods, and properties for building web applications with this version.
+menu: api
 redirect_from: "/api.html"
 ---
 <div id="api-doc" markdown="1">

--- a/es/3x/api.md
+++ b/es/3x/api.md
@@ -3,6 +3,7 @@ layout: api
 version: 3x
 title: Express 3.x - Referencia de API
 description: Access the API reference for Express.js version 3.x, noting that this version is end-of-life and no longer maintained - includes details on modules and methods.
+menu: api
 redirect_from: "  "
 ---
 

--- a/es/4x/api.md
+++ b/es/4x/api.md
@@ -3,6 +3,7 @@ layout: api
 version: 4x
 title: Express 4.x - Referencia de API
 description: Access the API reference for Express.js 4.x, detailing all modules, methods, and properties for building web applications with this version.
+menu: api
 redirect_from: "  "
 ---
 

--- a/es/5x/api.md
+++ b/es/5x/api.md
@@ -3,6 +3,7 @@ layout: api
 version: 5x
 title: Express 5.x - Referencia de API
 description: Access the API reference for Express.js 5.x, detailing all modules, methods, and properties for building web applications with this latest version.
+menu: api
 redirect_from: "  "
 ---
 

--- a/es/api.md
+++ b/es/api.md
@@ -3,6 +3,7 @@ layout: api
 version: 5x
 title: Express 5.x - Referencia de API
 description: Acceda a la referencia de la API para Express.js detallando todos los módulos, métodos y propiedades para construir aplicaciones web con esta versión.
+menu: api
 redirect_from: "  "
 ---
 

--- a/fr/3x/api.md
+++ b/fr/3x/api.md
@@ -3,6 +3,7 @@ layout: api
 version: 3x
 title: Express 3.x - Référence de l'API
 description: Access the API reference for Express.js version 3.x, noting that this version is end-of-life and no longer maintained - includes details on modules and methods.
+menu: api
 redirect_from: "  "
 ---
 

--- a/fr/4x/api.md
+++ b/fr/4x/api.md
@@ -3,6 +3,7 @@ layout: api
 version: 4x
 title: Express 4.x - Référence de l'API
 description: Access the API reference for Express.js 4.x, detailing all modules, methods, and properties for building web applications with this version.
+menu: api
 redirect_from: "  "
 ---
 

--- a/fr/5x/api.md
+++ b/fr/5x/api.md
@@ -3,6 +3,7 @@ layout: api
 version: 5x
 title: Express 5.x - Référence de l'API
 description: Access the API reference for Express.js 5.x, detailing all modules, methods, and properties for building web applications with this latest version.
+menu: api
 redirect_from: "  "
 ---
 

--- a/fr/api.md
+++ b/fr/api.md
@@ -3,6 +3,7 @@ layout: api
 version: 5x
 title: Express 5.x - Référence de l'API
 description: Access the API reference for Express.js detailing all modules, methods, and properties for building web applications with this version.
+menu: api
 redirect_from: "  "
 ---
 

--- a/it/3x/api.md
+++ b/it/3x/api.md
@@ -3,6 +3,7 @@ layout: api
 version: 3x
 title: Express 3.x - Riferimento API
 description: Access the API reference for Express.js version 3.x, noting that this version is end-of-life and no longer maintained - includes details on modules and methods.
+menu: api
 redirect_from: "  "
 ---
 

--- a/it/4x/api.md
+++ b/it/4x/api.md
@@ -3,6 +3,7 @@ layout: api
 version: 4x
 title: Express 4.x - Riferimento API
 description: Access the API reference for Express.js 4.x, detailing all modules, methods, and properties for building web applications with this version.
+menu: api
 redirect_from: "  "
 ---
 

--- a/it/5x/api.md
+++ b/it/5x/api.md
@@ -3,6 +3,7 @@ layout: api
 version: 5x
 title: Express 5.x - Riferimento API
 description: Access the API reference for Express.js 5.x, detailing all modules, methods, and properties for building web applications with this latest version.
+menu: api
 redirect_from: "  "
 ---
 

--- a/it/api.md
+++ b/it/api.md
@@ -3,6 +3,7 @@ layout: api
 version: 5x
 title: Express 5.x - Riferimento API
 description: Access the API reference for Express.js detailing all modules, methods, and properties for building web applications with this version.
+menu: api
 redirect_from: "  "
 ---
 

--- a/ja/3x/api.md
+++ b/ja/3x/api.md
@@ -3,6 +3,7 @@ layout: api
 version: 3x
 title: Express 3.x - API リファレンス
 description: Access the API reference for Express.js version 3.x, noting that this version is end-of-life and no longer maintained - includes details on modules and methods.
+menu: api
 redirect_from: "  "
 ---
 

--- a/ja/4x/api.md
+++ b/ja/4x/api.md
@@ -3,6 +3,7 @@ layout: api
 version: 4x
 title: Express 4.x - API リファレンス
 description: Access the API reference for Express.js 4.x, detailing all modules, methods, and properties for building web applications with this version.
+menu: api
 redirect_from: "  "
 ---
 

--- a/ja/5x/api.md
+++ b/ja/5x/api.md
@@ -3,6 +3,7 @@ layout: api
 version: 5x
 title: Express 5.x - API リファレンス
 description: Access the API reference for Express.js 5.x, detailing all modules, methods, and properties for building web applications with this latest version.
+menu: api
 redirect_from: "  "
 ---
 

--- a/ja/api.md
+++ b/ja/api.md
@@ -3,6 +3,7 @@ layout: api
 version: 5x
 title: Express 5.x - API リファレンス
 description: Access the API reference for Express.js detailing all modules, methods, and properties for building web applications with this version.
+menu: api
 redirect_from: "  "
 ---
 

--- a/ko/3x/api.md
+++ b/ko/3x/api.md
@@ -3,6 +3,7 @@ layout: api
 version: 3x
 title: Express 3.x - API 참조
 description: Express.js 3.x 버전의 API 참조에 접근할 수 있습니다. 이 버전은 지원이 종료되었으며 더 이상 유지보수되지 않습니다. 모듈과 메소드에 대한 상세한 정보가 포함되어 있습니다.
+menu: api
 redirect_from: "  "
 ---
 

--- a/ko/4x/api.md
+++ b/ko/4x/api.md
@@ -3,6 +3,7 @@ layout: api
 version: 4x
 title: Express 4.x - API 참조
 description: Express.js 4.x의 API 레퍼런스를 확인하여, 이 버전으로 웹 애플리케이션을 구축할 때 사용할 수 있는 모든 모듈, 메서드, 속성에 대해 자세히 알아봅니다.
+menu: api
 redirect_from: "  "
 ---
 

--- a/ko/5x/api.md
+++ b/ko/5x/api.md
@@ -3,6 +3,7 @@ layout: api
 version: 5x
 title: Express 5.x - API 참조
 description: Express.js 5.x의 API 레퍼런스를 확인하여, 이 버전으로 웹 애플리케이션을 구축할 때 사용할 수 있는 모든 모듈, 메서드, 속성에 대해 자세히 알아봅니다.
+menu: api
 redirect_from: "  "
 ---
 

--- a/ko/api.md
+++ b/ko/api.md
@@ -3,6 +3,7 @@ layout: api
 version: 5x
 title: Express 5.x - API 참조
 description: Access the API reference for Express.js detailing all modules, methods, and properties for building web applications with this version.
+menu: api
 redirect_from: "  "
 ---
 

--- a/pt-br/3x/api.md
+++ b/pt-br/3x/api.md
@@ -3,6 +3,7 @@ layout: api
 version: 3x
 title: Express 3.x - API Reference
 description: Access the API reference for Express.js version 3.x, noting that this version is end-of-life and no longer maintained - includes details on modules and methods.
+menu: api
 redirect_from: "  "
 ---
 

--- a/pt-br/4x/api.md
+++ b/pt-br/4x/api.md
@@ -3,6 +3,7 @@ layout: api
 version: 4x
 title: Express 4.x - Referência de API
 description: Access the API reference for Express.js 4.x, detailing all modules, methods, and properties for building web applications with this version.
+menu: api
 redirect_from: "  "
 ---
 

--- a/pt-br/5x/api.md
+++ b/pt-br/5x/api.md
@@ -3,6 +3,7 @@ layout: api
 version: 5x
 title: Express 5.x - Referência da API
 description: Access the API reference for Express.js 5.x, detailing all modules, methods, and properties for building web applications with this latest version.
+menu: api
 redirect_from: "  "
 ---
 

--- a/pt-br/api.md
+++ b/pt-br/api.md
@@ -3,6 +3,7 @@ layout: api
 version: 5x
 title: Express 5.x - Referência da API
 description: Access the API reference for Express.js detailing all modules, methods, and properties for building web applications with this version.
+menu: api
 redirect_from: "  "
 ---
 

--- a/zh-cn/3x/api.md
+++ b/zh-cn/3x/api.md
@@ -3,6 +3,7 @@ layout: api
 version: 3x
 title: Express 3.x - API 参考
 description: Access the API reference for Express.js version 3.x, noting that this version is end-of-life and no longer maintained - includes details on modules and methods.
+menu: api
 redirect_from: "  "
 ---
 

--- a/zh-cn/4x/api.md
+++ b/zh-cn/4x/api.md
@@ -3,6 +3,7 @@ layout: api
 version: 4x
 title: Express 4.x - API 参考
 description: Access the API reference for Express.js 4.x, detailing all modules, methods, and properties for building web applications with this version.
+menu: api
 redirect_from: "  "
 ---
 

--- a/zh-cn/5x/api.md
+++ b/zh-cn/5x/api.md
@@ -3,6 +3,7 @@ layout: api
 version: 5x
 title: Express 5.x - API 参考
 description: Access the API reference for Express.js 5.x, detailing all modules, methods, and properties for building web applications with this latest version.
+menu: api
 redirect_from: "  "
 ---
 

--- a/zh-cn/api.md
+++ b/zh-cn/api.md
@@ -3,6 +3,7 @@ layout: api
 version: 5x
 title: Express 5.x - API 参考
 description: 访问 Express.js API 参考文档，获取当前版本所有模块、方法及属性的详细说明，助您构建 Web 应用。
+menu: api
 redirect_from: "  "
 ---
 

--- a/zh-tw/3x/api.md
+++ b/zh-tw/3x/api.md
@@ -3,6 +3,7 @@ layout: api
 version: 3x
 title: Express 3.x - API 參照
 description: Access the API reference for Express.js version 3.x, noting that this version is end-of-life and no longer maintained - includes details on modules and methods.
+menu: api
 redirect_from: "  "
 ---
 

--- a/zh-tw/4x/api.md
+++ b/zh-tw/4x/api.md
@@ -3,6 +3,7 @@ layout: api
 version: 4x
 title: Express 4.x - API 參照
 description: Access the API reference for Express.js 4.x, detailing all modules, methods, and properties for building web applications with this version.
+menu: api
 redirect_from: "  "
 ---
 

--- a/zh-tw/5x/api.md
+++ b/zh-tw/5x/api.md
@@ -3,6 +3,7 @@ layout: api
 version: 5x
 title: Express 5.x - API 參照
 description: Access the API reference for Express.js 5.x, detailing all modules, methods, and properties for building web applications with this latest version.
+menu: api
 redirect_from: "  "
 ---
 

--- a/zh-tw/api.md
+++ b/zh-tw/api.md
@@ -3,6 +3,7 @@ layout: api
 version: 5x
 title: Express 5.x - API 參照
 description: Access the API reference for Express.js detailing all modules, methods, and properties for building web applications with this version.
+menu: api
 redirect_from: "  "
 ---
 


### PR DESCRIPTION
This fixes the "API reference" nav missing bold. Split from #1983.

# Before

<img width="2012" height="683" alt="API Reference menu item missing bold" src="https://github.com/user-attachments/assets/fbc8f7b0-be1b-4bfd-98ca-6ab6ab4a6d61" />

# After

<img width="2000" height="701" alt="API Reference menu item properly bolded" src="https://github.com/user-attachments/assets/06e84f81-630b-4e53-a85b-681e036f2154" />

<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
