### PR TITLE
fix: limit trademark line length so it doesnt stretch

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -743,6 +743,7 @@ footer {
   opacity: 0.8;
   margin-top: 8px;
   text-align: center;
+  max-width: 35rem;
 }
 
 #footer-copyright {


### PR DESCRIPTION
After #2178  on desktop the trademark line stretches:
<img width="1413" height="758" alt="Screenshot 2026-02-04 at 3 57 03 PM" src="https://github.com/user-attachments/assets/dff229c9-5f05-4187-9eae-8dd77bd83a08" />


This PR limits it to `35rem` which looks like:
<img width="1413" height="758" alt="Screenshot 2026-02-04 at 3 59 17 PM" src="https://github.com/user-attachments/assets/c4486e54-bd80-4e11-9ab3-19569045f32c" />


Mobile doesn't change much
Before:
<img width="401" height="371" alt="Screenshot 2026-02-04 at 4 00 45 PM" src="https://github.com/user-attachments/assets/85091bfb-eeea-4f7e-a1f1-5593e60fbca2" />


After:
<img width="401" height="371" alt="Screenshot 2026-02-04 at 4 00 35 PM" src="https://github.com/user-attachments/assets/291fc54e-596e-4071-8a5a-676d61a5a40b" />

