### PR TITLE
feat: add redirects for blog posts and legacy API links

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,7 +105,7 @@ jobs:
           workingDirectory: astro # TODO: change when Astro site is moved to root
           args: |
             --root-dir $PWD/dist
-            --remap 'https://expressjs\.com\/(.*[^/])/?$' file://'$PWD'/dist/$1/index.html'
-            --remap 'https://expressjs\.com\/(.*\.html)$ file://'$PWD'/dist/$1'
+            --remap "https://expressjs\.com\/(.*[^/])/?$ file://$PWD/dist/$1/index.html"
+            --remap "https://expressjs\.com\/(.*\.html)$ file://$PWD/dist/$1"
             dist/
           fail: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,6 +105,7 @@ jobs:
           workingDirectory: astro # TODO: change when Astro site is moved to root
           args: |
             --root-dir $PWD/dist
-            --remap 'https://expressjs\.com\/(.*)/ file://'$PWD'/dist/$1/index.html'
+            --remap 'https://expressjs\.com\/(.*[^/])/$ file://'$PWD'/dist/$1/index.html'
+            --remap 'https://expressjs\.com\/(.*\.html)$ file://'$PWD'/dist/$1'
             dist/
           fail: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,8 +105,7 @@ jobs:
           workingDirectory: astro # TODO: change when Astro site is moved to root
           args: |
             --root-dir $PWD/dist
-            --remap "https://expressjs\\.com\/(.*[^/\.]+)\/?$ file://$PWD/dist/\$1/index.html"
-            --remap "https://expressjs\\.com\/(.*\.html)$ file://$PWD/dist/\$1"
-            --remap "https://expressjs\\.com\/(.*\.(xml|json|svg|png|jpg|jpeg|webp))$ file://$PWD/dist/\$1"
+            --remap "https://expressjs\.com\/(.*[^/\.]+)\/?$ file://$PWD/dist/\$1/index.html"
+            --remap "https://expressjs\.com\/(.*\.html)$ file://$PWD/dist/\$1"
             dist/
           fail: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,7 +105,7 @@ jobs:
           workingDirectory: astro # TODO: change when Astro site is moved to root
           args: |
             --root-dir $PWD/dist
-            --remap "https://expressjs\.com\/(.*[^/])/?$ file://$PWD/dist/$1/index.html"
-            --remap "https://expressjs\.com\/(.*\.html)$ file://$PWD/dist/$1"
+            --remap "https://expressjs\.com\/(.*[^/])/?$ file://$PWD/dist/\$1/index.html"
+            --remap "https://expressjs\.com\/(.*\.html)$ file://$PWD/dist/\$1"
             dist/
           fail: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,7 +105,7 @@ jobs:
           workingDirectory: astro # TODO: change when Astro site is moved to root
           args: |
             --root-dir $PWD/dist
-            --remap "https://expressjs\.com\/(.+[^\/\.])\/?$ file://$PWD/dist/\$1/index.html"
+            --remap "https://expressjs\.com\/((?:[^\/]+\/)*[^\/\.]+)\/?$ file://$PWD/dist/\$1/index.html"
             --remap "https://expressjs\.com\/(.*\.html)$ file://$PWD/dist/\$1"
             dist/
           fail: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,7 +105,7 @@ jobs:
           workingDirectory: astro # TODO: change when Astro site is moved to root
           args: |
             --root-dir $PWD/dist
-            --remap "https://expressjs\.com\/([^.?]+(?:\/[^.?]+)*)\/?$ file://$PWD/dist/\$1/index.html"
+            --remap "https://expressjs\.com\/(.+[^\/\.])\/?$ file://$PWD/dist/\$1/index.html"
             --remap "https://expressjs\.com\/(.*\.html)$ file://$PWD/dist/\$1"
             dist/
           fail: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,7 +105,7 @@ jobs:
           workingDirectory: astro # TODO: change when Astro site is moved to root
           args: |
             --root-dir $PWD/dist
-            --remap "https://expressjs\.com\/(.*[^/\.]+)\/?$ file://$PWD/dist/\$1/index.html"
+            --remap "https://expressjs\.com\/([^.?]+(?:\/[^.?]+)*)\/?$ file://$PWD/dist/\$1/index.html"
             --remap "https://expressjs\.com\/(.*\.html)$ file://$PWD/dist/\$1"
             dist/
           fail: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,8 +105,7 @@ jobs:
           workingDirectory: astro # TODO: change when Astro site is moved to root
           args: |
             --root-dir $PWD/dist
-            --remap 'https://expressjs\.com\/(.*[^/])/$ file://'$PWD'/dist/$1/index.html'
-            --remap 'https://expressjs\.com\/(.*[^/])$' file://'$PWD'/dist/$1/index.html'
+            --remap 'https://expressjs\.com\/(.*[^/])/?$' file://'$PWD'/dist/$1/index.html'
             --remap 'https://expressjs\.com\/(.*\.html)$ file://'$PWD'/dist/$1'
             dist/
           fail: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,6 +106,7 @@ jobs:
           args: |
             --root-dir $PWD/dist
             --remap 'https://expressjs\.com\/(.*[^/])/$ file://'$PWD'/dist/$1/index.html'
+            --remap 'https://expressjs\.com\/(.*[^/])$' file://'$PWD'/dist/$1/index.html'
             --remap 'https://expressjs\.com\/(.*\.html)$ file://'$PWD'/dist/$1'
             dist/
           fail: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,7 +105,8 @@ jobs:
           workingDirectory: astro # TODO: change when Astro site is moved to root
           args: |
             --root-dir $PWD/dist
-            --remap "https://expressjs\.com\/(.*[^/])/?$ file://$PWD/dist/\$1/index.html"
-            --remap "https://expressjs\.com\/(.*\.html)$ file://$PWD/dist/\$1"
+            --remap "https://expressjs\\.com\/(.*[^/\.]+)\/?$ file://$PWD/dist/\$1/index.html"
+            --remap "https://expressjs\\.com\/(.*\.html)$ file://$PWD/dist/\$1"
+            --remap "https://expressjs\\.com\/(.*\.(xml|json|svg|png|jpg|jpeg|webp))$ file://$PWD/dist/\$1"
             dist/
           fail: true

--- a/astro/astro.config.mjs
+++ b/astro/astro.config.mjs
@@ -7,8 +7,7 @@ import expressiveCode from 'astro-expressive-code';
 import react from '@astrojs/react';
 import svgr from 'vite-plugin-svgr';
 import Icons from 'unplugin-icons/vite';
-
-// TODO: add redirecto for blog posts
+import redirects from './src/config/redirect.js';
 
 /* https://docs.netlify.com/configure-builds/environment-variables/#read-only-variables */
 const NETLIFY_PREVIEW_SITE = process.env.CONTEXT !== 'production' && process.env.DEPLOY_PRIME_URL;
@@ -17,6 +16,7 @@ const site = NETLIFY_PREVIEW_SITE || 'https://expressjs.com';
 
 // https://astro.build/config
 export default defineConfig({
+  redirects,
   site,
   vite: {
     plugins: [

--- a/astro/src/config/redirect.js
+++ b/astro/src/config/redirect.js
@@ -1,0 +1,67 @@
+// Redirect .html and non-.html blog post URLs to the new format. This will ensure that any existing links to blog posts will continue to work and redirect users to the correct location on the new site.
+const blog = {
+  '/2024/07/16/welcome-post.html': '/en/blog/2024-07-16-welcome-post',
+  '/2024/07/16/welcome-post': '/en/blog/2024-07-16-welcome-post',
+  '/2024/09/29/security-releases.html': '/en/blog/2024-09-29-security-releases',
+  '/2024/09/29/security-releases': '/en/blog/2024-09-29-security-releases',
+  '/2024/10/01/HeroDevs-partnership-announcement.html':
+    '/en/blog/2024-10-01-herodevs-partnership-announcement',
+  '/2024/10/01/HeroDevs-partnership-announcement':
+    '/en/blog/2024-10-01-herodevs-partnership-announcement',
+  '/2024/10/15/v5-release': '/en/blog/2024-10-15-v5-release',
+  '/2024/10/15/v5-release.html': '/en/blog/2024-10-15-v5-release',
+  '/2024/10/22/security-audit-milestone-achievement.html':
+    '/en/blog/2024-10-22-security-audit-milestone-achievement',
+  '/2024/10/22/security-audit-milestone-achievement':
+    '/en/blog/2024-10-22-security-audit-milestone-achievement',
+  '/2025/01/09/rewind-2024-triumphs-and-2025-vision.html':
+    '/en/blog/2025-01-09-rewind-2024-triumphs-and-2025-vision',
+  '/2025/01/09/rewind-2024-triumphs-and-2025-vision':
+    '/en/blog/2025-01-09-rewind-2024-triumphs-and-2025-vision',
+  '/2025/03/31/v5-1-latest-release.html': '/en/blog/2025-03-31-v5-1-latest-release',
+  '/2025/03/31/v5-1-latest-release': '/en/blog/2025-03-31-v5-1-latest-release',
+  '/2025/05/16/express-cleanup-legacy-packages.html':
+    '/en/blog/2025-05-16-express-cleanup-legacy-packages',
+  '/2025/05/16/express-cleanup-legacy-packages':
+    '/en/blog/2025-05-16-express-cleanup-legacy-packages',
+  '/2025/05/19/security-releases.html': '/en/blog/2025-05-19-security-releases',
+  '/2025/05/19/security-releases': '/en/blog/2025-05-19-security-releases',
+  '/2025/06/05/vulnerability-reporting-process-overhaul.html':
+    '/en/blog/2025-06-05-vulnerability-reporting-process-overhaul',
+  '/2025/06/05/vulnerability-reporting-process-overhaul':
+    '/en/blog/2025-06-05-vulnerability-reporting-process-overhaul',
+  '/2025/07/18/security-releases.html': '/en/blog/2025-07-18-security-releases',
+  '/2025/07/18/security-releases': '/en/blog/2025-07-18-security-releases',
+  '/2025/07/31/security-releases.html': '/en/blog/2025-07-31-security-releases',
+  '/2025/07/31/security-releases': '/en/blog/2025-07-31-security-releases',
+  '/2025/12/01/security-releases.html': '/en/blog/2025-12-01-security-releases',
+  '/2025/12/01/security-releases': '/en/blog/2025-12-01-security-releases',
+  '/2026/02/27/security-releases.html': '/en/blog/2026-02-27-security-releases',
+  '/2026/02/27/security-releases': '/en/blog/2026-02-27-security-releases',
+};
+
+const api_v2 = {
+  '/2x/': 'https://github.com/expressjs/expressjs.com/tree/2x',
+  '/2x/guide/': 'https://github.com/expressjs/expressjs.com/tree/2x',
+  '/2x/migrate/': 'https://github.com/expressjs/expressjs.com/tree/2x',
+  '/2x/screencasts/': 'https://github.com/expressjs/expressjs.com/tree/2x',
+  '/2x/executables/': 'https://github.com/expressjs/expressjs.com/tree/2x',
+  '/2x/contrib': 'https://github.com/expressjs/expressjs.com/tree/2x',
+  '/2x/applications': 'https://github.com/expressjs/expressjs.com/tree/2x',
+  '/2x/docs': 'https://github.com/expressjs/expressjs.com/tree/2x',
+  '/2x/docs/guide/': 'https://github.com/expressjs/expressjs.com/tree/2x',
+  '/2x/docs/migrate/': 'https://github.com/expressjs/expressjs.com/tree/2x',
+  '/2x/docs/screencasts/': 'https://github.com/expressjs/expressjs.com/tree/2x',
+  '/2x/docs/executables/': 'https://github.com/expressjs/expressjs.com/tree/2x',
+  '/2x/docs/contrib': 'https://github.com/expressjs/expressjs.com/tree/2x',
+  '/2x/docs/applications': 'https://github.com/expressjs/expressjs.com/tree/2x',
+};
+
+const pages = {
+  '/en/changelog/4x.html': 'https://github.com/expressjs/express/releases',
+  '/en/changelog/4x': 'https://github.com/expressjs/express/releases',
+};
+
+const redirects = { ...blog, ...api_v2, ...pages };
+
+export default redirects;

--- a/astro/src/config/redirect.js
+++ b/astro/src/config/redirect.js
@@ -42,19 +42,19 @@ const blog = {
 
 const api_v2 = {
   '/2x/': 'https://github.com/expressjs/expressjs.com/tree/2x',
-  '/2x/guide/': 'https://github.com/expressjs/expressjs.com/tree/2x',
-  '/2x/migrate/': 'https://github.com/expressjs/expressjs.com/tree/2x',
-  '/2x/screencasts/': 'https://github.com/expressjs/expressjs.com/tree/2x',
-  '/2x/executables/': 'https://github.com/expressjs/expressjs.com/tree/2x',
-  '/2x/contrib': 'https://github.com/expressjs/expressjs.com/tree/2x',
-  '/2x/applications': 'https://github.com/expressjs/expressjs.com/tree/2x',
-  '/2x/docs': 'https://github.com/expressjs/expressjs.com/tree/2x',
-  '/2x/docs/guide/': 'https://github.com/expressjs/expressjs.com/tree/2x',
-  '/2x/docs/migrate/': 'https://github.com/expressjs/expressjs.com/tree/2x',
-  '/2x/docs/screencasts/': 'https://github.com/expressjs/expressjs.com/tree/2x',
-  '/2x/docs/executables/': 'https://github.com/expressjs/expressjs.com/tree/2x',
-  '/2x/docs/contrib': 'https://github.com/expressjs/expressjs.com/tree/2x',
-  '/2x/docs/applications': 'https://github.com/expressjs/expressjs.com/tree/2x',
+  '/2x/guide.html': 'https://github.com/expressjs/expressjs.com/tree/2x',
+  '/2x/migrate.html': 'https://github.com/expressjs/expressjs.com/tree/2x',
+  '/2x/screencasts.html': 'https://github.com/expressjs/expressjs.com/tree/2x',
+  '/2x/executables.html': 'https://github.com/expressjs/expressjs.com/tree/2x',
+  '/2x/contrib.html': 'https://github.com/expressjs/expressjs.com/tree/2x',
+  '/2x/applications.html': 'https://github.com/expressjs/expressjs.com/tree/2x',
+  '/2x/docs.html': 'https://github.com/expressjs/expressjs.com/tree/2x',
+  '/2x/docs/guide.html': 'https://github.com/expressjs/expressjs.com/tree/2x',
+  '/2x/docs/migrate.html': 'https://github.com/expressjs/expressjs.com/tree/2x',
+  '/2x/docs/screencasts.html': 'https://github.com/expressjs/expressjs.com/tree/2x',
+  '/2x/docs/executables.html': 'https://github.com/expressjs/expressjs.com/tree/2x',
+  '/2x/docs/contrib.html': 'https://github.com/expressjs/expressjs.com/tree/2x',
+  '/2x/docs/applications.html': 'https://github.com/expressjs/expressjs.com/tree/2x',
 };
 
 const pages = {


### PR DESCRIPTION
These are the pages that have redirects or will be moved to a new location in the new documentation, all to avoid breaking links.