### PR TITLE
docs: add verification step for Express installation

### DIFF
--- a/en/starter/installing.md
+++ b/en/starter/installing.md
@@ -50,3 +50,18 @@ $ npm install express --no-save
 <div class="doc-box doc-info" markdown="1">
 By default with version npm 5.0+, `npm install` adds the module to the `dependencies` list in the `package.json` file; with earlier versions of npm, you must specify the `--save` option explicitly. Then, afterwards, running `npm install` in the app directory will automatically install modules in the dependencies list.
 </div>
+
+
+## Verify your installation
+
+After installing Express, verify it is available:
+
+```bash
+npx express-generator@latest --version
+```
+If the command is not found, install it globally:
+
+```
+npm install -g express-generator
+```
+

--- a/en/starter/installing.md
+++ b/en/starter/installing.md
@@ -54,14 +54,11 @@ By default with version npm 5.0+, `npm install` adds the module to the `dependen
 
 ## Verify your installation
 
-After installing Express, verify it is available:
+After installing, confirm Express is available in your project:
 
 ```bash
-npx express-generator@latest --version
-```
-If the command is not found, install it globally:
-
-```
-npm install -g express-generator
+npm ls express
 ```
 
+You should see `express@x.x.x` in the output. If the package 
+is missing, re-run the install command above.


### PR DESCRIPTION
### What
Added a "Verify your installation" section to the installing guide.

### Why
New users have no way to confirm Express installed correctly.
This adds a quick verification step using express-generator.

### Changes
- Added "Verify your installation" section at the end of 
  en/starter/installing.md

I certify that this contribution is my own work and submitted 
under the project's open source license.