### PR TITLE
docs: Fix broken links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@
 This is the contribution documentation for the [expressjs.com](https://github.com/expressjs/expressjs.com) website.
 
 >[!NOTE]
-> This is not the repo for Express JS framework. To contribute to the _[Express JS framework](https://github.com/expressjs/express_)_, check out the [Github repo contributing page](https://github.com/expressjs/.github/blob/master/CONTRIBUTING.md) or the website's [Contributing to Express](https://expressjs.com/en/resources/contributing.html) page.
+> This is not the repo for Express JS framework. To contribute to the _[Express JS framework](https://github.com/expressjs/express_)_, check out the [Github repo contributing page](https://github.com/expressjs/express/blob/master/Contributing.md) or the website's [Contributing to Express](https://expressjs.com/en/resources/contributing.html) page.
 
 
 #### Need some ideas? These are some typical issues.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@
 This is the contribution documentation for the [expressjs.com](https://github.com/expressjs/expressjs.com) website.
 
 >[!NOTE]
-> This is not the repo for Express JS framework. To contribute to the _[Express JS framework](https://github.com/expressjs/express_)_, check out the [Github repo contributing page](https://github.com/expressjs/express/blob/master/Contributing.md) or the website's [Contributing to Express](https://expressjs.com/en/resources/contributing.html) page.
+> This is not the repo for Express JS framework. To contribute to the _[Express JS framework](https://github.com/expressjs/express_)_, check out the [Github repo contributing page](https://github.com/expressjs/.github/blob/master/CONTRIBUTING.md) or the website's [Contributing to Express](https://expressjs.com/en/resources/contributing.html) page.
 
 
 #### Need some ideas? These are some typical issues.

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -13,7 +13,7 @@
         <a href="https://privacy-policy.openjsf.org">
           {{ site.data[page.lang].footer.privacy_policy }}
         </a>
-        <a id="coc" href="https://github.com/expressjs/express/blob/master/Code-Of-Conduct.md">
+        <a id="coc" href="https://github.com/expressjs/.github/blob/HEAD/CODE_OF_CONDUCT.md">
           {{ site.data[page.lang].footer.coc }}
         </a>
         <a href="https://trademark-policy.openjsf.org">

--- a/de/resources/community.md
+++ b/de/resources/community.md
@@ -45,7 +45,7 @@ Unsere lebhafte Community hat zu einer Vielzahl von Erweiterungen, [Middlewaremo
 Additionally, the Express community maintains modules in these two GitHub orgs:
 
 - [jshttp](https://github.com/jshttp) modules providing useful utility functions; see [Utility modules](/{{ page.lang }}/resources/utils.html).
-- [pillarjs](https://pillarjs.github.io/): low-level modules that Express uses internally.
+- [pillarjs](https://github.com/pillarjs): low-level modules that Express uses internally.
 
 To keep up with what is going on in the whole community, check out the [ExpressJS StatusBoard](https://expressjs.github.io/statusboard/).
 

--- a/de/resources/community.md
+++ b/de/resources/community.md
@@ -44,7 +44,7 @@ Unsere lebhafte Community hat zu einer Vielzahl von Erweiterungen, [Middlewaremo
 
 Additionally, the Express community maintains modules in these two GitHub orgs:
 
-- [jshttp](https://jshttp.github.io/) modules providing useful utility functions; see [Utility modules](/{{ page.lang }}/resources/utils.html).
+- [jshttp](https://github.com/jshttp) modules providing useful utility functions; see [Utility modules](/{{ page.lang }}/resources/utils.html).
 - [pillarjs](https://pillarjs.github.io/): low-level modules that Express uses internally.
 
 To keep up with what is going on in the whole community, check out the [ExpressJS StatusBoard](https://expressjs.github.io/statusboard/).

--- a/de/starter/examples.md
+++ b/de/starter/examples.md
@@ -15,7 +15,6 @@ These are some additional examples with more extensive integrations.
 
 {% include community-caveat.html %}
 
-- [prisma-fullstack](https://github.com/prisma/prisma-examples/tree/latest/pulse/fullstack-simple-chat) - Fullstack app with Express and Next.js using [Prisma](https://www.npmjs.com/package/prisma) as an ORM
 - [prisma-rest-api-ts](https://github.com/prisma/prisma-examples/tree/latest/orm/express) - REST API with Express in TypeScript using [Prisma](https://www.npmjs.com/package/prisma) as an ORM
 
 ### [Previous: Static Files ](/{{ page.lang }}/starter/static-files.html)&nbsp;&nbsp;&nbsp;&nbsp;[Next: FAQ ](/{{ page.lang }}/starter/faq.html)

--- a/en/resources/community.md
+++ b/en/resources/community.md
@@ -45,7 +45,7 @@ Our vibrant community has created a large variety of extensions,
 
 Additionally, the Express community maintains modules in these two GitHub orgs:
 
-- [jshttp](https://jshttp.github.io/) modules providing useful utility functions; see [Utility modules](/{{ page.lang }}/resources/utils.html).
+- [jshttp](https://github.com/jshttp) modules providing useful utility functions; see [Utility modules](/{{ page.lang }}/resources/utils.html).
 - [pillarjs](https://pillarjs.github.io/): low-level modules that Express uses internally.
 
 To keep up with what is going on in the whole community, check out the [ExpressJS StatusBoard](https://expressjs.github.io/statusboard/).

--- a/en/resources/community.md
+++ b/en/resources/community.md
@@ -46,7 +46,7 @@ Our vibrant community has created a large variety of extensions,
 Additionally, the Express community maintains modules in these two GitHub orgs:
 
 - [jshttp](https://github.com/jshttp) modules providing useful utility functions; see [Utility modules](/{{ page.lang }}/resources/utils.html).
-- [pillarjs](https://pillarjs.github.io/): low-level modules that Express uses internally.
+- [pillarjs](https://github.com/pillarjs): low-level modules that Express uses internally.
 
 To keep up with what is going on in the whole community, check out the [ExpressJS StatusBoard](https://expressjs.github.io/statusboard/).
 

--- a/en/starter/examples.md
+++ b/en/starter/examples.md
@@ -15,7 +15,6 @@ These are some additional examples with more extensive integrations.
 
 {% include community-caveat.html %}
 
-- [prisma-fullstack](https://github.com/prisma/prisma-examples/tree/latest/pulse/fullstack-simple-chat) - Fullstack app with Express and Next.js using [Prisma](https://www.npmjs.com/package/prisma) as an ORM
 - [prisma-rest-api-ts](https://github.com/prisma/prisma-examples/tree/latest/orm/express) - REST API with Express in TypeScript using [Prisma](https://www.npmjs.com/package/prisma) as an ORM
 
 ### [Previous: Static Files ](/{{ page.lang }}/starter/static-files.html)&nbsp;&nbsp;&nbsp;&nbsp;[Next: FAQ ](/{{ page.lang }}/starter/faq.html)

--- a/es/resources/community.md
+++ b/es/resources/community.md
@@ -41,7 +41,7 @@ Nuestra vibrante comunidad ha creado una larga variedad de extensiones, [módulo
 
 Además, la comunidad de Express mantiene módulos en estas dos organizaciones de GitHub:
 
-- [jshttp](https://jshttp.github.io/): módulos que proporcionan funciones utilitarias útiles; consulte [Módulos de utilidad](/{{ page.lang }}/resources/utils.html).
+- [jshttp](https://github.com/jshttp): módulos que proporcionan funciones utilitarias útiles; consulte [Módulos de utilidad](/{{ page.lang }}/resources/utils.html).
 - [pillarjs](https://pillarjs.github.io/): módulos de bajo nivel que Express utiliza internamente.
 
 Para mantenerse al tanto de lo que está sucediendo en toda la comunidad, consulte [ExpressJS StatusBoard](https://expressjs.github.io/statusboard/).

--- a/es/resources/community.md
+++ b/es/resources/community.md
@@ -42,7 +42,7 @@ Nuestra vibrante comunidad ha creado una larga variedad de extensiones, [módulo
 Además, la comunidad de Express mantiene módulos en estas dos organizaciones de GitHub:
 
 - [jshttp](https://github.com/jshttp): módulos que proporcionan funciones utilitarias útiles; consulte [Módulos de utilidad](/{{ page.lang }}/resources/utils.html).
-- [pillarjs](https://pillarjs.github.io/): módulos de bajo nivel que Express utiliza internamente.
+- [pillarjs](https://github.com/pillarjs): módulos de bajo nivel que Express utiliza internamente.
 
 Para mantenerse al tanto de lo que está sucediendo en toda la comunidad, consulte [ExpressJS StatusBoard](https://expressjs.github.io/statusboard/).
 

--- a/es/starter/examples.md
+++ b/es/starter/examples.md
@@ -15,7 +15,6 @@ These are some additional examples with more extensive integrations.
 
 {% include community-caveat.html %}
 
-- [prisma-fullstack](https://github.com/prisma/prisma-examples/tree/latest/pulse/fullstack-simple-chat) - Fullstack app with Express and Next.js using [Prisma](https://www.npmjs.com/package/prisma) as an ORM
 - [prisma-rest-api-ts](https://github.com/prisma/prisma-examples/tree/latest/orm/express) - REST API with Express in TypeScript using [Prisma](https://www.npmjs.com/package/prisma) as an ORM
 
 ### [Previous: Static Files ](/{{ page.lang }}/starter/static-files.html)&nbsp;&nbsp;&nbsp;&nbsp;[Next: FAQ ](/{{ page.lang }}/starter/faq.html)

--- a/fr/resources/community.md
+++ b/fr/resources/community.md
@@ -47,7 +47,7 @@ infrastructures de niveau supérieur.
 Additionally, the Express community maintains modules in these two GitHub orgs:
 
 - [jshttp](https://github.com/jshttp) modules providing useful utility functions; see [Utility modules](/{{ page.lang }}/resources/utils.html).
-- [pillarjs](https://pillarjs.github.io/): low-level modules that Express uses internally.
+- [pillarjs](https://github.com/pillarjs): low-level modules that Express uses internally.
 
 To keep up with what is going on in the whole community, check out the [ExpressJS StatusBoard](https://expressjs.github.io/statusboard/).
 

--- a/fr/resources/community.md
+++ b/fr/resources/community.md
@@ -46,7 +46,7 @@ infrastructures de niveau supérieur.
 
 Additionally, the Express community maintains modules in these two GitHub orgs:
 
-- [jshttp](https://jshttp.github.io/) modules providing useful utility functions; see [Utility modules](/{{ page.lang }}/resources/utils.html).
+- [jshttp](https://github.com/jshttp) modules providing useful utility functions; see [Utility modules](/{{ page.lang }}/resources/utils.html).
 - [pillarjs](https://pillarjs.github.io/): low-level modules that Express uses internally.
 
 To keep up with what is going on in the whole community, check out the [ExpressJS StatusBoard](https://expressjs.github.io/statusboard/).

--- a/fr/starter/examples.md
+++ b/fr/starter/examples.md
@@ -15,7 +15,6 @@ These are some additional examples with more extensive integrations.
 
 {% include community-caveat.html %}
 
-- [prisma-fullstack](https://github.com/prisma/prisma-examples/tree/latest/pulse/fullstack-simple-chat) - Fullstack app with Express and Next.js using [Prisma](https://www.npmjs.com/package/prisma) as an ORM
 - [prisma-rest-api-ts](https://github.com/prisma/prisma-examples/tree/latest/orm/express) - REST API with Express in TypeScript using [Prisma](https://www.npmjs.com/package/prisma) as an ORM
 
 ### [Previous: Static Files ](/{{ page.lang }}/starter/static-files.html)&nbsp;&nbsp;&nbsp;&nbsp;[Next: FAQ ](/{{ page.lang }}/starter/faq.html)

--- a/it/resources/community.md
+++ b/it/resources/community.md
@@ -45,7 +45,7 @@ La nostra community molto attiva ha creato una vasta varietà di estensioni,
 
 Additionally, the Express community maintains modules in these two GitHub orgs:
 
-- [jshttp](https://jshttp.github.io/) modules providing useful utility functions; see [Utility modules](/{{ page.lang }}/resources/utils.html).
+- [jshttp](https://github.com/jshttp) modules providing useful utility functions; see [Utility modules](/{{ page.lang }}/resources/utils.html).
 - [pillarjs](https://pillarjs.github.io/): low-level modules that Express uses internally.
 
 To keep up with what is going on in the whole community, check out the [ExpressJS StatusBoard](https://expressjs.github.io/statusboard/).

--- a/it/resources/community.md
+++ b/it/resources/community.md
@@ -46,7 +46,7 @@ La nostra community molto attiva ha creato una vasta varietà di estensioni,
 Additionally, the Express community maintains modules in these two GitHub orgs:
 
 - [jshttp](https://github.com/jshttp) modules providing useful utility functions; see [Utility modules](/{{ page.lang }}/resources/utils.html).
-- [pillarjs](https://pillarjs.github.io/): low-level modules that Express uses internally.
+- [pillarjs](https://github.com/pillarjs): low-level modules that Express uses internally.
 
 To keep up with what is going on in the whole community, check out the [ExpressJS StatusBoard](https://expressjs.github.io/statusboard/).
 

--- a/it/starter/examples.md
+++ b/it/starter/examples.md
@@ -15,7 +15,6 @@ These are some additional examples with more extensive integrations.
 
 {% include community-caveat.html %}
 
-- [prisma-fullstack](https://github.com/prisma/prisma-examples/tree/latest/pulse/fullstack-simple-chat) - Fullstack app with Express and Next.js using [Prisma](https://www.npmjs.com/package/prisma) as an ORM
 - [prisma-rest-api-ts](https://github.com/prisma/prisma-examples/tree/latest/orm/express) - REST API with Express in TypeScript using [Prisma](https://www.npmjs.com/package/prisma) as an ORM
 
 ### [Previous: Static Files ](/{{ page.lang }}/starter/static-files.html)&nbsp;&nbsp;&nbsp;&nbsp;[Next: FAQ ](/{{ page.lang }}/starter/faq.html)

--- a/ja/resources/community.md
+++ b/ja/resources/community.md
@@ -45,7 +45,7 @@ Members of the Express technical committee are:
 Additionally, the Express community maintains modules in these two GitHub orgs:
 
 - [jshttp](https://github.com/jshttp) modules providing useful utility functions; see [Utility modules](/{{ page.lang }}/resources/utils.html).
-- [pillarjs](https://pillarjs.github.io/): low-level modules that Express uses internally.
+- [pillarjs](https://github.com/pillarjs): low-level modules that Express uses internally.
 
 To keep up with what is going on in the whole community, check out the [ExpressJS StatusBoard](https://expressjs.github.io/statusboard/).
 

--- a/ja/resources/community.md
+++ b/ja/resources/community.md
@@ -44,7 +44,7 @@ Members of the Express technical committee are:
 
 Additionally, the Express community maintains modules in these two GitHub orgs:
 
-- [jshttp](https://jshttp.github.io/) modules providing useful utility functions; see [Utility modules](/{{ page.lang }}/resources/utils.html).
+- [jshttp](https://github.com/jshttp) modules providing useful utility functions; see [Utility modules](/{{ page.lang }}/resources/utils.html).
 - [pillarjs](https://pillarjs.github.io/): low-level modules that Express uses internally.
 
 To keep up with what is going on in the whole community, check out the [ExpressJS StatusBoard](https://expressjs.github.io/statusboard/).

--- a/ja/starter/examples.md
+++ b/ja/starter/examples.md
@@ -15,7 +15,6 @@ These are some additional examples with more extensive integrations.
 
 {% include community-caveat.html %}
 
-- [prisma-fullstack](https://github.com/prisma/prisma-examples/tree/latest/pulse/fullstack-simple-chat) - Fullstack app with Express and Next.js using [Prisma](https://www.npmjs.com/package/prisma) as an ORM
 - [prisma-rest-api-ts](https://github.com/prisma/prisma-examples/tree/latest/orm/express) - REST API with Express in TypeScript using [Prisma](https://www.npmjs.com/package/prisma) as an ORM
 
 ### [Previous: Static Files ](/{{ page.lang }}/starter/static-files.html)&nbsp;&nbsp;&nbsp;&nbsp;[Next: FAQ ](/{{ page.lang }}/starter/faq.html)

--- a/ko/resources/community.md
+++ b/ko/resources/community.md
@@ -45,7 +45,7 @@ Members of the Express technical committee are:
 
 Additionally, the Express community maintains modules in these two GitHub orgs:
 
-- [jshttp](https://jshttp.github.io/) modules providing useful utility functions; see [Utility modules](/{{ page.lang }}/resources/utils.html).
+- [jshttp](https://github.com/jshttp) modules providing useful utility functions; see [Utility modules](/{{ page.lang }}/resources/utils.html).
 - [pillarjs](https://pillarjs.github.io/): low-level modules that Express uses internally.
 
 To keep up with what is going on in the whole community, check out the [ExpressJS StatusBoard](https://expressjs.github.io/statusboard/).

--- a/ko/resources/community.md
+++ b/ko/resources/community.md
@@ -46,7 +46,7 @@ Members of the Express technical committee are:
 Additionally, the Express community maintains modules in these two GitHub orgs:
 
 - [jshttp](https://github.com/jshttp) modules providing useful utility functions; see [Utility modules](/{{ page.lang }}/resources/utils.html).
-- [pillarjs](https://pillarjs.github.io/): low-level modules that Express uses internally.
+- [pillarjs](https://github.com/pillarjs): low-level modules that Express uses internally.
 
 To keep up with what is going on in the whole community, check out the [ExpressJS StatusBoard](https://expressjs.github.io/statusboard/).
 

--- a/ko/starter/examples.md
+++ b/ko/starter/examples.md
@@ -15,7 +15,6 @@ These are some additional examples with more extensive integrations.
 
 {% include community-caveat.html %}
 
-- [prisma-fullstack](https://github.com/prisma/prisma-examples/tree/latest/pulse/fullstack-simple-chat) - Fullstack app with Express and Next.js using [Prisma](https://www.npmjs.com/package/prisma) as an ORM
 - [prisma-rest-api-ts](https://github.com/prisma/prisma-examples/tree/latest/orm/express) - REST API with Express in TypeScript using [Prisma](https://www.npmjs.com/package/prisma) as an ORM
 
 ### [Previous: Static Files ](/{{ page.lang }}/starter/static-files.html)&nbsp;&nbsp;&nbsp;&nbsp;[Next: FAQ ](/{{ page.lang }}/starter/faq.html)

--- a/pt-br/resources/community.md
+++ b/pt-br/resources/community.md
@@ -46,7 +46,7 @@ Nossa vibrante comunidade criou uma grande variedade de extensões,
 Além disso, a comunidade Express mantém módulos nestes duas organizações no GitHub:
 
 - [jshttp](https://github.com/jshttp) módulos que fornecem função utilitária útil; ver [Módulos utilitários](/{{ page.lang }}/resources/utils.html).
-- [pillarjs](https://pillarjs.github.io/): módulos de baixo nível que o Express usa internamente.
+- [pillarjs](https://github.com/pillarjs): módulos de baixo nível que o Express usa internamente.
 
 Para acompanhar o que está acontecendo em toda a comunidade, Confira a [ExpressJS StatusBoard](https://expressjs.github.io/statusboard/).
 

--- a/pt-br/resources/community.md
+++ b/pt-br/resources/community.md
@@ -45,7 +45,7 @@ Nossa vibrante comunidade criou uma grande variedade de extensões,
 
 Além disso, a comunidade Express mantém módulos nestes duas organizações no GitHub:
 
-- [jshttp](https://jshttp.github.io/) módulos que fornecem função utilitária útil; ver [Módulos utilitários](/{{ page.lang }}/resources/utils.html).
+- [jshttp](https://github.com/jshttp) módulos que fornecem função utilitária útil; ver [Módulos utilitários](/{{ page.lang }}/resources/utils.html).
 - [pillarjs](https://pillarjs.github.io/): módulos de baixo nível que o Express usa internamente.
 
 Para acompanhar o que está acontecendo em toda a comunidade, Confira a [ExpressJS StatusBoard](https://expressjs.github.io/statusboard/).

--- a/zh-cn/resources/community.md
+++ b/zh-cn/resources/community.md
@@ -45,7 +45,7 @@ Members of the Express technical committee are:
 Additionally, the Express community maintains modules in these two GitHub orgs:
 
 - [jshttp](https://github.com/jshttp) modules providing useful utility functions; see [Utility modules](/{{ page.lang }}/resources/utils.html).
-- [pillarjs](https://pillarjs.github.io/): low-level modules that Express uses internally.
+- [pillarjs](https://github.com/pillarjs): low-level modules that Express uses internally.
 
 To keep up with what is going on in the whole community, check out the [ExpressJS StatusBoard](https://expressjs.github.io/statusboard/).
 

--- a/zh-cn/resources/community.md
+++ b/zh-cn/resources/community.md
@@ -44,7 +44,7 @@ Members of the Express technical committee are:
 
 Additionally, the Express community maintains modules in these two GitHub orgs:
 
-- [jshttp](https://jshttp.github.io/) modules providing useful utility functions; see [Utility modules](/{{ page.lang }}/resources/utils.html).
+- [jshttp](https://github.com/jshttp) modules providing useful utility functions; see [Utility modules](/{{ page.lang }}/resources/utils.html).
 - [pillarjs](https://pillarjs.github.io/): low-level modules that Express uses internally.
 
 To keep up with what is going on in the whole community, check out the [ExpressJS StatusBoard](https://expressjs.github.io/statusboard/).

--- a/zh-cn/starter/examples.md
+++ b/zh-cn/starter/examples.md
@@ -15,7 +15,6 @@ These are some additional examples with more extensive integrations.
 
 {% include community-caveat.html %}
 
-- [prisma-fullstack](https://github.com/prisma/prisma-examples/tree/latest/pulse/fullstack-simple-chat) - Fullstack app with Express and Next.js using [Prisma](https://www.npmjs.com/package/prisma) as an ORM
 - [prisma-rest-api-ts](https://github.com/prisma/prisma-examples/tree/latest/orm/express) - REST API with Express in TypeScript using [Prisma](https://www.npmjs.com/package/prisma) as an ORM
 
 ### [Previous: Static Files ](/{{ page.lang }}/starter/static-files.html)&nbsp;&nbsp;&nbsp;&nbsp;[Next: FAQ ](/{{ page.lang }}/starter/faq.html)

--- a/zh-tw/resources/community.md
+++ b/zh-tw/resources/community.md
@@ -45,7 +45,7 @@ Members of the Express technical committee are:
 Additionally, the Express community maintains modules in these two GitHub orgs:
 
 - [jshttp](https://github.com/jshttp) modules providing useful utility functions; see [Utility modules](/{{ page.lang }}/resources/utils.html).
-- [pillarjs](https://pillarjs.github.io/): low-level modules that Express uses internally.
+- [pillarjs](https://github.com/pillarjs): low-level modules that Express uses internally.
 
 To keep up with what is going on in the whole community, check out the [ExpressJS StatusBoard](https://expressjs.github.io/statusboard/).
 

--- a/zh-tw/resources/community.md
+++ b/zh-tw/resources/community.md
@@ -44,7 +44,7 @@ Members of the Express technical committee are:
 
 Additionally, the Express community maintains modules in these two GitHub orgs:
 
-- [jshttp](https://jshttp.github.io/) modules providing useful utility functions; see [Utility modules](/{{ page.lang }}/resources/utils.html).
+- [jshttp](https://github.com/jshttp) modules providing useful utility functions; see [Utility modules](/{{ page.lang }}/resources/utils.html).
 - [pillarjs](https://pillarjs.github.io/): low-level modules that Express uses internally.
 
 To keep up with what is going on in the whole community, check out the [ExpressJS StatusBoard](https://expressjs.github.io/statusboard/).

--- a/zh-tw/starter/examples.md
+++ b/zh-tw/starter/examples.md
@@ -15,7 +15,6 @@ These are some additional examples with more extensive integrations.
 
 {% include community-caveat.html %}
 
-- [prisma-fullstack](https://github.com/prisma/prisma-examples/tree/latest/pulse/fullstack-simple-chat) - Fullstack app with Express and Next.js using [Prisma](https://www.npmjs.com/package/prisma) as an ORM
 - [prisma-rest-api-ts](https://github.com/prisma/prisma-examples/tree/latest/orm/express) - REST API with Express in TypeScript using [Prisma](https://www.npmjs.com/package/prisma) as an ORM
 
 ### [Previous: Static Files ](/{{ page.lang }}/starter/static-files.html)&nbsp;&nbsp;&nbsp;&nbsp;[Next: FAQ ](/{{ page.lang }}/starter/faq.html)


### PR DESCRIPTION
Towards #1100 

My initial goal was to come up with a workflow, [but the outcome was not really reliable](https://github.com/efekrskl/expressjs.com/actions/runs/18627609284/job/53107790131?pr=3). Considering the efforts at #1787 it's probably time not so well spent. So I'd fix some of the broken links instead

<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
