### PR TITLE
ci: skip Lighthouse audit when Netlify preview is not live

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -26,8 +26,6 @@ jobs:
         run: npm install lighthouse
 
       - name: Wait for Netlify preview to be live
-        id: wait_preview
-        continue-on-error: true
         run: |
           PREVIEW_URL="https://deploy-preview-${{ github.event.pull_request.number }}--expressjscom-preview.netlify.app"
           echo "PREVIEW_URL=$PREVIEW_URL" >> "$GITHUB_ENV"
@@ -36,8 +34,9 @@ jobs:
 
           echo "Checking Netlify preview: $PREVIEW_URL"
           for i in $(seq 1 $MAX_RETRIES); do
-            if curl -s --head "$PREVIEW_URL" | grep "200 OK" > /dev/null; then
+            if curl -s --head --max-time 5 "$PREVIEW_URL" | grep "200 OK" > /dev/null; then
               echo "✅ Preview is live!"
+              echo "skip_lighthouse=false" >> "$GITHUB_ENV"
               exit 0
             fi
             echo "⏳ Waiting for Netlify to deploy... ($i/$MAX_RETRIES)"
@@ -45,10 +44,11 @@ jobs:
           done
 
           echo "❌ Preview not live after $((MAX_RETRIES*DELAY)) seconds."
-          exit 1
+          echo "skip_lighthouse=true" >> "$GITHUB_ENV"
+          exit 0
 
       - name: Run Lighthouse audits
-        if: steps.wait_preview.outcome == 'success'
+        if: env.skip_lighthouse == 'false'
         run: |
           URLS=(
             "$PREVIEW_URL"
@@ -98,12 +98,12 @@ jobs:
           done
 
       - name: Log Lighthouse report
-        if: steps.wait_preview.outcome == 'success'
+        if: env.skip_lighthouse == 'false'
         run: |
           cat lighthouse-report.md
 
       - name: Upload Lighthouse reports as artifacts
-        if: steps.wait_preview.outcome == 'success'
+        if: env.skip_lighthouse == 'false'
         uses: actions/upload-artifact@v4
         with:
           name: lighthouse-reports
@@ -111,7 +111,7 @@ jobs:
             lighthouse-report.md
 
       - name: Comment on PR with Lighthouse results
-        if: steps.wait_preview.outcome == 'success'
+        if: env.skip_lighthouse == 'false'
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -26,19 +26,29 @@ jobs:
         run: npm install lighthouse
 
       - name: Wait for Netlify preview to be live
+        id: wait_preview
+        continue-on-error: true
         run: |
           PREVIEW_URL="https://deploy-preview-${{ github.event.pull_request.number }}--expressjscom-preview.netlify.app"
           echo "PREVIEW_URL=$PREVIEW_URL" >> "$GITHUB_ENV"
-          for i in {1..4}; do
+          MAX_RETRIES=12
+          DELAY=10
+
+          echo "Checking Netlify preview: $PREVIEW_URL"
+          for i in $(seq 1 $MAX_RETRIES); do
             if curl -s --head "$PREVIEW_URL" | grep "200 OK" > /dev/null; then
-              echo "Preview is live!"
-              break
+              echo "✅ Preview is live!"
+              exit 0
             fi
-            echo "Waiting for Netlify to deploy... ($i/4)"
-            sleep 10
+            echo "⏳ Waiting for Netlify to deploy... ($i/$MAX_RETRIES)"
+            sleep $DELAY
           done
 
+          echo "❌ Preview not live after $((MAX_RETRIES*DELAY)) seconds."
+          exit 1
+
       - name: Run Lighthouse audits
+        if: steps.wait_preview.outcome == 'success'
         run: |
           URLS=(
             "$PREVIEW_URL"
@@ -88,10 +98,12 @@ jobs:
           done
 
       - name: Log Lighthouse report
+        if: steps.wait_preview.outcome == 'success'
         run: |
           cat lighthouse-report.md
 
       - name: Upload Lighthouse reports as artifacts
+        if: steps.wait_preview.outcome == 'success'
         uses: actions/upload-artifact@v4
         with:
           name: lighthouse-reports
@@ -99,6 +111,7 @@ jobs:
             lighthouse-report.md
 
       - name: Comment on PR with Lighthouse results
+        if: steps.wait_preview.outcome == 'success'
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
same as title
<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
