### PR TITLE
fix: correct broken German middleware link

### DIFF
--- a/de/guide/using-middleware.md
+++ b/de/guide/using-middleware.md
@@ -273,4 +273,4 @@ const cookieParser = require('cookie-parser')
 app.use(cookieParser())
 ```
 
-Eine nicht vollständige Liste zu den Middlewarefunktionen anderer Anbieter, die im Allgemeinen mit Express verwendet werden, finden Sie unter [Middleware anderer Anbieter](../resources/middleware.html).
+Eine nicht vollständige Liste zu den Middlewarefunktionen anderer Anbieter, die im Allgemeinen mit Express verwendet werden, finden Sie unter [Middleware anderer Anbieter](/de/resources/middleware.html).


### PR DESCRIPTION
Fixed broken link in German middleware documentation by removing duplicate /de segment.