### PR TITLE
Add Nodemon usage instructions for live server restarting

### DIFF
--- a/en/starter/generator.md
+++ b/en/starter/generator.md
@@ -74,6 +74,20 @@ Then install dependencies:
 ```bash
 $ cd myapp
 $ npm install
+
+## Using Nodemon for Live Server Restarting
+Nodemon automatically restarts your Node.js server whenever you make changes to your files — perfect for development.
+ Installation
+npm install --save-dev nodemon
+Add to Scripts
+In your package.json:
+"scripts": {
+  "start": "nodemon server.js"
+}
+Run the Server
+npm start
+or
+npx nodemon server.js
 ```
 
 On MacOS or Linux, run the app with this command:


### PR DESCRIPTION
Added instructions for using Nodemon to restart the Node.js server automatically during development.

<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
