### PR TITLE
docs: document array and multiple-args support in req.is

### DIFF
--- a/_includes/api/en/4x/req-is.md
+++ b/_includes/api/en/4x/req-is.md
@@ -21,8 +21,26 @@ req.is('application/json')
 req.is('application/*')
 // => 'application/*'
 
+
+// Using arrays
+// When Content-Type is application/json
+req.is(['json', 'html'])
+// => 'json' 
+
+// Using multiple arguments
+// When Content-Type is application/json
+req.is('json', 'html')
+// => 'json'
+
+
 req.is('html')
 // => false
+req.is(['xml', 'yaml'])
+// => false
+req.is('xml', 'yaml')
+// => false
+
+
 ```
 
 For more information, or if you have issues or concerns, see [type-is](https://github.com/expressjs/type-is).

--- a/_includes/api/en/4x/req-is.md
+++ b/_includes/api/en/4x/req-is.md
@@ -24,7 +24,7 @@ req.is('application/*')
 // Using arrays
 // When Content-Type is application/json
 req.is(['json', 'html'])
-// => 'json' 
+// => 'json'
 
 // Using multiple arguments
 // When Content-Type is application/json

--- a/_includes/api/en/4x/req-is.md
+++ b/_includes/api/en/4x/req-is.md
@@ -21,7 +21,6 @@ req.is('application/json')
 req.is('application/*')
 // => 'application/*'
 
-
 // Using arrays
 // When Content-Type is application/json
 req.is(['json', 'html'])
@@ -32,15 +31,12 @@ req.is(['json', 'html'])
 req.is('json', 'html')
 // => 'json'
 
-
 req.is('html')
 // => false
 req.is(['xml', 'yaml'])
 // => false
 req.is('xml', 'yaml')
 // => false
-
-
 ```
 
 For more information, or if you have issues or concerns, see [type-is](https://github.com/expressjs/type-is).

--- a/_includes/api/en/5x/req-is.md
+++ b/_includes/api/en/5x/req-is.md
@@ -17,17 +17,15 @@ req.is('application/*') // => 'application/*'
 
 // Using arrays
 // When Content-Type is application/json
-req.is(['json', 'html']) // => 'json' 
-
+req.is(['json', 'html']) // => 'json'
 
 // Using multiple arguments
 // When Content-Type is application/json
-req.is('json', 'html') // => 'json' 
-
+req.is('json', 'html') // => 'json'
 
 req.is('html') // => false
-req.is(['xml', 'yaml']) // => false 
-req.is('xml', 'yaml') // => false 
+req.is(['xml', 'yaml']) // => false
+req.is('xml', 'yaml') // => false
 ```
 
 For more information, or if you have issues or concerns, see [type-is](https://github.com/expressjs/type-is).

--- a/_includes/api/en/5x/req-is.md
+++ b/_includes/api/en/5x/req-is.md
@@ -15,8 +15,19 @@ req.is('json') // => 'json'
 req.is('application/json') // => 'application/json'
 req.is('application/*') // => 'application/*'
 
-req.is('html')
-// => false
+// Using arrays
+// When Content-Type is application/json
+req.is(['json', 'html']) // => 'json' 
+
+
+// Using multiple arguments
+// When Content-Type is application/json
+req.is('json', 'html') // => 'json' 
+
+
+req.is('html') // => false
+req.is(['xml', 'yaml']) // => false 
+req.is('xml', 'yaml') // => false 
 ```
 
 For more information, or if you have issues or concerns, see [type-is](https://github.com/expressjs/type-is).


### PR DESCRIPTION
This PR updates the Express 4.x and 5.x API documentation to clarify that
`req.is()` accepts either an array or multiple arguments, which provides more
flexibility when checking against content types.

Fixes: #2038
