### PR TITLE
ci: skip Orama Cloud sync for external PRs

### DIFF
--- a/.github/workflows/sync-orama.yml
+++ b/.github/workflows/sync-orama.yml
@@ -22,23 +22,29 @@ jobs:
   sync-orama-cloud:
     name: Sync Orama Cloud
     runs-on: ubuntu-latest
+    env:
+      HAS_API_KEY_SECRET: ${{ github.event_name == 'push' || secrets.PRIVATE_ORAMA_API_KEY != '' }}
 
     steps:
       - name: 'Checkout'
+        if: ${{ env.HAS_API_KEY_SECRET == 'true' }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
 
       - name: Set up Node.js
+        if: ${{ env.HAS_API_KEY_SECRET == 'true' }}
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
 
       - name: Install Node.js dependencies
+        if: ${{ env.HAS_API_KEY_SECRET == 'true' }}
         run: npm ci
 
       - name: Sync Orama Cloud
+        if: ${{ env.HAS_API_KEY_SECRET == 'true' }}
         run: node ./scripts/sync-orama.mjs
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
PRs coming from forks (and dependabot) do not have access to secrets, which are required for this job.

GitHub does not allow checking `env` or `secrets` in `jobs.<id>.if` (https://github.com/actions/runner/issues/1138), so instead skip all steps separately.

Ref: https://github.com/expressjs/expressjs.com/pull/2169#discussion_r3142147162

<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
