### PR TITLE
docs: update res.clearCookie documentation for clarity and accuracy

### DIFF
--- a/_includes/api/en/4x/res-clearCookie.md
+++ b/_includes/api/en/4x/res-clearCookie.md
@@ -1,6 +1,14 @@
 <h3 id='res.clearCookie'>res.clearCookie(name [, options])</h3>
 
-Clears the cookie specified by `name`. For details about the `options` object, see [res.cookie()](#res.cookie).
+Clears the cookie with the specified `name` by sending a `Set-Cookie` header that sets its expiration date in the past.
+This instructs the client that the cookie has expired and is no longer valid. For more information
+about available `options`, see [res.cookie()](#res.cookie).
+
+<div class="doc-box doc-warn" markdown="1">
+If the `maxAge` or `expires` options are set, the cookie may not be cleared depending on the time values provided,
+as Express does not ignore these options. It is therefore recommended to omit these options when calling this
+method. Passing these two options has been deprecated since Express v4.20.0.
+</div>
 
 <div class="doc-box doc-notice" markdown="1">
 Web browsers and other compliant clients will only clear the cookie if the given

--- a/_includes/api/en/5x/res-clearCookie.md
+++ b/_includes/api/en/5x/res-clearCookie.md
@@ -1,11 +1,16 @@
 <h3 id='res.clearCookie'>res.clearCookie(name [, options])</h3>
 
-Clears the cookie specified by `name`. For details about the `options` object, see [res.cookie()](#res.cookie).
+Clears the cookie with the specified `name` by sending a `Set-Cookie` header that sets its expiration date in the past.
+This instructs the client that the cookie has expired and is no longer valid. For more information
+about available `options`, see [res.cookie()](#res.cookie).
+
+<div class="doc-box doc-notice" markdown="1">
+The `expires` and `max-age` options are being ignored completely.
+</div>
 
 <div class="doc-box doc-notice" markdown="1">
 Web browsers and other compliant clients will only clear the cookie if the given
-`options` is identical to those given to [res.cookie()](#res.cookie), excluding
-`expires` and `maxAge`.
+`options` is identical to those given to [res.cookie()](#res.cookie)
 </div>
 
 ```js


### PR DESCRIPTION
Improve the message by expanding on how the cookie is cleared, and include a note about the deprecation of the `max-age` and `expires` options: in Express 4 they are still respected (not ignored), whereas in Express 5 they are ignored.

ref: https://github.com/expressjs/express/pull/5792
ref: https://github.com/expressjs/express/issues/5640
ref: https://github.com/expressjs/express/pull/5672

closes: https://github.com/expressjs/expressjs.com/issues/1146

Preview: https://deploy-preview-2000--expressjscom-preview.netlify.app/en/4x/api.html#res.clearCookie, https://deploy-preview-2000--expressjscom-preview.netlify.app/en/5x/api.html#res.clearCookie

Note: We need to manage changes more effectively. Whenever there are changes, and once they have been released, a PR should be opened here to update the documentation. Improving these processes will help us keep our documentation better maintained.

cc: @expressjs/express-collaborators @expressjs/docs-wg 