### PR TITLE
Adjust layout content width for responsive sidebar

### DIFF
--- a/astro/src/styles/base/_global.css
+++ b/astro/src/styles/base/_global.css
@@ -272,15 +272,16 @@ must be updated as well.
 */
 
 .layout-content {
-  max-width: calc(100dvw - 16px); 
+  max-width: calc(100dvw - 16px);
 }
 
 @media (--md-up) {
   .layout-content {
     max-width: calc(100dvw - 116px);
   }
-  
-  .layout-wrapper:has([data-toggle-nested-button][data-visible="true"][aria-expanded="true"]) .layout-content {
+
+  .layout-wrapper:has([data-toggle-nested-button][data-visible='true'][aria-expanded='true'])
+    .layout-content {
     max-width: calc(100dvw - 372px);
   }
 }

--- a/astro/src/styles/base/_global.css
+++ b/astro/src/styles/base/_global.css
@@ -248,3 +248,39 @@ main {
     background-color: var(--color-bg-primary);
   }
 }
+
+/*
+Layout width logic
+
+Mobile
+Content width = 100dvw - 16px
+
+Tablet
+Content width = 100dvw - 116px
+This includes the main sidebar column.
+
+Tablet with nested sidebar open
+Content width = 100dvw - 372px
+This includes the main sidebar column + nested sidebar.
+
+Important maintenance notes
+If the sidebar width changes, these max-width values must be updated to match.
+
+If the toggle button attributes (data-toggle-nested-button or aria-expanded)
+are modified, the :has() selector used to detect the open nested sidebar
+must be updated as well.
+*/
+
+.layout-content {
+  max-width: calc(100dvw - 16px); 
+}
+
+@media (--md-up) {
+  .layout-content {
+    max-width: calc(100dvw - 116px);
+  }
+  
+  .layout-wrapper:has([data-toggle-nested-button][aria-expanded="true"]) .layout-content {
+    max-width: calc(100dvw - 372px);
+  }
+}

--- a/astro/src/styles/base/_global.css
+++ b/astro/src/styles/base/_global.css
@@ -249,39 +249,6 @@ main {
   }
 }
 
-/*
-Layout width logic
-
-Mobile
-Content width = 100dvw
-
-Tablet
-Content width = 100dvw - 100px
-This includes the main sidebar column.
-
-Tablet with nested sidebar open
-Content width = 100dvw - 356px
-This includes the main sidebar column + nested sidebar.
-
-Important maintenance notes
-If the sidebar width changes, these max-width values must be updated to match.
-
-If the toggle button attributes (data-toggle-nested-button, data-visible, or aria-expanded)
-are modified, the :has() selector used to detect the open nested sidebar
-must be updated as well.
-*/
-
 .layout-content {
-  max-width: calc(100dvw);
-}
-
-@media (--md-up) {
-  .layout-content {
-    max-width: calc(100dvw - 100px);
-  }
-
-  .layout-wrapper:has([data-toggle-nested-button][data-visible='true'][aria-expanded='true'])
-    .layout-content {
-    max-width: calc(100dvw - 356px);
-  }
+  min-width: 0;
 }

--- a/astro/src/styles/base/_global.css
+++ b/astro/src/styles/base/_global.css
@@ -266,7 +266,7 @@ This includes the main sidebar column + nested sidebar.
 Important maintenance notes
 If the sidebar width changes, these max-width values must be updated to match.
 
-If the toggle button attributes (data-toggle-nested-button or aria-expanded)
+If the toggle button attributes (data-toggle-nested-button, data-visible, or aria-expanded)
 are modified, the :has() selector used to detect the open nested sidebar
 must be updated as well.
 */
@@ -280,7 +280,7 @@ must be updated as well.
     max-width: calc(100dvw - 116px);
   }
   
-  .layout-wrapper:has([data-toggle-nested-button][aria-expanded="true"]) .layout-content {
+  .layout-wrapper:has([data-toggle-nested-button][data-visible="true"][aria-expanded="true"]) .layout-content {
     max-width: calc(100dvw - 372px);
   }
 }

--- a/astro/src/styles/base/_global.css
+++ b/astro/src/styles/base/_global.css
@@ -253,14 +253,14 @@ main {
 Layout width logic
 
 Mobile
-Content width = 100dvw - 16px
+Content width = 100dvw
 
 Tablet
-Content width = 100dvw - 116px
+Content width = 100dvw - 100px
 This includes the main sidebar column.
 
 Tablet with nested sidebar open
-Content width = 100dvw - 372px
+Content width = 100dvw - 356px
 This includes the main sidebar column + nested sidebar.
 
 Important maintenance notes
@@ -272,16 +272,16 @@ must be updated as well.
 */
 
 .layout-content {
-  max-width: calc(100dvw - 16px);
+  max-width: calc(100dvw);
 }
 
 @media (--md-up) {
   .layout-content {
-    max-width: calc(100dvw - 116px);
+    max-width: calc(100dvw - 100px);
   }
 
   .layout-wrapper:has([data-toggle-nested-button][data-visible='true'][aria-expanded='true'])
     .layout-content {
-    max-width: calc(100dvw - 372px);
+    max-width: calc(100dvw - 356px);
   }
 }


### PR DESCRIPTION
Adjusts content width behavior across breakpoints to better accommodate the sidebar layout and maintain consistent spacing in responsive views.

Video (before/after):

https://github.com/user-attachments/assets/92e71e3e-3463-4fd6-bdd3-8b204a752a39

