### PR TITLE
fix: update link to triage process document in contributing guides

### DIFF
--- a/de/resources/contributing.md
+++ b/de/resources/contributing.md
@@ -87,7 +87,7 @@ compromise among committers be the default resolution mechanism.
 ### Becoming a Triager
 
 Anyone can become a triager! Read more about the process of being a triager in
-[the triage process document](https://github.com/expressjs/discussions/blob/master/Triager-Guide.md).
+[the triage process document](https://github.com/expressjs/discussions/blob/master/docs/contributing/triager-guide.md).
 
 Currently, any existing [organization member](https://github.com/orgs/expressjs/people) can nominate
 a new triager. If you are interested in becoming a triager, our best advice is to actively participate

--- a/en/resources/contributing.md
+++ b/en/resources/contributing.md
@@ -87,7 +87,7 @@ compromise among committers be the default resolution mechanism.
 ### Becoming a Triager
 
 Anyone can become a triager! Read more about the process of being a triager in
-[the triage process document](https://github.com/expressjs/discussions/blob/master/Triager-Guide.md).
+[the triage process document](https://github.com/expressjs/discussions/blob/master/docs/contributing/triager-guide.md).
 
 Currently, any existing [organization member](https://github.com/orgs/expressjs/people) can nominate
 a new triager. If you are interested in becoming a triager, our best advice is to actively participate

--- a/es/resources/contributing.md
+++ b/es/resources/contributing.md
@@ -87,7 +87,7 @@ compromise among committers be the default resolution mechanism.
 ### Becoming a Triager
 
 Anyone can become a triager! Read more about the process of being a triager in
-[the triage process document](https://github.com/expressjs/discussions/blob/master/Triager-Guide.md).
+[the triage process document](https://github.com/expressjs/discussions/blob/master/docs/contributing/triager-guide.md).
 
 Currently, any existing [organization member](https://github.com/orgs/expressjs/people) can nominate
 a new triager. If you are interested in becoming a triager, our best advice is to actively participate

--- a/fr/resources/contributing.md
+++ b/fr/resources/contributing.md
@@ -87,7 +87,7 @@ compromise among committers be the default resolution mechanism.
 ### Becoming a Triager
 
 Anyone can become a triager! Read more about the process of being a triager in
-[the triage process document](https://github.com/expressjs/discussions/blob/master/Triager-Guide.md).
+[the triage process document](https://github.com/expressjs/discussions/blob/master/docs/contributing/triager-guide.md).
 
 Currently, any existing [organization member](https://github.com/orgs/expressjs/people) can nominate
 a new triager. If you are interested in becoming a triager, our best advice is to actively participate

--- a/it/resources/contributing.md
+++ b/it/resources/contributing.md
@@ -87,7 +87,7 @@ compromise among committers be the default resolution mechanism.
 ### Becoming a Triager
 
 Anyone can become a triager! Read more about the process of being a triager in
-[the triage process document](https://github.com/expressjs/discussions/blob/master/Triager-Guide.md).
+[the triage process document](https://github.com/expressjs/discussions/blob/master/docs/contributing/triager-guide.md).
 
 Currently, any existing [organization member](https://github.com/orgs/expressjs/people) can nominate
 a new triager. If you are interested in becoming a triager, our best advice is to actively participate

--- a/ja/resources/contributing.md
+++ b/ja/resources/contributing.md
@@ -87,7 +87,7 @@ compromise among committers be the default resolution mechanism.
 ### Becoming a Triager
 
 Anyone can become a triager! Read more about the process of being a triager in
-[the triage process document](https://github.com/expressjs/discussions/blob/master/Triager-Guide.md).
+[the triage process document](https://github.com/expressjs/discussions/blob/master/docs/contributing/triager-guide.md).
 
 Currently, any existing [organization member](https://github.com/orgs/expressjs/people) can nominate
 a new triager. If you are interested in becoming a triager, our best advice is to actively participate

--- a/ko/resources/contributing.md
+++ b/ko/resources/contributing.md
@@ -87,7 +87,7 @@ compromise among committers be the default resolution mechanism.
 ### Becoming a Triager
 
 Anyone can become a triager! Read more about the process of being a triager in
-[the triage process document](https://github.com/expressjs/discussions/blob/master/Triager-Guide.md).
+[the triage process document](https://github.com/expressjs/discussions/blob/master/docs/contributing/triager-guide.md).
 
 Currently, any existing [organization member](https://github.com/orgs/expressjs/people) can nominate
 a new triager. If you are interested in becoming a triager, our best advice is to actively participate

--- a/pt-br/resources/contributing.md
+++ b/pt-br/resources/contributing.md
@@ -87,7 +87,7 @@ compromise among committers be the default resolution mechanism.
 ### Becoming a Triager
 
 Anyone can become a triager! Read more about the process of being a triager in
-[the triage process document](https://github.com/expressjs/discussions/blob/master/Triager-Guide.md).
+[the triage process document](https://github.com/expressjs/discussions/blob/master/docs/contributing/triager-guide.md).
 
 Currently, any existing [organization member](https://github.com/orgs/expressjs/people) can nominate
 a new triager. If you are interested in becoming a triager, our best advice is to actively participate

--- a/zh-cn/resources/contributing.md
+++ b/zh-cn/resources/contributing.md
@@ -87,7 +87,7 @@ compromise among committers be the default resolution mechanism.
 ### Becoming a Triager
 
 Anyone can become a triager! Read more about the process of being a triager in
-[the triage process document](https://github.com/expressjs/discussions/blob/master/Triager-Guide.md).
+[the triage process document](https://github.com/expressjs/discussions/blob/master/docs/contributing/triager-guide.md).
 
 Currently, any existing [organization member](https://github.com/orgs/expressjs/people) can nominate
 a new triager. If you are interested in becoming a triager, our best advice is to actively participate

--- a/zh-tw/resources/contributing.md
+++ b/zh-tw/resources/contributing.md
@@ -87,7 +87,7 @@ compromise among committers be the default resolution mechanism.
 ### Becoming a Triager
 
 Anyone can become a triager! Read more about the process of being a triager in
-[the triage process document](https://github.com/expressjs/discussions/blob/master/Triager-Guide.md).
+[the triage process document](https://github.com/expressjs/discussions/blob/master/docs/contributing/triager-guide.md).
 
 Currently, any existing [organization member](https://github.com/orgs/expressjs/people) can nominate
 a new triager. If you are interested in becoming a triager, our best advice is to actively participate


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

The triage process url was broken in multiple pages, because the file structure changed.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
