### PR TITLE
docs: add example for req.accepts usage

### DIFF
--- a/_includes/api/en/5x/req-accepts.md
+++ b/_includes/api/en/5x/req-accepts.md
@@ -33,4 +33,24 @@ req.accepts(['html', 'json'])
 // => "json"
 ```
 
+#### Example
+
+```js
+app.get('/resource', function (req, res) {
+  // Check which response type the client prefers
+  const type = req.accepts(['json', 'html'])
+
+  if (type === 'json') {
+    return res.json({ message: 'Hello world' })
+  }
+
+  if (type === 'html') {
+    return res.send('<p>Hello world</p>')
+  }
+
+  // If none of the supported types are acceptable
+  res.status(406).send('Not Acceptable')
+})
+
+
 For more information, or if you have issues or concerns, see [accepts](https://github.com/expressjs/accepts).


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

### What this PR does
Adds a practical example demonstrating how `req.accepts()` can be used
to respond with different content types and handle unsupported formats.

### Why
The existing documentation explains the method but lacks a concrete
example, which can be confusing for new users.

### Checklist
- [v] Documentation only
- [v] No behavior changes
- [v] Tests pass

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
