### PR TITLE
Fix typos in documentation and posts

### DIFF
--- a/_includes/api/en/3x/app-VERB.md
+++ b/_includes/api/en/3x/app-VERB.md
@@ -11,7 +11,7 @@ with the route matched.
 
 The following snippet illustrates the most simple route definition possible. Express
 translates the path strings to regular expressions, used internally to match incoming requests.
-Query strings are <em>not</em> considered when peforming these matches, for example "GET /"
+Query strings are <em>not</em> considered when performing these matches, for example "GET /"
 would match the following route, as would "GET /?name=tobi".
 
 ```js

--- a/_includes/api/en/3x/app-engine.md
+++ b/_includes/api/en/3x/app-engine.md
@@ -30,7 +30,7 @@ Some template engines do not follow this convention, the
 <a href="https://github.com/visionmedia/consolidate.js">consolidate.js</a>
 library was created to map all of node's popular template
 engines to follow this convention, thus allowing them to
-work seemlessly within Express.
+work seamlessly within Express.
 
 ```js
 var engines = require('consolidate')

--- a/_includes/api/en/3x/res-download.md
+++ b/_includes/api/en/3x/res-download.md
@@ -3,10 +3,10 @@
 Transfer the file at `path` as an "attachment",
 typically browsers will prompt the user for download. The
 Content-Disposition "filename=" parameter, aka the one
-that will appear in the brower dialog is set to `path`
+that will appear in the browser dialog is set to `path`
 by default, however you may provide an override `filename`.
 
-When an error has ocurred or transfer is complete the optional
+When an error has occurred or transfer is complete the optional
 callback `fn` is invoked. This method uses <a href="#res.sendfile">res.sendfile()</a>
 to transfer the file.
 

--- a/_includes/readmes/serve-index.md
+++ b/_includes/readmes/serve-index.md
@@ -26,7 +26,7 @@ var serveIndex = require('serve-index')
 
 ### serveIndex(path, options)
 
-Returns middlware that serves an index of the directory in the given `path`.
+Returns middleware that serves an index of the directory in the given `path`.
 
 The `path` is based off the `req.url` value, so a `req.url` of `'/some/dir`
 with a `path` of `'public'` will look at `'public/some/dir'`. If you are using

--- a/_posts/2024-09-29-security-releases.md
+++ b/_posts/2024-09-29-security-releases.md
@@ -48,7 +48,7 @@ basic-auth-connect `<1.1.0` uses a timing-unsafe equality comparison that can le
 **Patched versions**
 - `>=1.1.0`
 
-This vulnerability was discovered during the [OSTIF audit to Express](https://github.com/expressjs/security-wg/issues/6) and was mitigated by [the Express Securty triage team](https://github.com/expressjs/security-wg?tab=readme-ov-file#security-triage-team).
+This vulnerability was discovered during the [OSTIF audit to Express](https://github.com/expressjs/security-wg/issues/6) and was mitigated by [the Express Security triage team](https://github.com/expressjs/security-wg?tab=readme-ov-file#security-triage-team).
 
 More details area available in [GHSA-7p89-p6hx-q4fw](https://github.com/expressjs/basic-auth-connect/security/advisories/GHSA-7p89-p6hx-q4fw)
 
@@ -134,4 +134,3 @@ Because JavaScript is single-threaded and regex matching runs on the main thread
 Thanks to [Blake Embrey](https://github.com/blakeembrey) who reported and created the security patch.
 
 For more details, see [GHSA-9wv6-86v2-598j](https://github.com/pillarjs/path-to-regexp/security/advisories/GHSA-9wv6-86v2-598j)
-

--- a/_posts/2025-03-31-v5-1-latest-release.md
+++ b/_posts/2025-03-31-v5-1-latest-release.md
@@ -115,8 +115,8 @@ starts the clock on EOL for v4 by moving it to `MAINTENANCE`. We recognize that 
 only major version for most of the history of Node.js itself. Because of this, we want to remain flexible and also
 provide a bit longer support. We want to do what is best for the ecosystem, so consider these goals not commitments.
 
-\*: v4 is a special case, and we may extend MAINTENENCE support  
-\*\*: v5 MAINTENENCE and EOL dates are determined by when v6 is released, these dates reflect the earliest dates if we
+\*: v4 is a special case, and we may extend MAINTENANCE support
+\*\*: v5 MAINTENANCE and EOL dates are determined by when v6 is released, these dates reflect the earliest dates if we
 were to ship v6 on 2025-10-01  
 \*\*\* : v6 work has not officially started yet, this is simply the earliest date we can ship based on our proposed policy
 


### PR DESCRIPTION
### Summary

Fixes a few small spelling errors in English documentation and blog content:

- `peforming` -> `performing`
- `seemlessly` -> `seamlessly`
- `brower` -> `browser`
- `ocurred` -> `occurred`
- `middlware` -> `middleware`
- `Securty` -> `Security`
- `MAINTENENCE` -> `MAINTENANCE`

### Validation

- `git diff --check`
- `node node_modules/eslint/bin/eslint.js --ignore-path .gitignore --ignore-pattern _includes/readmes/ "**/*.md"`

Note: `npm test` invokes `node_modules/.bin/eslint`, which is not executable on my mounted workspace, so I ran the same eslint entrypoint with `node` directly.