### PR TITLE
docs: add manual setup guide for Handlebarsdocs

### DIFF
--- a/en/guide/using-template-engines.md
+++ b/en/guide/using-template-engines.md
@@ -20,19 +20,20 @@ To render template files, set the following [application setting properties](/{{
 * `views`, the directory where the template files are located. Eg: `app.set('views', './views')`.
 This defaults to the `views` directory in the application root directory.
 * `view engine`, the template engine to use. For example, to use the Pug template engine: `app.set('view engine', 'pug')`.
+
 ### Manual Setup (Without Generator)
-+
-+ If you are not using the Express generator, you must manually configure the engine to ensure Express can interface with it properly. While engines like Pug work out of the box, others (like Handlebars) require a specific wrapper package.
-+
-+ For example, to use Handlebars manually:
-+ 1. Install the `express-handlebars` package: `$ npm install express-handlebars`
-+ 2. Configure it in your `app.js`:
-+
-+ ```js
-+ const { engine } = require('express-handlebars');
-+ app.engine('handlebars', engine());
-+ app.set('view engine', 'handlebars');
-+ ```
+
+If you are not using the Express generator, you must manually configure the engine to ensure Express can interface with it properly. While engines like Pug work out of the box, others (like Handlebars) require a specific wrapper package.
+
+For example, to use Handlebars manually:
+
+1. Install the `express-handlebars` package: `$ npm install express-handlebars`
+2. Configure it in your `app.js`:
+
+```js
+const { engine } = require('express-handlebars');
+app.engine('handlebars', engine());
+app.set('view engine', 'handlebars');
 Then install the corresponding template engine npm package; for example to install Pug:
 
 ```bash

--- a/en/guide/using-template-engines.md
+++ b/en/guide/using-template-engines.md
@@ -31,9 +31,9 @@ For example, to use Handlebars manually:
 2. Configure it in your `app.js`:
 
 ```js
-const { engine } = require('express-handlebars');
-app.engine('handlebars', engine());
-app.set('view engine', 'handlebars');
+const { engine } = require('express-handlebars')
+app.engine('handlebars', engine())
+app.set('view engine', 'handlebars')
 ```
 Then install the corresponding template engine npm package; for example to install Pug:
 

--- a/en/guide/using-template-engines.md
+++ b/en/guide/using-template-engines.md
@@ -22,6 +22,7 @@ This defaults to the `views` directory in the application root directory.
 * `view engine`, the template engine to use. For example, to use the Pug template engine: `app.set('view engine', 'pug')`.
 
 ### Manual Setup (Without Generator)
+
 If you are not using the Express generator, you must manually configure the engine to ensure Express can interface with it properly. While engines like Pug work out of the box, others (like Handlebars) require a specific wrapper package.
 
 For example, to use Handlebars manually:
@@ -33,6 +34,7 @@ For example, to use Handlebars manually:
 const { engine } = require('express-handlebars');
 app.engine('handlebars', engine());
 app.set('view engine', 'handlebars');
+```
 Then install the corresponding template engine npm package; for example to install Pug:
 
 ```bash

--- a/en/guide/using-template-engines.md
+++ b/en/guide/using-template-engines.md
@@ -22,7 +22,6 @@ This defaults to the `views` directory in the application root directory.
 * `view engine`, the template engine to use. For example, to use the Pug template engine: `app.set('view engine', 'pug')`.
 
 ### Manual Setup (Without Generator)
-
 If you are not using the Express generator, you must manually configure the engine to ensure Express can interface with it properly. While engines like Pug work out of the box, others (like Handlebars) require a specific wrapper package.
 
 For example, to use Handlebars manually:

--- a/en/guide/using-template-engines.md
+++ b/en/guide/using-template-engines.md
@@ -21,6 +21,20 @@ To render template files, set the following [application setting properties](/{{
 This defaults to the `views` directory in the application root directory.
 * `view engine`, the template engine to use. For example, to use the Pug template engine: `app.set('view engine', 'pug')`.
 
+### Manual Setup (Without Generator)
++
++ If you are not using the Express generator, you must manually configure the engine to ensure Express can interface with it properly. While engines like Pug work out of the box, others (like Handlebars) require a specific wrapper package.
++
++ For example, to use Handlebars manually:
++ 1. Install the `express-handlebars` package: `$ npm install express-handlebars`
++ 2. Configure it in your `app.js`:
++
++ ```js
++ const { engine } = require('express-handlebars');
++ app.engine('handlebars', engine());
++ app.set('view engine', 'handlebars');
++ ```
+
 Then install the corresponding template engine npm package; for example to install Pug:
 
 ```bash

--- a/en/guide/using-template-engines.md
+++ b/en/guide/using-template-engines.md
@@ -20,7 +20,6 @@ To render template files, set the following [application setting properties](/{{
 * `views`, the directory where the template files are located. Eg: `app.set('views', './views')`.
 This defaults to the `views` directory in the application root directory.
 * `view engine`, the template engine to use. For example, to use the Pug template engine: `app.set('view engine', 'pug')`.
-
 ### Manual Setup (Without Generator)
 +
 + If you are not using the Express generator, you must manually configure the engine to ensure Express can interface with it properly. While engines like Pug work out of the box, others (like Handlebars) require a specific wrapper package.
@@ -34,7 +33,6 @@ This defaults to the `views` directory in the application root directory.
 + app.engine('handlebars', engine());
 + app.set('view engine', 'handlebars');
 + ```
-
 Then install the corresponding template engine npm package; for example to install Pug:
 
 ```bash


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
### Description
This PR addresses a documentation gap in the "Using template engines with Express" guide. Currently, the documentation assumes users are using the `express-generator`. Developers building applications manually often encounter `Error: Module "handlebars" does not provide a view engine` because the core `handlebars` package is not Express-compliant without a wrapper.

### Changes
- Added a **Manual Setup (Without Generator)** section.
- Included a clear code example for manually configuring the `express-handlebars` engine using `app.engine()`.
- Clarified the distinction between the core library and the necessary Express adapter.

### Impact
Improves the developer experience (DX) for users building minimal or custom Express configurations, reducing common setup errors.

### Related Issues
Fixes #2128 