### PR TITLE
Clarify path matching behavior in Express.js documentation

### DIFF
--- a/_includes/api/en/4x/app-use.md
+++ b/_includes/api/en/4x/app-use.md
@@ -79,7 +79,8 @@ mounting middleware.
 <tr>
 <td>Path</td>
 <td markdown="1">
-This will match paths starting with `/abcd`:
+This will match the exact path `/abcd` and any paths beginning with `/abcd/` (including subdirectories), but will not match paths like `/abcde` :
+
 
 ```js
 app.use('/abcd', function (req, res, next) {

--- a/_includes/api/en/4x/app-use.md
+++ b/_includes/api/en/4x/app-use.md
@@ -79,7 +79,7 @@ mounting middleware.
 <tr>
 <td>Path</td>
 <td markdown="1">
-This will match the exact path `/abcd` and any paths beginning with `/abcd/` (including subdirectories), but will not match paths like `/abcde` :
+Matches the exact path `/abcd` and any sub-paths starting with `/abcd/` (for example, `/abcd/foo`):
 
 
 ```js

--- a/_includes/api/en/5x/app-use.md
+++ b/_includes/api/en/5x/app-use.md
@@ -80,7 +80,8 @@ mounting middleware.
 <tr>
 <td>Path</td>
 <td markdown="1">
-This will match paths starting with `/abcd`:
+This will match the exact path `/abcd` and any paths beginning with `/abcd/` (including subdirectories), but will not match paths like `/abcde` :
+
 
 ```js
 app.use('/abcd', (req, res, next) => {

--- a/_includes/api/en/5x/app-use.md
+++ b/_includes/api/en/5x/app-use.md
@@ -80,7 +80,7 @@ mounting middleware.
 <tr>
 <td>Path</td>
 <td markdown="1">
-This will match the exact path `/abcd` and any paths beginning with `/abcd/` (including subdirectories), but will not match paths like `/abcde` :
+Matches the exact path `/abcd` and any sub-paths starting with `/abcd/` (for example, `/abcd/foo`):
 
 
 ```js


### PR DESCRIPTION
## Summary
Updated the path examples documentation to clarify that route matching in Express.js is exact by default, unless path patterns, wildcards, or regular expressions are used.

## Details
Previously, the docs said “This will match paths starting with…”, which could be interpreted as matching partial strings (e.g., `/abcde`) when using `app.use('/abcd', ...)`. This is misleading because Express matches exact paths unless explicitly configured otherwise.

## Change
- Reworded the examples to clearly explain the exact-match behavior.
- Added note about wildcards and regular expressions for broader matching.
Fixes #1892

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
