### PR TITLE
Fix typo in Chinese routing guide: /random.text vs / route mislabeled…

### DIFF
--- a/zh-cn/guide/routing.md
+++ b/zh-cn/guide/routing.md
@@ -95,7 +95,7 @@ Query strings are not part of the route path.
 
 ### 以下是基于字符串的路由路径的一些示例。
 
-此路由路径将请求与 `/random.text` 匹配。
+此路由路径将请求与 `/` 匹配。
 
 ```js
 app.get('/', (req, res) => {
@@ -111,7 +111,7 @@ app.get('/about', (req, res) => {
 })
 ```
 
-此路由路径将请求与根路由 `/` 匹配。
+此路由路径将请求与 `/random.text` 匹配。
 
 ```js
 app.get('/random.text', (req, res) => {


### PR DESCRIPTION
**Description**

```
Issue #2058

This is my first contribution to the project.  
I’ve corrected a typo in the Chinese routing guide where the routes `/random.text` and `/` were mislabeled.  

File updated:  
- `guide/routing.md` (Chinese version)

Please review and let me know if any improvements are needed.
```

**Developer's Certificate of Origin**

```
By making this contribution, I certify that:

- The work is my own or based on appropriately licensed work.  
- I have the right to submit it under the project’s open source license.  
- I agree that this contribution is public and may be redistributed under the same license.  

Signed-off-by: dhruvinjs <dhruvinjs.me@gmail.com>
```

