### PR TITLE
deploy: create tar archive for gh-pages manually

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,24 +20,31 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
       - name: Setup Ruby
         uses: ruby/setup-ruby@8d27f39a5e7ad39aebbcbd1324f7af020229645c $ v1.287.0
         with:
-          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-          cache-version: 0 # Increment this number if you need to re-download cached gems
+          bundler-cache: true
+
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
+
       - name: Build with Jekyll
-        # Outputs to the './_site' directory by default
         run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
         env:
           JEKYLL_ENV: production
-      - name: Upload gh-pages artifact
-        uses: actions/upload-pages-artifact@v4
+
+      # doing this ourselves to get .well-known included
+      # https://github.com/actions/upload-pages-artifact/issues/129
+      - name: Create pages artifact
+        run: tar -cf "$RUNNER_TEMP/github-pages.tar" -C _site .
+
+      - name: Upload pages artifact
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
-          path: _site
-          include-hidden-files: true # required for /.well-known/security.txt
+          name: github-pages
+          path: ${{ runner.temp }}/github-pages.tar
 
   deploy:
     environment:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,15 +19,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
-      - name: Setup Ruby    
-        uses: ruby/setup-ruby@4c24fa5ec04b2e79eb40571b1cee2a0d2b705771 # https://github.com/ruby/setup-ruby/releases/tag/v1.278.0
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@8d27f39a5e7ad39aebbcbd1324f7af020229645c $ v1.287.0
         with:
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
           cache-version: 0 # Increment this number if you need to re-download cached gems
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
       - name: Build with Jekyll
         # Outputs to the './_site' directory by default
         run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
@@ -48,4 +48,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5


### PR DESCRIPTION
[upload-pages-artifact](https://github.com/actions/upload-pages-artifact) excludes hidden files, so .well-known isnt being
published. see https://github.com/actions/upload-pages-artifact/issues/129

This PR drops that action to tar the _site dir ourselves and hands it
off to upload-artifact for publishing.

We probably don't even need to use that action if it ever has the config
changed (creating the tar is a one liner), but I'll open a PR to them with a `include-hidden-files` option
Edit: [PR to upstream](https://github.com/actions/upload-pages-artifact/pull/137) w/ the option