### PR TITLE
ci: fix multiple comments in Lighthouse workflow

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -2,7 +2,6 @@ name: Lighthouse audit
 
 on:
   pull_request_target:
-    types: [opened, synchronize]
 
 permissions:
   contents: read
@@ -107,7 +106,8 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const fs = require('fs');
-            const report = fs.readFileSync('lighthouse-report.md', 'utf8');
+            let report = fs.readFileSync('lighthouse-report.md', 'utf8');
+            report += "\n<!-- Lighthouse Results Comment -->";
       
             const { data: comments } = await github.rest.issues.listComments({
               issue_number: context.payload.pull_request.number,
@@ -116,8 +116,7 @@ jobs:
             });
       
             const botComment = comments.find(comment =>
-              comment.user.type === 'Bot' &&
-              comment.body.includes('🚦Lighthouse Results')
+              comment.body.includes('<!-- Lighthouse Results Comment -->')
             );
       
             if (botComment) {
@@ -135,4 +134,3 @@ jobs:
                 body: report
               });
             }
-

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -32,12 +32,12 @@ jobs:
         run: |
           PREVIEW_URL="https://deploy-preview-${{ github.event.pull_request.number }}--expressjscom-preview.netlify.app"
           echo "PREVIEW_URL=$PREVIEW_URL" >> "$GITHUB_ENV"
-          for i in {1..2}; do
+          for i in {1..4}; do
             if curl -s --head "$PREVIEW_URL" | grep "200 OK" > /dev/null; then
               echo "Preview is live!"
               break
             fi
-            echo "Waiting for Netlify to deploy... ($i/2)"
+            echo "Waiting for Netlify to deploy... ($i/4)"
             sleep 10
           done
 
@@ -63,6 +63,7 @@ jobs:
 
               npx lighthouse "$url" \
                 $lighthouse_args \
+                --only-categories=performance,accessibility,best-practices \
                 --output json \
                 --output-path="lighthouse-report-${device}.json" \
                 --chrome-flags="--headless"
@@ -106,31 +107,33 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const fs = require('fs');
-            let report = fs.readFileSync('lighthouse-report.md', 'utf8');
-            report += "\n<!-- Lighthouse Results Comment -->";
-      
+            const report = fs.readFileSync('lighthouse-report.md', 'utf8');
+
             const { data: comments } = await github.rest.issues.listComments({
               issue_number: context.payload.pull_request.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
             });
-      
+
             const botComment = comments.find(comment =>
-              comment.body.includes('<!-- Lighthouse Results Comment -->')
+              comment.user.type === "Bot" &&
+              comment.body.includes("🚦 Lighthouse Results")
             );
-      
+
             if (botComment) {
               await github.rest.issues.updateComment({
                 comment_id: botComment.id,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                body: report
+                body: report,
               });
+              console.log("Updated existing Lighthouse comment.");
             } else {
               await github.rest.issues.createComment({
                 issue_number: context.payload.pull_request.number,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                body: report
+                body: report,
               });
+              console.log("Created new Lighthouse comment.");
             }


### PR DESCRIPTION
The problem is that new comments are being created every time a new commit is added, which generates spam, and it should actually update the existing comment, but it's not working.

I really don't know why the includes is not working properly. I want to try this before disabling the workflow until it is truly fixed.
