### PR TITLE
docs: add send options and methods changes to Express 5 migration guide

### DIFF
--- a/en/guide/migrating-5.md
+++ b/en/guide/migrating-5.md
@@ -56,8 +56,10 @@ You can find the list of available codemods [here](https://codemod.link/express)
   <li><a href="#res.send.body">res.send(body, status)</a></li>
   <li><a href="#res.send.status">res.send(status)</a></li>
   <li><a href="#res.sendfile">res.sendfile()</a></li>
+  <li><a href="#res.sendFile.options">res.sendFile() and express.static() options</a></li>
   <li><a href="#router.param">router.param(fn)</a></li>
   <li><a href="#express.static.mime">express.static.mime</a></li>
+  <li><a href="#send-methods">Removed send methods</a></li>
   <li><a href="#express:router-debug-logs">express:router debug logs</a></li>
 </ul>
 
@@ -401,6 +403,22 @@ express.static.mime.lookup('json')
 const mime = require('mime-types')
 mime.lookup('json')
 ```
+
+<h3 id="res.sendFile.options">res.sendFile() and express.static() options</h3>
+
+The following options to the `res.sendFile()` and `express.static()` functions are no longer supported:
+
+* `hidden`: Use the `dotfiles` option instead.
+* `from`: Use the `root` option instead.
+
+<h3 id="send-methods">Removed send methods</h3>
+
+The `send` package no longer exports the following methods. If your app relies on them, replace them with properties in the `options` object for `res.sendFile()` and `express.static()`:
+
+* `send.etag()`: Use the `etag` option instead.
+* `send.index()`: Use the `index` option instead.
+* `send.maxage()`: Use the `maxAge` option instead.
+* `send.root()`: Use the `root` option instead.
 
 <h3 id="express:router-debug-logs">express:router debug logs</h3>
 


### PR DESCRIPTION
## Description

Fixes #1868

Added missing documentation to the Express 5 migration guide for 
breaking changes from the `send` package that directly affect 
Express users upgrading from v4 to v5.

## Changes made

**`en/guide/migrating-5.md`**

- Added new section `res.sendFile() and express.static() options` 
  documenting removed options:
  - `hidden` → use `dotfiles` instead
  - `from` → use `root` instead

- Added new section `Removed send methods` documenting methods 
  no longer exported by the `send` package:
  - `send.etag()` → use `etag` option instead
  - `send.index()` → use `index` option instead
  - `send.maxage()` → use `maxAge` option instead
  - `send.root()` → use `root` option instead

- Updated table of contents with links to both new sections

## Motivation

Developers upgrading from Express 4 to Express 5 who relied on 
these options and methods would encounter silent breakage with 
no guidance in the migration guide. This PR fills that gap.