### PR TITLE
fix(navmenu): enable scrolling at 400% zoom for accessibility

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,3 +1,7 @@
+:root {
+  --header-height: 57px;
+}
+
 * {
   box-sizing: border-box;
   -webkit-tap-highlight-color: transparent;
@@ -34,6 +38,7 @@ body {
 
 header {
   grid-area: header;
+  height: var(--header-height);
 }
 
 .content {
@@ -1699,6 +1704,9 @@ blockquote {
 
   #navmenu.opens {
     display: block;
+    max-height: calc(100dvh - var(--header-height));
+    overflow-y: auto;
+    overscroll-behavior: contain;
   }
 
   #navbar a {


### PR DESCRIPTION
This change constrains the menu height relative to the fixed header using a CSS variable and enables vertical scrolling within the menu container. The layout and visual design remain unchanged.

Fixes #1731
