### PR TITLE
docs: imprive migration guide to v5

### DIFF
--- a/src/content/pages/en/guide/migrating-5.mdx
+++ b/src/content/pages/en/guide/migrating-5.mdx
@@ -336,6 +336,8 @@ Router handling logic is now performed by a separate dependency ([`router`](http
 
 ## Changed
 
+These APIs still exist but their behavior has changed. Review these changes to make sure your app works as expected.
+
 ### Path route matching syntax
 
 Path route matching syntax is when a string is supplied as the first parameter to the `app.all()`, `app.use()`, `app.METHOD()`, `router.all()`, `router.METHOD()`, and `router.use()` APIs. The following changes have been made to how the path string is matched to an incoming request:

--- a/src/content/pages/en/guide/migrating-5.mdx
+++ b/src/content/pages/en/guide/migrating-5.mdx
@@ -270,6 +270,7 @@ In Express 5, `res.sendFile()` uses the `mime-types` package for MIME type detec
 - XML files (.xml): now "application/xml" instead of "text/xml"
 - Font files (.woff): now "font/woff" instead of "application/font-woff"
 - SVG files (.svg): now "image/svg+xml" instead of "application/svg+xml"
+
 </Alert>
 
 #### How to update
@@ -430,6 +431,16 @@ The `app.router` object, which was removed in Express 4, has made a comeback in 
 
 The `req.body` property returns `undefined` when the body has not been parsed. In Express 4, it returns `{}` by default.
 
+```js del={4} ins={6}
+app.post('/user', (req, res) => {
+  console.dir(req.body);
+  // Express 4
+  // => {}
+  // Express 5
+  // => undefined
+});
+```
+
 ### req.host
 
 In Express 4, the `req.host` function incorrectly stripped off the port number if it was present. In Express 5, the port number is maintained.
@@ -480,6 +491,13 @@ In Express 4, unmatched wildcards were empty strings (`''`) and optional `:` par
 ### req.query
 
 The `req.query` property is no longer a writable property and is instead a getter. The default query parser has been changed from "extended" to "simple".
+
+```js del={3}
+app.get('/search', (req, res) => {
+  // This is no longer possible in Express 5
+  req.query.page = 1;
+});
+```
 
 ### res.clearCookie
 

--- a/src/content/pages/en/guide/migrating-5.mdx
+++ b/src/content/pages/en/guide/migrating-5.mdx
@@ -33,113 +33,6 @@ npx codemod@latest @expressjs/name-of-the-codemod
 
 You can find the list of available codemods [here](https://codemod.link/express).
 
-## Changes in Express 5
-
-**Removed methods and properties**
-
-<ul class="doclist">
-  <li>
-    <a href="#app.del">app.del()</a>
-  </li>
-  <li>
-    <a href="#app.param">app.param(fn)</a>
-  </li>
-  <li>
-    <a href="#plural">Pluralized method names</a>
-  </li>
-  <li>
-    <a href="#leading">Leading colon in name argument to app.param(name, fn)</a>
-  </li>
-  <li>
-    <a href="#req.param">req.param(name)</a>
-  </li>
-  <li>
-    <a href="#res.json">res.json(obj, status)</a>
-  </li>
-  <li>
-    <a href="#res.jsonp">res.jsonp(obj, status)</a>
-  </li>
-  <li>
-    <a href="#magic-redirect">res.redirect('back') and res.location('back')</a>
-  </li>
-  <li>
-    <a href="#res.redirect">res.redirect(url, status)</a>
-  </li>
-  <li>
-    <a href="#res.send.body">res.send(body, status)</a>
-  </li>
-  <li>
-    <a href="#res.send.status">res.send(status)</a>
-  </li>
-  <li>
-    <a href="#res.sendfile">res.sendfile()</a>
-  </li>
-  <li>
-    <a href="#router.param">router.param(fn)</a>
-  </li>
-  <li>
-    <a href="#express.static.mime">express.static.mime</a>
-  </li>
-  <li>
-    <a href="#express:router-debug-logs">express:router debug logs</a>
-  </li>
-</ul>
-
-**Changed**
-
-<ul class="doclist">
-  <li>
-    <a href="#path-syntax">Path route matching syntax</a>
-  </li>
-  <li>
-    <a href="#rejected-promises">Rejected promises handled from middleware and handlers</a>
-  </li>
-  <li>
-    <a href="#express.urlencoded">express.urlencoded</a>
-  </li>
-  <li>
-    <a href="#express.static.dotfiles">express.static dotfiles</a>
-  </li>
-  <li>
-    <a href="#app.listen">app.listen</a>
-  </li>
-  <li>
-    <a href="#app.router">app.router</a>
-  </li>
-  <li>
-    <a href="#req.body">req.body</a>
-  </li>
-  <li>
-    <a href="#req.host">req.host</a>
-  </li>
-  <li>
-    <a href="#req.params">req.params</a>
-  </li>
-  <li>
-    <a href="#req.query">req.query</a>
-  </li>
-  <li>
-    <a href="#res.clearCookie">res.clearCookie</a>
-  </li>
-  <li>
-    <a href="#res.status">res.status</a>
-  </li>
-  <li>
-    <a href="#res.vary">res.vary</a>
-  </li>
-</ul>
-
-**Improvements**
-
-<ul class="doclist">
-  <li>
-    <a href="#res.render">res.render()</a>
-  </li>
-  <li>
-    <a href="#brotli-support">Brotli encoding support</a>
-  </li>
-</ul>
-
 ## Removed methods and properties
 
 If you use any of these methods or properties in your app, it will crash. So, you'll need to change your app after you update to version 5.
@@ -150,25 +43,21 @@ Express 5 no longer supports the `app.del()` function. If you use this function,
 
 Initially, `del` was used instead of `delete`, because `delete` is a reserved keyword in JavaScript. However, as of ECMAScript 6, `delete` and other reserved keywords can legally be used as property names.
 
-<Alert type="info">
-You can replace the deprecated signatures with the following command:
+#### How to update
 
-```plaintext
+You can automatically update your code by running the following command:
+
+```sh
 npx codemod@latest @expressjs/route-del-to-delete
 ```
 
-</Alert>
+Or you can update your code manually:
 
-```js
-// v4
-app.del('/user/:id', (req, res) => {
-  res.send(`DELETE /user/${req.params.id}`);
-});
-
-// v5
-app.delete('/user/:id', (req, res) => {
-  res.send(`DELETE /user/${req.params.id}`);
-});
+```diff
+-app.del('/user/:id', (req, res) => {
++app.delete('/user/:id', (req, res) => {
+   res.send(`DELETE /user/${req.params.id}`);
+ });
 ```
 
 ### app.param(fn)
@@ -185,33 +74,27 @@ The following method names have been pluralized. In Express 4, using the old met
 
 `req.acceptsLanguage()` is replaced by `req.acceptsLanguages()`.
 
-<Alert type="info">
-You can replace the deprecated signatures with the following command:
+#### How to update
 
-```plaintext
+You can automatically update your code by running the following command:
+
+```sh
 npx codemod@latest @expressjs/pluralize-method-names
 ```
 
-</Alert>
+Or you can update your code manually:
 
-```js
-// v4
-app.all('/', (req, res) => {
-  req.acceptsCharset('utf-8');
-  req.acceptsEncoding('br');
-  req.acceptsLanguage('en');
+```diff
+ app.all('/', (req, res) => {
+-  req.acceptsCharset('utf-8');
+-  req.acceptsEncoding('br');
+-  req.acceptsLanguage('en');
++  req.acceptsCharsets('utf-8');
++  req.acceptsEncodings('br');
++  req.acceptsLanguages('en');
 
-  // ...
-});
-
-// v5
-app.all('/', (req, res) => {
-  req.acceptsCharsets('utf-8');
-  req.acceptsEncodings('br');
-  req.acceptsLanguages('en');
-
-  // ...
-});
+   // ...
+ });
 ```
 
 ### Leading colon (:) in the name for app.param(name, fn)
@@ -224,158 +107,132 @@ This should not affect your code if you follow the Express 4 documentation of [a
 
 This potentially confusing and dangerous method of retrieving form data has been removed. You will now need to specifically look for the submitted parameter name in the `req.params`, `req.body`, or `req.query` object.
 
-<Alert type="info">
-You can replace the deprecated signatures with the following command:
+#### How to update
 
-```plaintext
+You can automatically update your code by running the following command:
+
+```sh
 npx codemod@latest @expressjs/explicit-request-params
 ```
 
-</Alert>
+Or you can update your code manually:
 
-```js
-// v4
-app.post('/user', (req, res) => {
-  const id = req.param('id');
-  const body = req.param('body');
-  const query = req.param('query');
+```diff
+ app.post('/user', (req, res) => {
+-  const id = req.param('id');
+-  const body = req.param('body');
+-  const query = req.param('query');
++  const id = req.params.id;
++  const body = req.body;
++  const query = req.query;
 
-  // ...
-});
-
-// v5
-app.post('/user', (req, res) => {
-  const id = req.params.id;
-  const body = req.body;
-  const query = req.query;
-
-  // ...
-});
+   // ...
+ });
 ```
 
 ### res.json(obj, status)
 
 Express 5 no longer supports the signature `res.json(obj, status)`. Instead, set the status and then chain it to the `res.json()` method like this: `res.status(status).json(obj)`.
 
-<Alert type="info">
-You can replace the deprecated signatures with the following command:
+#### How to update
 
-```plaintext
+You can automatically update your code by running the following command:
+
+```sh
 npx codemod@latest @expressjs/status-send-order
 ```
 
-</Alert>
+Or you can update your code manually:
 
-```js
-// v4
-app.post('/user', (req, res) => {
-  res.json({ name: 'Ruben' }, 201);
-});
-
-// v5
-app.post('/user', (req, res) => {
-  res.status(201).json({ name: 'Ruben' });
-});
+```diff
+ app.post('/user', (req, res) => {
+-  res.json({ name: 'Ruben' }, 201);
++  res.status(201).json({ name: 'Ruben' });
+ });
 ```
 
 ### res.jsonp(obj, status)
 
 Express 5 no longer supports the signature `res.jsonp(obj, status)`. Instead, set the status and then chain it to the `res.jsonp()` method like this: `res.status(status).jsonp(obj)`.
 
-<Alert type="info">
-You can replace the deprecated signatures with the following command:
+#### How to update
 
-```plaintext
+You can automatically update your code by running the following command:
+
+```sh
 npx codemod@latest @expressjs/status-send-order
 ```
 
-</Alert>
+Or you can update your code manually:
 
-```js
-// v4
-app.post('/user', (req, res) => {
-  res.jsonp({ name: 'Ruben' }, 201);
-});
-
-// v5
-app.post('/user', (req, res) => {
-  res.status(201).jsonp({ name: 'Ruben' });
-});
+```diff
+ app.post('/user', (req, res) => {
+-  res.jsonp({ name: 'Ruben' }, 201);
++  res.status(201).jsonp({ name: 'Ruben' });
+ });
 ```
 
 ### res.redirect(url, status)
 
 Express 5 no longer supports the signature `res.redirect(url, status)`. Instead, use the following signature: `res.redirect(status, url)`.
 
-<Alert type="info">
-You can replace the deprecated signatures with the following command:
+#### How to update
 
-```plaintext
+You can automatically update your code by running the following command:
+
+```sh
 npx codemod@latest @expressjs/redirect-arg-order
 ```
 
-</Alert>
+Or you can update your code manually:
 
-```js
-// v4
-app.get('/user', (req, res) => {
-  res.redirect('/users', 301);
-});
-
-// v5
-app.get('/user', (req, res) => {
-  res.redirect(301, '/users');
-});
+```diff
+ app.get('/user', (req, res) => {
+-  res.redirect('/users', 301);
++  res.redirect(301, '/users');
+ });
 ```
 
 ### res.redirect('back') and res.location('back')
 
 Express 5 no longer supports the magic string `back` in the `res.redirect()` and `res.location()` methods. Instead, use the `req.get('Referrer') || '/'` value to redirect back to the previous page. In Express 4, the `res.redirect('back')` and `res.location('back')` methods were deprecated.
 
-<Alert type="info">
-You can replace the deprecated signatures with the following command:
+#### How to update
 
-```plaintext
+You can automatically update your code by running the following command:
+
+```sh
 npx codemod@latest @expressjs/back-redirect-deprecated
 ```
 
-</Alert>
+Or you can update your code manually:
 
-```js
-// v4
-app.get('/user', (req, res) => {
-  res.redirect('back');
-});
-
-// v5
-app.get('/user', (req, res) => {
-  res.redirect(req.get('Referrer') || '/');
-});
+```diff
+ app.get('/user', (req, res) => {
+-  res.redirect('back');
++  res.redirect(req.get('Referrer') || '/');
+ });
 ```
 
 ### res.send(body, status)
 
 Express 5 no longer supports the signature `res.send(obj, status)`. Instead, set the status and then chain it to the `res.send()` method like this: `res.status(status).send(obj)`.
 
-<Alert type="info">
-You can replace the deprecated signatures with the following command:
+#### How to update
 
-```plaintext
+You can automatically update your code by running the following command:
+
+```sh
 npx codemod@latest @expressjs/status-send-order
 ```
 
-</Alert>
+Or you can update your code manually:
 
-```js
-// v4
-app.get('/user', (req, res) => {
-  res.send({ name: 'Ruben' }, 200);
-});
-
-// v5
-app.get('/user', (req, res) => {
-  res.status(200).send({ name: 'Ruben' });
-});
+```diff
+ app.get('/user', (req, res) => {
+-  res.send({ name: 'Ruben' }, 200);
++  res.status(200).send({ name: 'Ruben' });
+ });
 ```
 
 ### res.send(status)
@@ -383,32 +240,29 @@ app.get('/user', (req, res) => {
 Express 5 no longer supports the signature `res.send(status)`, where `status` is a number. Instead, use the `res.sendStatus(statusCode)` function, which sets the HTTP response header status code and sends the text version of the code: "Not Found", "Internal Server Error", and so on.
 If you need to send a number by using the `res.send()` function, quote the number to convert it to a string, so that Express does not interpret it as an attempt to use the unsupported old signature.
 
-<Alert type="info">
-You can replace the deprecated signatures with the following command:
+#### How to update
 
-```plaintext
+You can automatically update your code by running the following command:
+
+```sh
 npx codemod@latest @expressjs/status-send-order
 ```
 
-</Alert>
+Or you can update your code manually:
 
-```js
-// v4
-app.get('/user', (req, res) => {
-  res.send(200);
-});
-
-// v5
-app.get('/user', (req, res) => {
-  res.sendStatus(200);
-});
+```diff
+ app.get('/user', (req, res) => {
+-  res.send(200);
++  res.sendStatus(200);
+ });
 ```
 
 ### res.sendfile()
 
 The `res.sendfile()` function has been replaced by a camel-cased version `res.sendFile()` in Express 5.
 
-**Note:** In Express 5, `res.sendFile()` uses the `mime-types` package for MIME type detection, which returns different Content-Type values than Express 4 for several common file types:
+<Alert type="info">
+In Express 5, `res.sendFile()` uses the `mime-types` package for MIME type detection, which returns different Content-Type values than Express 4 for several common file types:
 
 - JavaScript files (.js): now "text/javascript" instead of "application/javascript"
 - JSON files (.json): now "application/json" instead of "text/json"
@@ -416,26 +270,23 @@ The `res.sendfile()` function has been replaced by a camel-cased version `res.se
 - XML files (.xml): now "application/xml" instead of "text/xml"
 - Font files (.woff): now "font/woff" instead of "application/font-woff"
 - SVG files (.svg): now "image/svg+xml" instead of "application/svg+xml"
+</Alert>
 
-<Alert type="info">
-You can replace the deprecated signatures with the following command:
+#### How to update
 
-```plaintext
+You can automatically update your code by running the following command:
+
+```sh
 npx codemod@latest @expressjs/camelcase-sendfile
 ```
 
-</Alert>
+Or you can update your code manually:
 
-```js
-// v4
-app.get('/user', (req, res) => {
-  res.sendfile('/path/to/file');
-});
-
-// v5
-app.get('/user', (req, res) => {
-  res.sendFile('/path/to/file');
-});
+```diff
+ app.get('/user', (req, res) => {
+-  res.sendfile('/path/to/file');
++  res.sendFile('/path/to/file');
+ });
 ```
 
 ### router.param(fn)
@@ -456,13 +307,10 @@ Use the [`mime-types` package](https://github.com/jshttp/mime-types) to work wit
 - XML files (.xml): now served as "application/xml" instead of "text/xml"
 - Font files (.woff): now served as "font/woff" instead of "application/font-woff"
 
-```js
-// v4
-express.static.mime.lookup('json');
-
-// v5
-const mime = require('mime-types');
-mime.lookup('json');
+```diff
+-express.static.mime.lookup('json');
++const mime = require('mime-types');
++mime.lookup('json');
 ```
 
 ### express:router debug logs
@@ -476,12 +324,9 @@ The logs from `router:layer` and `router:route` are included in the namespace `r
 To achieve the same detail of debug logging when using `express:*` in v4, use a conjunction of
 `express:*`, `router`, and `router:*`.
 
-```sh
-
-DEBUG=express:* node index.js
-
-
-DEBUG=express:*,router,router:* node index.js
+```diff
+-DEBUG=express:* node index.js
++DEBUG=express:*,router,router:* node index.js
 ```
 
 ## Changed
@@ -492,23 +337,17 @@ Path route matching syntax is when a string is supplied as the first parameter t
 
 - The wildcard `*` must have a name, matching the behavior of parameters `:`, use `/*splat` instead of `/*`
 
-```js
-// v4
-app.get('/*', async (req, res) => {
-  res.send('ok');
-});
-
-// v5
-app.get('/*splat', async (req, res) => {
-  res.send('ok');
-});
+```diff
+-app.get('/*', async (req, res) => {
++app.get('/*splat', async (req, res) => {
+   res.send('ok');
+ });
 ```
 
 <Alert type="info">
 `*splat` matches any path without the root path. If you need to match the root path as well `/`, you can use `/{*splat}`, wrapping the wildcard in braces.
 
 ```js
-// v5
 app.get('/{*splat}', async (req, res) => {
   res.send('ok');
 });
@@ -518,32 +357,20 @@ app.get('/{*splat}', async (req, res) => {
 
 - The optional character `?` is no longer supported, use braces instead.
 
-```js
-// v4
-app.get('/:file.:ext?', async (req, res) => {
-  res.send('ok');
-});
-
-// v5
-app.get('/:file{.:ext}', async (req, res) => {
-  res.send('ok');
-});
+```diff
+-app.get('/:file.:ext?', async (req, res) => {
++app.get('/:file{.:ext}', async (req, res) => {
+   res.send('ok');
+ });
 ```
 
 - Regexp characters are not supported. For example:
 
-```js
-app.get('/[discussion|page]/:slug', async (req, res) => {
-  res.status(200).send('ok');
-});
-```
-
-should be changed to:
-
-```js
-app.get(['/discussion/:slug', '/page/:slug'], async (req, res) => {
-  res.status(200).send('ok');
-});
+```diff
+-app.get('/[discussion|page]/:slug', async (req, res) => {
++app.get(['/discussion/:slug', '/page/:slug'], async (req, res) => {
+   res.status(200).send('ok');
+ });
 ```
 
 - Some characters have been reserved to avoid confusion during upgrade (`()[]?+!`), use `\` to escape them.
@@ -559,35 +386,34 @@ Details of how Express handles errors is covered in the [error handling document
 
 The `express.urlencoded` method makes the `extended` option `false` by default.
 
+#### How to update
+
+If your application relies on the `extended` behavior, explicitly set it to `true`:
+
+```diff
+-app.use(express.urlencoded());
++app.use(express.urlencoded({ extended: true }));
+```
+
 ### express.static dotfiles
 
-In Express 5, the `express.static` middleware's `dotfiles` option now defaults to `"ignore"`. This is a change from Express 4, where dotfiles were served by default. As a result, files inside a directory that starts with a dot (`.`), such as `.well-known`, will no longer be accessible and will return a **404 Not Found** error. This can break functionality that depends on serving dot-directories, such as Android App Links, and Apple Universal Links.
+The `express.static` middleware's `dotfiles` option now defaults to `"ignore"`. In Express 4, dotfiles were served by default. As a result, files inside a directory that starts with a dot (`.`), such as `.well-known`, will no longer be accessible and will return a **404 Not Found** error. This can break functionality that depends on serving dot-directories, such as Android App Links and Apple Universal Links.
 
-Example of breaking code:
+#### How to update
 
-```js
-// v4
-app.use(express.static('public'));
+Serve specific dot-directories explicitly using the `dotfiles: "allow"` option. This allows you to safely serve only the intended dot-directories while keeping the default secure behavior for other dotfiles.
+
+```diff
++app.use('/.well-known', express.static('public/.well-known', { dotfiles: 'allow' }));
+ app.use(express.static('public'));
 ```
-
-After migrating to Express 5, a request to `/.well-known/assetlinks.json` will result in a **404 Not Found**.
-
-To fix this, serve specific dot-directories explicitly using the `dotfiles: "allow"` option:
-
-```js
-// v5
-app.use('/.well-known', express.static('public/.well-known', { dotfiles: 'allow' }));
-app.use(express.static('public'));
-```
-
-This approach allows you to safely serve only the intended dot-directories while keeping the default secure behavior for other dotfiles, which remain inaccessible.
 
 ### app.listen
 
 In Express 5, the `app.listen` method will invoke the user-provided callback function (if provided) when the server receives an error event. In Express 4, such errors would be thrown. This change shifts error-handling responsibility to the callback function in Express 5. If there is an error, it will be passed to the callback as an argument.
 For example:
 
-```js
+```js ins={2-4}
 const server = app.listen(8080, '0.0.0.0', (error) => {
   if (error) {
     throw error; // e.g. EADDRINUSE
@@ -628,27 +454,27 @@ app.get('/*splat', (req, res) => {
 
 In Express 4, unmatched wildcards were empty strings (`''`) and optional `:` parameters (using `?`) had a key with value `undefined`. In Express 5, unmatched parameters are completely omitted from `req.params`.
 
-```js
-// v4: unmatched wildcard is empty string
-app.get('/*', (req, res) => {
-  // GET /
-  console.dir(req.params);
-  // => { '0': '' }
-});
-
-// v4: unmatched optional param is undefined
-app.get('/:file.:ext?', (req, res) => {
-  // GET /image
-  console.dir(req.params);
-  // => { file: 'image', ext: undefined }
-});
-
-// v5: unmatched optional param is omitted
-app.get('/:file{.:ext}', (req, res) => {
-  // GET /image
-  console.dir(req.params);
-  // => [Object: null prototype] { file: 'image' }
-});
+```diff
+-// v4: unmatched wildcard is empty string
+-app.get('/*', (req, res) => {
+-  // GET /
+-  console.dir(req.params);
+-  // => { '0': '' }
+-});
+-
+-// v4: unmatched optional param is undefined
+-app.get('/:file.:ext?', (req, res) => {
+-  // GET /image
+-  console.dir(req.params);
+-  // => { file: 'image', ext: undefined }
+-});
+-
++// v5: unmatched optional param is omitted
++app.get('/:file{.:ext}', (req, res) => {
++  // GET /image
++  console.dir(req.params);
++  // => [Object: null prototype] { file: 'image' }
++});
 ```
 
 ### req.query
@@ -669,10 +495,12 @@ The `res.vary` throws an error when the `field` argument is missing. In Express 
 
 ## Improvements
 
+These changes don't require any migration steps, but are worth knowing about when upgrading.
+
 ### res.render()
 
 This method now enforces asynchronous behavior for all view engines, avoiding bugs caused by view engines that had a synchronous implementation and that violated the recommended interface.
 
 ### Brotli encoding support
 
-Express 5 supports Brotli encoding for requests received from clients that support it.
+Middleware like `express.json()`, `express.urlencoded()`, `express.text()`, and `express.raw()` now support Brotli (`Content-Encoding: br`) decompression for incoming request bodies, in addition to `gzip` and `deflate`.

--- a/src/content/pages/en/guide/migrating-5.mdx
+++ b/src/content/pages/en/guide/migrating-5.mdx
@@ -384,6 +384,22 @@ Request middleware and handlers that return rejected promises are now handled by
 
 Details of how Express handles errors is covered in the [error handling documentation](/en/guide/error-handling).
 
+#### How to update
+
+You can now use `async/await` directly without manually catching errors. If `getUserById` throws an error or rejects, `next` will be called automatically with the rejected value.
+
+```diff
+-app.get('/user/:id', (req, res, next) => {
+-  getUserById(req.params.id)
+-    .then((user) => res.send(user))
+-    .catch(next);
+-});
++app.get('/user/:id', async (req, res) => {
++  const user = await getUserById(req.params.id);
++  res.send(user);
++});
+```
+
 ### express.urlencoded
 
 The `express.urlencoded` method makes the `extended` option `false` by default.
@@ -504,13 +520,34 @@ app.get('/search', (req, res) => {
 
 The `res.clearCookie` method ignores the `maxAge` and `expires` options provided by the user.
 
+```diff
+ app.get('/logout', (req, res) => {
+-  res.clearCookie('session', { maxAge: 0, expires: new Date(0) });
++  res.clearCookie('session');
+ });
+```
+
 ### res.status
 
 The `res.status` method only accepts integers in the range of `100` to `999`, following the behavior defined by Node.js, and it returns an error when the status code is not an integer.
 
+```js del={2}
+app.get('/user', (req, res) => {
+  res.status(99); // Throws an error
+  res.status(200); // OK
+});
+```
+
 ### res.vary
 
-The `res.vary` throws an error when the `field` argument is missing. In Express 4, if the argument was omitted, it gave a warning in the console
+The `res.vary` throws an error when the `field` argument is missing. In Express 4, if the argument was omitted, it gave a warning in the console.
+
+```js del={2}
+app.get('/user', (req, res) => {
+  res.vary(); // Throws an error
+  res.vary('Accept'); // OK
+});
+```
 
 ## Improvements
 

--- a/src/content/pages/en/guide/migrating-5.mdx
+++ b/src/content/pages/en/guide/migrating-5.mdx
@@ -318,14 +318,16 @@ Use the [`mime-types` package](https://github.com/jshttp/mime-types) to work wit
 
 ### express:router debug logs
 
-In Express 5, router handling logic is performed by a dependency. Therefore, the
-debug logs for the router are no longer available under the `express:` namespace.
-In v4, the logs were available under the namespaces `express:router`, `express:router:layer`,
-and `express:router:route`. All of these were included under the namespace `express:*`.
-In v5.1+, the logs are available under the namespaces `router`, `router:layer`, and `router:route`.
-The logs from `router:layer` and `router:route` are included in the namespace `router:*`.
-To achieve the same detail of debug logging when using `express:*` in v4, use a conjunction of
-`express:*`, `router`, and `router:*`.
+Router handling logic is now performed by a separate dependency ([`router`](https://github.com/pillarjs/router)) maintained by the Express team, so debug logs have moved to a different namespace. Before Express 5.1, these debug logs did not exist. To get them, update to a recent Express 5 version or update the `router` package in your `package-lock.json`:
+
+| v4 | v5 |
+| --- | --- |
+| `express:router` | `router` |
+| `express:router:layer` | `router:layer` |
+| `express:router:route` | `router:route` |
+| `express:*` (includes all) | `express:*` + `router` + `router:*` |
+
+#### How to update
 
 ```diff
 -DEBUG=express:* node index.js

--- a/src/content/pages/en/guide/migrating-5.mdx
+++ b/src/content/pages/en/guide/migrating-5.mdx
@@ -338,41 +338,42 @@ Path route matching syntax is when a string is supplied as the first parameter t
 
 - The wildcard `*` must have a name, matching the behavior of parameters `:`, use `/*splat` instead of `/*`
 
-```diff
--app.get('/*', async (req, res) => {
-+app.get('/*splat', async (req, res) => {
-   res.send('ok');
- });
-```
+  ```diff
+  -app.get('/*', async (req, res) => {
+  +app.get('/*splat', async (req, res) => {
+     res.send('ok');
+   });
+  ```
 
-<Alert type="info">
-`*splat` matches any path without the root path. If you need to match the root path as well `/`, you can use `/{*splat}`, wrapping the wildcard in braces.
+    <Alert type="info">
 
-```js
-app.get('/{*splat}', async (req, res) => {
-  res.send('ok');
-});
-```
+  `*splat` matches any path without the root path. If you need to match the root path as well `/`, you can use `/{*splat}`, wrapping the wildcard in braces.
 
-</Alert>
+  ```js
+  app.get('/{*splat}', async (req, res) => {
+    res.send('ok');
+  });
+  ```
+
+    </Alert>
 
 - The optional character `?` is no longer supported, use braces instead.
 
-```diff
--app.get('/:file.:ext?', async (req, res) => {
-+app.get('/:file{.:ext}', async (req, res) => {
-   res.send('ok');
- });
-```
+  ```diff
+  -app.get('/:file.:ext?', async (req, res) => {
+  +app.get('/:file{.:ext}', async (req, res) => {
+     res.send('ok');
+   });
+  ```
 
 - Regexp characters are not supported. For example:
 
-```diff
--app.get('/[discussion|page]/:slug', async (req, res) => {
-+app.get(['/discussion/:slug', '/page/:slug'], async (req, res) => {
-   res.status(200).send('ok');
- });
-```
+  ```diff
+  -app.get('/[discussion|page]/:slug', async (req, res) => {
+  +app.get(['/discussion/:slug', '/page/:slug'], async (req, res) => {
+     res.status(200).send('ok');
+   });
+  ```
 
 - Some characters have been reserved to avoid confusion during upgrade (`()[]?+!`), use `\` to escape them.
 - Parameter names now support valid JavaScript identifiers, or quoted like `:"this"`.

--- a/src/content/pages/en/guide/migrating-5.mdx
+++ b/src/content/pages/en/guide/migrating-5.mdx
@@ -1,5 +1,5 @@
 ---
-title: Moving to Express 5
+title: Upgrade to Express v5
 description: A comprehensive guide to migrating your Express.js applications from version 4 to 5, detailing breaking changes, deprecated methods, and new improvements.
 ---
 

--- a/src/content/pages/en/guide/migrating-5.mdx
+++ b/src/content/pages/en/guide/migrating-5.mdx
@@ -7,7 +7,9 @@ import Alert from '@components/primitives/Alert/Alert.astro';
 
 Express 5 is not very different from Express 4; although it maintains the same basic API, there are still changes that break compatibility with the previous version. Therefore, an application built with Express 4 might not work if you update it to use Express 5.
 
-To install this version, you need to have a Node.js version 18 or higher. Then, execute the following command in your application directory:
+## Installation
+
+To install this version, you need to have a **Node.js version 18 or higher**. Then, execute the following command in your application directory:
 
 ```sh
 npm install "express@5"

--- a/src/content/pages/en/guide/migrating-5.mdx
+++ b/src/content/pages/en/guide/migrating-5.mdx
@@ -320,11 +320,11 @@ Use the [`mime-types` package](https://github.com/jshttp/mime-types) to work wit
 
 Router handling logic is now performed by a separate dependency ([`router`](https://github.com/pillarjs/router)) maintained by the Express team, so debug logs have moved to a different namespace. Before Express 5.1, these debug logs did not exist. To get them, update to a recent Express 5 version or update the `router` package in your `package-lock.json`:
 
-| v4 | v5 |
-| --- | --- |
-| `express:router` | `router` |
-| `express:router:layer` | `router:layer` |
-| `express:router:route` | `router:route` |
+| v4                         | v5                                  |
+| -------------------------- | ----------------------------------- |
+| `express:router`           | `router`                            |
+| `express:router:layer`     | `router:layer`                      |
+| `express:router:route`     | `router:route`                      |
 | `express:*` (includes all) | `express:*` + `router` + `router:*` |
 
 #### How to update


### PR DESCRIPTION
Things like this are why I’m grateful for this redesign, I can modify everything more comfortably; I’m just improving the structure of this migration guide.