### PR TITLE
fix: ensure footer is pushed to the bottom on large screens

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -17,20 +17,8 @@ h1, h2, h3, h4, h5, h6,
   }
 }
 
-html {
-  /*
-    html & body need to take the whole
-    visible area in order for the footer
-    to be pushed all the way down or else
-    on really big screens or when the user
-    is zoomed out, the footer is not all
-    the way at the bottom of the screen
-  */
-  height: 100%;
-}
-
 body {
-  height: 100%;
+  height: 100vh;
   font: 400 14px/1.6 "Open Sans", sans-serif;
   background: var(--bg);
   margin: 0;
@@ -1750,3 +1738,4 @@ blockquote {
     border-bottom: 1px solid var(--border);
   }
 }
+

--- a/css/style.css
+++ b/css/style.css
@@ -17,7 +17,20 @@ h1, h2, h3, h4, h5, h6,
   }
 }
 
+html {
+  /*
+    html & body need to take the whole
+    visible area in order for the footer
+    to be pushed all the way down or else
+    on really big screens or when the user
+    is zoomed out, the footer is not all
+    the way at the bottom of the screen
+  */
+  height: 100%;
+}
+
 body {
+  height: 100%;
   font: 400 14px/1.6 "Open Sans", sans-serif;
   background: var(--bg);
   margin: 0;
@@ -40,6 +53,7 @@ header {
 }
 
 footer {
+  margin-top: auto;
   grid-area: footer;
 }
 


### PR DESCRIPTION
### Summary

Fixes footer layout issue on very wide screens where the footer does not stick to the bottom of the page.

### Problem

* On large screens, the homepage layout leaves the footer floating above the bottom of the viewport.
* This looks fine on normal screens, but on very wide screens the gap is obvious.

Screenshots:

* **Big screen (before):** <img width="3436" height="1308" alt="original_big_screen" src="https://github.com/user-attachments/assets/6faf0442-beb8-4ac1-b800-1dfc388fed10" />

* **Small/normal screen (before):** <img width="1899" height="965" alt="original_small_screen" src="https://github.com/user-attachments/assets/1d0d62ee-31ef-47de-8b88-af6f6c120d2d" />

### Changes Made

* Set `html` and `body` to take up the full screen height.
* Adjusted footer styling so it always sticks to the bottom.

### Testing

* Verified locally on normal and wide screens.
* Layout works consistently across different viewport sizes.

---

Let me know if further adjustments are needed.

closes #2079 