### PR TITLE
ci: fix security alert for Lighthouse workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: ["javascript"]
+        language: ["javascript", "actions"]
         # CodeQL supports [ $supported-codeql-languages ]
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -2,7 +2,6 @@ name: Lighthouse audit
 
 on:
   pull_request_target:
-    types: [opened, synchronize]
 
 permissions:
   contents: read
@@ -16,9 +15,6 @@ jobs:
     steps:
       - name: Checkout PR code
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: Setup Node.js with npm cache
         uses: actions/setup-node@v4


### PR DESCRIPTION
It's not necessary to define this since the action itself handles it, and it could also cause security issues within the repository. Please, whoever reviews it, merge it as soon as possible

see https://github.com/expressjs/expressjs.com/security/code-scanning/39