### PR TITLE
docs(express.static): add accept-ranges and cache-control options to express.static

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,6 +40,7 @@ GEM
       logger
     faraday-net_http (3.3.0)
       net-http
+    ffi (1.17.0-aarch64-linux-gnu)
     ffi (1.17.0-x64-mingw-ucrt)
     ffi (1.17.0-x86_64-linux-gnu)
     forwardable-extended (2.6.0)
@@ -229,6 +230,8 @@ GEM
     minitest (5.25.1)
     net-http (0.4.1)
       uri
+    nokogiri (1.18.9-aarch64-linux-gnu)
+      racc (~> 1.4)
     nokogiri (1.18.9-x64-mingw-ucrt)
       racc (~> 1.4)
     nokogiri (1.18.9-x86_64-linux-gnu)
@@ -268,6 +271,7 @@ GEM
     webrick (1.9.1)
 
 PLATFORMS
+  aarch64-linux
   x64-mingw-ucrt
   x86_64-linux
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -267,7 +267,7 @@ GEM
     uri (0.13.2)
     webrick (1.9.1)
 
-PLATFORMS  
+PLATFORMS
   x64-mingw-ucrt
   x86_64-linux
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,7 +40,6 @@ GEM
       logger
     faraday-net_http (3.3.0)
       net-http
-    ffi (1.17.0-aarch64-linux-gnu)
     ffi (1.17.0-x64-mingw-ucrt)
     ffi (1.17.0-x86_64-linux-gnu)
     forwardable-extended (2.6.0)
@@ -230,8 +229,6 @@ GEM
     minitest (5.25.1)
     net-http (0.4.1)
       uri
-    nokogiri (1.18.9-aarch64-linux-gnu)
-      racc (~> 1.4)
     nokogiri (1.18.9-x64-mingw-ucrt)
       racc (~> 1.4)
     nokogiri (1.18.9-x86_64-linux-gnu)
@@ -270,8 +267,7 @@ GEM
     uri (0.13.2)
     webrick (1.9.1)
 
-PLATFORMS
-  aarch64-linux
+PLATFORMS  
   x64-mingw-ucrt
   x86_64-linux
 

--- a/_includes/api/en/4x/express.static.md
+++ b/_includes/api/en/4x/express.static.md
@@ -30,6 +30,8 @@ See also the [example below](#example.of.express.static).
 | `maxAge`      | Set the max-age property of the Cache-Control header in milliseconds or a string in [ms format](https://www.npmjs.org/package/ms). | Number | 0 |
 | `redirect`    | Redirect to trailing "/" when the pathname is a directory. | Boolean | `true` |
 | `setHeaders`  | Function for setting HTTP headers to serve with the file. <br/><br/>See [setHeaders](#setHeaders) below. | Function |  |
+| `acceptRanges`    | Enable or disable accepting ranged requests. Disabling this will not send the Accept-Ranges header and will ignore the contents of the Range request header.  <br/><br/>See [acceptRanges](#acceptRanges) below. | Boolean | true |
+| `cacheControl`    | Enable or disable setting the Cache-Control response header. Disabling this will ignore the immutable and maxAge options.  <br/><br/>See [cacheControl](#cacheControl) below. | Boolean | true |
 
 </div>
 
@@ -57,6 +59,17 @@ to the same web address or for routes to fill in non-existent files.
 Use `false` if you have mounted this middleware at a path designed
 to be strictly a single file system directory, which allows for short-circuiting 404s
 for less overhead. This middleware will also reply to all methods.
+
+<h5 id='acceptRanges'>acceptRanges</h5>
+
+Enable or disable accepting ranged requests, defaults to true.
+Disabling this will not send `Accept-Ranges` and ignore the contents
+of the `Range` request header.
+
+<h5 id='cacheControl'>cacheControl</h5>
+
+Enable or disable setting `Cache-Control` response header, defaults to
+true. Disabling this will ignore the `immutable` and `maxAge` options.
 
 <h5 id='setHeaders'>setHeaders</h5>
 

--- a/_includes/api/en/4x/express.static.md
+++ b/_includes/api/en/4x/express.static.md
@@ -30,8 +30,8 @@ See also the [example below](#example.of.express.static).
 | `maxAge`      | Set the max-age property of the Cache-Control header in milliseconds or a string in [ms format](https://www.npmjs.org/package/ms). | Number | 0 |
 | `redirect`    | Redirect to trailing "/" when the pathname is a directory. | Boolean | `true` |
 | `setHeaders`  | Function for setting HTTP headers to serve with the file. <br/><br/>See [setHeaders](#setHeaders) below. | Function |  |
-| `acceptRanges`    | Enable or disable accepting ranged requests. Disabling this will not send the Accept-Ranges header and will ignore the contents of the Range request header.  <br/><br/>See [acceptRanges](#acceptRanges) below. | Boolean | true |
-| `cacheControl`    | Enable or disable setting the Cache-Control response header. Disabling this will ignore the immutable and maxAge options.  <br/><br/>See [cacheControl](#cacheControl) below. | Boolean | true |
+| `acceptRanges`    | Enable or disable accepting ranged requests. Disabling this will not send the `Accept-Ranges` header and will ignore the contents of the Range request header.| Boolean | true |
+| `cacheControl`    | Enable or disable setting the `Cache-Control` response header. Disabling this will ignore the immutable and maxAge options. | Boolean | true |
 
 </div>
 
@@ -59,17 +59,6 @@ to the same web address or for routes to fill in non-existent files.
 Use `false` if you have mounted this middleware at a path designed
 to be strictly a single file system directory, which allows for short-circuiting 404s
 for less overhead. This middleware will also reply to all methods.
-
-<h5 id='acceptRanges'>acceptRanges</h5>
-
-Enable or disable accepting ranged requests, defaults to true.
-Disabling this will not send `Accept-Ranges` and ignore the contents
-of the `Range` request header.
-
-<h5 id='cacheControl'>cacheControl</h5>
-
-Enable or disable setting `Cache-Control` response header, defaults to
-true. Disabling this will ignore the `immutable` and `maxAge` options.
 
 <h5 id='setHeaders'>setHeaders</h5>
 

--- a/_includes/api/en/5x/express.static.md
+++ b/_includes/api/en/5x/express.static.md
@@ -28,8 +28,8 @@ See also the [example below](#example.of.express.static).
 | `maxAge`      | Set the max-age property of the Cache-Control header in milliseconds or a string in [ms format](https://www.npmjs.org/package/ms). | Number | 0 |
 | `redirect`    | Redirect to trailing "/" when the pathname is a directory. | Boolean | `true` |
 | `setHeaders`  | Function for setting HTTP headers to serve with the file. <br/><br/>See [setHeaders](#setHeaders) below. | Function |  |
-| `acceptRanges`    | Enable or disable accepting ranged requests. Disabling this will not send the Accept-Ranges header and will ignore the contents of the Range request header.  <br/><br/>See [acceptRanges](#acceptRanges) below. | Boolean | true |
-| `cacheControl`    | Enable or disable setting the Cache-Control response header. Disabling this will ignore the immutable and maxAge options.  <br/><br/>See [cacheControl](#cacheControl) below. | Boolean | true |
+| `acceptRanges`    | Enable or disable accepting ranged requests. Disabling this will not send the Accept-Ranges header and will ignore the contents of the Range request header.| Boolean | true |
+| `cacheControl`    | Enable or disable setting the Cache-Control response header. Disabling this will ignore the immutable and maxAge options. | Boolean | true |
 
 </div>
 
@@ -56,17 +56,6 @@ to the same web address or for routes to fill in non-existent files.
 Use `false` if you have mounted this middleware at a path designed
 to be strictly a single file system directory, which allows for short-circuiting 404s
 for less overhead. This middleware will also reply to all methods.
-
-<h5 id='acceptRanges'>acceptRanges</h5>
-
-Enable or disable accepting ranged requests, defaults to true.
-Disabling this will not send `Accept-Ranges` and ignore the contents
-of the `Range` request header.
-
-<h5 id='cacheControl'>cacheControl</h5>
-
-Enable or disable setting `Cache-Control` response header, defaults to
-true. Disabling this will ignore the `immutable` and `maxAge` options.
 
 <h5 id='setHeaders'>setHeaders</h5>
 

--- a/_includes/api/en/5x/express.static.md
+++ b/_includes/api/en/5x/express.static.md
@@ -28,6 +28,8 @@ See also the [example below](#example.of.express.static).
 | `maxAge`      | Set the max-age property of the Cache-Control header in milliseconds or a string in [ms format](https://www.npmjs.org/package/ms). | Number | 0 |
 | `redirect`    | Redirect to trailing "/" when the pathname is a directory. | Boolean | `true` |
 | `setHeaders`  | Function for setting HTTP headers to serve with the file. <br/><br/>See [setHeaders](#setHeaders) below. | Function |  |
+| `acceptRanges`    | Enable or disable accepting ranged requests. Disabling this will not send the Accept-Ranges header and will ignore the contents of the Range request header.  <br/><br/>See [acceptRanges](#acceptRanges) below. | Boolean | true |
+| `cacheControl`    | Enable or disable setting the Cache-Control response header. Disabling this will ignore the immutable and maxAge options.  <br/><br/>See [cacheControl](#cacheControl) below. | Boolean | true |
 
 </div>
 
@@ -54,6 +56,17 @@ to the same web address or for routes to fill in non-existent files.
 Use `false` if you have mounted this middleware at a path designed
 to be strictly a single file system directory, which allows for short-circuiting 404s
 for less overhead. This middleware will also reply to all methods.
+
+<h5 id='acceptRanges'>acceptRanges</h5>
+
+Enable or disable accepting ranged requests, defaults to true.
+Disabling this will not send `Accept-Ranges` and ignore the contents
+of the `Range` request header.
+
+<h5 id='cacheControl'>cacheControl</h5>
+
+Enable or disable setting `Cache-Control` response header, defaults to
+true. Disabling this will ignore the `immutable` and `maxAge` options.
 
 <h5 id='setHeaders'>setHeaders</h5>
 


### PR DESCRIPTION
Added missisng accept ranges and cachecontrol in _includes/api/en/4x/express.static.md and _includes/api/en/5x/express.static.md