### PR TITLE
style: remove inconsistent spacing in callout CSS rules

### DIFF
--- a/css/langs/zh-tw.css
+++ b/css/langs/zh-tw.css
@@ -1,6 +1,6 @@
 /* For image callouts in writing-middleware.md */
 
-#callout1 {top: 40px; }
+#callout1 {top: 40px;}
 
 #callout2 {top: 60px;}
 


### PR DESCRIPTION
Removed extra whitespace before closing braces in #callout1 rule to match formatting used in #callout2 and other CSS rules. Ensures consistent code style.

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
