### PR TITLE
blog: update the link for the captains

### DIFF
--- a/_posts/2025-06-05-vulnerability-reporting-process-overhaul.md
+++ b/_posts/2025-06-05-vulnerability-reporting-process-overhaul.md
@@ -39,7 +39,7 @@ Security Advisories are now enabled across all Express.js repositories, allowing
 
 Expectations around ownership and response timelines have been clarified and published to reduce ambiguity and improve responsiveness.  
 
-> A [Security triage team member](https://github.com/expressjs/security-wg#security-triage-team) or [the repo captain](https://github.com/expressjs/express/blob/master/Contributing.md#active-projects-and-captains) will acknowledge your report as soon as possible.
+> A [Security triage team member](https://github.com/expressjs/security-wg#security-triage-team)  will acknowledge your report as soon as possible.
 >
 > After the initial reply to your report, the security team will
 endeavor to keep you informed of the progress towards a fix and full

--- a/_posts/2025-06-05-vulnerability-reporting-process-overhaul.md
+++ b/_posts/2025-06-05-vulnerability-reporting-process-overhaul.md
@@ -39,7 +39,7 @@ Security Advisories are now enabled across all Express.js repositories, allowing
 
 Expectations around ownership and response timelines have been clarified and published to reduce ambiguity and improve responsiveness.  
 
-> A [Security triage team member](https://github.com/expressjs/security-wg#security-triage-team)  will acknowledge your report as soon as possible.
+> A [Security triage team member](https://github.com/expressjs/security-wg#security-triage-team) or [the repo captain](https://github.com/expressjs/discussions/blob/master/docs/contributing/captains_and_committers.md) will acknowledge your report as soon as possible.
 >
 > After the initial reply to your report, the security team will
 endeavor to keep you informed of the progress towards a fix and full


### PR DESCRIPTION
Removed mention of the repo captain from the acknowledgment process because hyperlink returned a 404 - Page Not Found error. Removed the outdated “repo captain” reference from the Security Policy . The acknowledgment responsibility is already covered by the “Security triage team member” mentioned in the same paragraph.
<img width="1893" height="501" alt="image" src="https://github.com/user-attachments/assets/b614718c-8211-428c-a701-acb4fb791995" />

<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
