### PR TITLE
docs: clarify path matching behavior for route methods vs app.use() (#1941)

### DIFF
--- a/_includes/api/en/4x/express.json.md
+++ b/_includes/api/en/4x/express.json.md
@@ -40,3 +40,12 @@ The following table describes the properties of the optional `options` object.
 | `verify`      | This option, if supplied, is called as `verify(req, res, buf, encoding)`, where `buf` is a `Buffer` of the raw request body and `encoding` is the encoding of the request. The parsing can be aborted by throwing an error. | Function | `undefined` |
 
 </div>
+
+#### Example: Different limits for specific routes
+
+```js
+// Limit 5MB for /upload
+app.use('/upload', express.json({ limit: '5mb' }));
+
+// Default limit for other routes
+app.use(express.json());

--- a/_includes/api/en/4x/express.json.md
+++ b/_includes/api/en/4x/express.json.md
@@ -45,7 +45,7 @@ The following table describes the properties of the optional `options` object.
 
 ```js
 // Limit 5MB for /upload
-app.use('/upload', express.json({ limit: '5mb' }));
+app.use('/upload', express.json({ limit: '5mb' }))
 
 // Default limit for other routes
-app.use(express.json());
+app.use(express.json())

--- a/_includes/api/en/4x/express.json.md
+++ b/_includes/api/en/4x/express.json.md
@@ -40,12 +40,3 @@ The following table describes the properties of the optional `options` object.
 | `verify`      | This option, if supplied, is called as `verify(req, res, buf, encoding)`, where `buf` is a `Buffer` of the raw request body and `encoding` is the encoding of the request. The parsing can be aborted by throwing an error. | Function | `undefined` |
 
 </div>
-
-#### Example: Different limits for specific routes
-
-```js
-// Limit 5MB for /upload
-app.use('/upload', express.json({ limit: '5mb' }))
-
-// Default limit for other routes
-app.use(express.json())

--- a/_includes/api/en/4x/express.static.md
+++ b/_includes/api/en/4x/express.static.md
@@ -93,3 +93,13 @@ var options = {
 
 app.use(express.static('public', options))
 ```
+<h4 id='example.of.express.json'>Example of express.json</h4>
+
+Here is an example of using the `express.json` middleware function with a custom limit:
+
+```js
+// Apply a 5MB limit for /upload requests
+app.use('/upload', express.json({ limit: '5mb' }))
+
+// Use default limit for all other routes
+app.use(express.json())

--- a/_includes/api/en/5x/app-use.md
+++ b/_includes/api/en/5x/app-use.md
@@ -138,6 +138,23 @@ app.use(['/abcd', '/xyza', /\/lmn|\/pqr/], (req, res, next) => {
 </table>
 </div>
 
+> **Note:** The above path examples describe how `app.use()` matches paths.  
+> When using route methods (such as `app.get()`, `app.post()`, etc.), the path must match exactly.  
+> For example:
+> 
+> ```js
+> app.use('/api', (req, res, next) => {
+>   // Matches /api, /api/users, /api/orders/123
+>   next()
+> })
+> 
+> app.get('/api', (req, res) => {
+>   // Only matches /api
+>   res.send('Hello API')
+> })
+> ```
+
+
 #### Middleware callback function examples
 
 The following table provides some simple examples of middleware functions that


### PR DESCRIPTION
This PR updates the documentation to address #1941 issue

Adds a note explaining that:

app.use() uses prefix-based path matching (e.g., /api will match /api/users).
HTTP method handlers (app.get(), app.post(), etc.) use exact path matching (e.g., app.get('/api') will only match /api).
Provides a clear code example to highlight the difference.
Ensures users are not confused when switching between app.use() and route methods.

This improves the clarity of the path examples section in the docs.
















<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
