### PR TITLE
docs: remove broken prisma-fullstack example link

### DIFF
--- a/src/content/docs/en/4x/starter/examples.mdx
+++ b/src/content/docs/en/4x/starter/examples.mdx
@@ -41,5 +41,4 @@ These are some additional examples with more extensive integrations.
   Expressjs project team.
 </Alert>
 
-- [prisma-fullstack](https://github.com/prisma/prisma-examples/tree/latest/pulse/fullstack-simple-chat) - Fullstack app with Express and Next.js using [Prisma](https://www.npmjs.com/package/prisma) as an ORM
 - [prisma-rest-api-ts](https://github.com/prisma/prisma-examples/tree/latest/orm/express) - REST API with Express in TypeScript using [Prisma](https://www.npmjs.com/package/prisma) as an ORM

--- a/src/content/docs/en/5x/starter/examples.mdx
+++ b/src/content/docs/en/5x/starter/examples.mdx
@@ -45,5 +45,4 @@ Expressjs project team.
 
 </Alert>
 
-- [prisma-fullstack](https://github.com/prisma/prisma-examples/tree/latest/pulse/fullstack-simple-chat) - Fullstack app with Express and Next.js using [Prisma](https://www.npmjs.com/package/prisma) as an ORM
 - [prisma-rest-api-ts](https://github.com/prisma/prisma-examples/tree/latest/orm/express) - REST API with Express in TypeScript using [Prisma](https://www.npmjs.com/package/prisma) as an ORM


### PR DESCRIPTION
Fixes #2270

The `prisma-fullstack` link points to `prisma/prisma-examples/tree/latest/pulse/fullstack-simple-chat` which returns a 404 — that path no longer exists in the prisma-examples repo.

Removed the broken entry from all 10 locale pages (`en`, `de`, `es`, `fr`, `it`, `ja`, `ko`, `pt-br`, `zh-cn`, `zh-tw`). The `prisma-rest-api-ts` entry below it remains as it points to a valid URL.