### PR TITLE
feat: add OpenJS trademark notice to footer (fixes #2172)

### DIFF
--- a/_data/en/footer.yml
+++ b/_data/en/footer.yml
@@ -4,3 +4,4 @@ coc: Code of Conduct
 trademark_policy: Trademark Policy
 security_policy: Security Policy
 license: License
+trademark_legal: Copyright <a href='https://openjsf.org'>OpenJS Foundation</a> and Express contributors. All rights reserved. The <a href='https://openjsf.org'>OpenJS Foundation</a> has registered trademarks and uses trademarks. For a list of trademarks of the <a href='https://openjsf.org'>OpenJS Foundation</a>, please see our <a href='https://trademark-policy.openjsf.org'>Trademark Policy</a> and <a href='https://trademark-list.openjsf.org'>Trademark List</a>. Trademarks and logos not indicated on the <a href='https://trademark-list.openjsf.org'>list of OpenJS Foundation trademarks</a> are trademarks™ or registered® trademarks of their respective holders. Use of them does not imply any affiliation with or endorsement by them.

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -6,6 +6,9 @@
       <a href="https://openjsf.org/" class="openjs-logo" title="OpenJS Foundation">
          {% include icons/openjs_foundation-logo-horizontal-white.svg %}
       </a>
+      <p id="footer-trademark-legal">
+        {{ site.data[page.lang].footer.trademark_legal | default: site.data.en.footer.trademark_legal }}
+      </p>
       <div id="footer-policy">
         <a href="https://terms-of-use.openjsf.org">
           {{ site.data[page.lang].footer.terms_of_use }}

--- a/css/style.css
+++ b/css/style.css
@@ -735,12 +735,21 @@ footer {
   justify-content: space-between;
   gap: 32px;
   display: flex;
+  flex-direction: column;
+}
+
+#footer-trademark-legal {
+  font-size: 0.8rem;
+  opacity: 0.8;
+  margin-top: 8px;
+  text-align: center;
 }
 
 #footer-copyright {
   display: flex;
   flex-direction: column;
   justify-content: center;
+  align-items: center;
   gap: 20px;
 }
 


### PR DESCRIPTION
### Description
This PR updates the footer to include the required OpenJS Foundation trademark notice as requested in issue #2172.

### Changes Made
- Added the trademark legal text to `_data/en.yml`.
- Updated `_includes/footer.html` to display the text.
- Added a new CSS rule `#footer-trademark-legal` in `css/style.css` to style the text (opacity, font-size) consistent with the footer design.

### ⚠️ Note on Localization (Important)
Since this is a legal trademark notice, I assumed it should remain in English for all locales unless an official translation is provided.

Instead of duplicating the English text across all language files (`es.yml`, `fr.yml`, etc.) which would violate DRY principles, I implemented a **Liquid fallback** in the footer template:

```liquid
{{ site.data[page.lang].footer.trademark_legal | default: site.data.en.footer.trademark_legal }}