### PR TITLE
Remove reference to unimplemented feature

### DIFF
--- a/en/guide/routing.md
+++ b/en/guide/routing.md
@@ -216,31 +216,6 @@ In express 5, Regexp characters are not supported in route paths, for more infor
 
 {% include admonitions/caution.html content=warning-regexp %}
 
-To have more control over the exact string that can be matched by a route parameter, you can append a regular expression in parentheses (`()`):
-
-```
-Route path: /user/:userId(\d+)
-Request URL: http://localhost:3000/user/42
-req.params: {"userId": "42"}
-```
-
-{% capture escape-advisory %}
-
-Because the regular expression is usually part of a literal string, be sure to escape any `\` characters with an additional backslash, for example `\\d+`.
-
-{% endcapture %}
-
-
-{% include admonitions/warning.html content=escape-advisory %}
-
-{% capture warning-version %}
-
-In Express 4.x, <a href="https://github.com/expressjs/express/issues/2495">the `*` character in regular expressions is not interpreted in the usual way</a>. As a workaround, use `{0,}` instead of `*`. This will likely be fixed in Express 5.
-
-{% endcapture %}
-
-{% include admonitions/warning.html content=warning-version %}
-
 <h2 id="route-handlers">Route handlers</h2>
 
 You can provide multiple callback functions that behave like [middleware](/{{ page.lang }}/guide/using-middleware.html) to handle a request. The only exception is that these callbacks might invoke `next('route')` to bypass the remaining route callbacks. You can use this mechanism to impose pre-conditions on a route, then pass control to subsequent routes if there's no reason to proceed with the current route.


### PR DESCRIPTION
path-to-regexp does not support this syntax at all. There was a PR to implement it, but it seems pretty dead. https://github.com/pillarjs/path-to-regexp/pull/362

<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
