### PR TITLE
docs: mention TypeScript generator options

### DIFF
--- a/src/content/docs/en/4x/starter/generator.mdx
+++ b/src/content/docs/en/4x/starter/generator.mdx
@@ -93,6 +93,22 @@ PS> $env:DEBUG='myapp:*'; npm start
 
 Then, load `http://localhost:3000/` in your browser to access the app.
 
+## TypeScript
+
+The `express-generator` package creates a JavaScript application skeleton.
+It does not currently include an option to generate a TypeScript application.
+
+If you want to start with TypeScript, you can add TypeScript to the generated app after creating it, or use a community generator.
+
+<Alert type="warning">
+
+This information refers to third-party sites, products, or modules that are not maintained by the Expressjs team.
+Listing here does not constitute an endorsement or recommendation from the Expressjs project team.
+
+</Alert>
+
+- [express-generator-typescript](https://github.com/seanpmaxwell/express-generator-typescript) - Community generator for Express applications written in TypeScript
+
 The generated app has the following directory structure:
 
 ```bash

--- a/src/content/docs/en/5x/starter/generator.mdx
+++ b/src/content/docs/en/5x/starter/generator.mdx
@@ -93,6 +93,22 @@ PS> $env:DEBUG='myapp:*'; npm start
 
 Then, load `http://localhost:3000/` in your browser to access the app.
 
+## TypeScript
+
+The `express-generator` package creates a JavaScript application skeleton.
+It does not currently include an option to generate a TypeScript application.
+
+If you want to start with TypeScript, you can add TypeScript to the generated app after creating it, or use a community generator.
+
+<Alert type="warning">
+
+This information refers to third-party sites, products, or modules that are not maintained by the Expressjs team.
+Listing here does not constitute an endorsement or recommendation from the Expressjs project team.
+
+</Alert>
+
+- [express-generator-typescript](https://github.com/seanpmaxwell/express-generator-typescript) - Community generator for Express applications written in TypeScript
+
 The generated app has the following directory structure:
 
 ```bash


### PR DESCRIPTION
Related to expressjs/express#7231

Summary:
- clarify that `express-generator` creates a JavaScript application skeleton
- add a short TypeScript section to the generator page
- reuse the existing community caveat before linking to a community TypeScript generator

Tests:
- `npm test -- --quiet en/starter/generator.md`