### PR TITLE
docs: add explanation of middleware execution order

### DIFF
--- a/en/guide/using-middleware.md
+++ b/en/guide/using-middleware.md
@@ -33,6 +33,26 @@ An Express application can use the following types of middleware:
 You can load application-level and router-level middleware with an optional mount path.
 You can also load a series of middleware functions together, which creates a sub-stack of the middleware system at a mount point.
 
+<h2 id="middleware.order">Middleware execution order (Important)</h2>
+
+Middleware functions in Express are executed **in the order they are defined**.
+
+This means the position of `app.use()` and route handlers in your code
+directly affects how requests are processed.
+
+Consider the following example:
+
+```js
+const express = require('express')
+const app = express()
+
+app.use(express.json())
+
+app.get('/user', (req, res) => {
+  res.send(req.body)
+})
+
+
 <h2 id='middleware.application'>Application-level middleware</h2>
 
 Bind application-level middleware to an instance of the [app object](/{{ page.lang }}/5x/api.html#app) by using the `app.use()` and `app.METHOD()` functions, where `METHOD` is the HTTP method of the request that the middleware function handles (such as GET, PUT, or POST) in lowercase.


### PR DESCRIPTION

Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 
Adds a new section explaining how middleware execution order works in Express,
with examples showing why middleware must be defined before routes.
This aims to reduce common beginner confusion around middleware order.



Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
