### PR TITLE
ci(deploy): ensure .well-known dir is uploaded to gh-pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,9 +33,11 @@ jobs:
         run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
         env:
           JEKYLL_ENV: production
-      - name: Upload artifact
-        # Automatically uploads an artifact from the './_site' directory by default
+      - name: Upload gh-pages artifact
         uses: actions/upload-pages-artifact@v4
+        with:
+          path: _site
+          include-hidden-files: true # required for /.well-known/security.txt
 
   deploy:
     environment:


### PR DESCRIPTION
fixes issue in https://github.com/expressjs/expressjs.com/pull/1974#issuecomment-3770111739 where the `.well-known/security.txt` was not being published to GH pages

That upload-pages-artifact action wraps the upload-artifact action which has this config option: https://github.com/actions/upload-artifact#usage

since `_site` is built fresh each time, we shouldnt need to worry about any credentials getting uploaded or anything