### PR TITLE
docs(migrating-5): add section about express.static dotfiles defaulting to ignore (#1987)

### DIFF
--- a/en/guide/migrating-5.md
+++ b/en/guide/migrating-5.md
@@ -472,7 +472,7 @@ Example of breaking code:
 
 ```js
 // v4
-app.use(express.static("public"));
+app.use(express.static('public'))
 ```
 
 After migrating to Express 5, a request to `/.well-known/assetlinks.json` will result in a **404 Not Found**.
@@ -481,8 +481,8 @@ To fix this, serve specific dot-directories explicitly using the `dotfiles: "all
 
 ```js
 // v5
-app.use("/.well-known", express.static("public/.well-known", { dotfiles: "allow" }));
-app.use(express.static("public"));
+app.use('/.well-known', express.static('public/.well-known', { dotfiles: 'allow' }))
+app.use(express.static('public'))
 ```
 
 This approach allows you to safely serve only the intended dot-directories while keeping the default secure behavior for other dotfiles, which remain inaccessible.

--- a/en/guide/migrating-5.md
+++ b/en/guide/migrating-5.md
@@ -66,6 +66,7 @@ You can find the list of available codemods [here](https://github.com/expressjs/
   <li><a href="#path-syntax">Path route matching syntax</a></li>
   <li><a href="#rejected-promises">Rejected promises handled from middleware and handlers</a></li>
   <li><a href="#express.urlencoded">express.urlencoded</a></li>
+  <li><a href="#express.static.dotfiles">express.static dotfiles</a></li>
   <li><a href="#app.listen">app.listen</a></li>
   <li><a href="#app.router">app.router</a></li>
   <li><a href="#req.body">req.body</a></li>
@@ -75,6 +76,7 @@ You can find the list of available codemods [here](https://github.com/expressjs/
   <li><a href="#res.status">res.status</a></li>
   <li><a href="#res.vary">res.vary</a></li>
 </ul>
+
 
 **Improvements**
 
@@ -461,6 +463,30 @@ Details of how Express handles errors is covered in the [error handling document
 <h3 id="express.urlencoded">express.urlencoded</h3>
 
 The `express.urlencoded` method makes the `extended` option `false` by default.
+
+<h3 id="express.static.dotfiles">express.static dotfiles</h3>
+
+In Express 5, the `express.static` middleware's `dotfiles` option now defaults to `"ignore"`. This is a change from Express 4, where dotfiles were served by default. As a result, files and directories starting with a dot (`.`), such as `.well-known`, will no longer be accessible and will return a **404 Not Found** error. This can break functionality that depends on serving dot-directories, such as Android App Links, and Apple Universal Links.
+
+Example of breaking code:
+
+```js
+// v4
+app.use(express.static("public"));
+```
+
+After migrating to Express 5, a request to `/.well-known/assetlinks.json` will result in a **404 Not Found**.
+
+To fix this, serve specific dot-directories explicitly using the `dotfiles: "allow"` option:
+
+```js
+// v5
+app.use("/.well-known", express.static("public/.well-known", { dotfiles: "allow" }));
+app.use(express.static("public"));
+```
+
+This approach allows you to safely serve only the intended dot-directories while keeping the default secure behavior for other dotfiles, which remain inaccessible.
+
 
 <h3 id="app.listen">app.listen</h3>
 

--- a/en/guide/migrating-5.md
+++ b/en/guide/migrating-5.md
@@ -466,7 +466,7 @@ The `express.urlencoded` method makes the `extended` option `false` by default.
 
 <h3 id="express.static.dotfiles">express.static dotfiles</h3>
 
-In Express 5, the `express.static` middleware's `dotfiles` option now defaults to `"ignore"`. This is a change from Express 4, where dotfiles were served by default. As a result, files and directories starting with a dot (`.`), such as `.well-known`, will no longer be accessible and will return a **404 Not Found** error. This can break functionality that depends on serving dot-directories, such as Android App Links, and Apple Universal Links.
+In Express 5, the `express.static` middleware's `dotfiles` option now defaults to `"ignore"`. This is a change from Express 4, where dotfiles were served by default. As a result, files inside a directory that starts with a dot (`.`), such as `.well-known`, will no longer be accessible and will return a **404 Not Found** error. This can break functionality that depends on serving dot-directories, such as Android App Links, and Apple Universal Links.
 
 Example of breaking code:
 


### PR DESCRIPTION
### Summary
This PR updates the "Migrating to Express 5" guide to document the breaking change where express.static's dotfiles option now defaults to "ignore".

### Fixes Issue
Fixes #1987

### Changes
- Added a new section to migrating-5.md explaining the dotfiles default change.
- Provided example code for migration from Express 4 to Express 5.

<img width="915" height="464" alt="image" src="https://github.com/user-attachments/assets/bcdbe7da-8961-4fb8-bb91-1faaaf7cf75e" />
