### PR TITLE
docs: correct casing typo

### DIFF
--- a/src/content/pages/en/advanced/best-practice-security.mdx
+++ b/src/content/pages/en/advanced/best-practice-security.mdx
@@ -244,7 +244,7 @@ $ npm audit
 
 If you want to stay more secure, consider [Snyk](https://snyk.io/).
 
-Snyk offers both a [command-line tool](https://www.npmjs.com/package/snyk) and a [Github integration](https://snyk.io/docs/github) that checks your application against [Snyk's open source vulnerability database](https://snyk.io/vuln/) for any known vulnerabilities in your dependencies. Install the CLI as follows:
+Snyk offers both a [command-line tool](https://www.npmjs.com/package/snyk) and a [GitHub integration](https://snyk.io/docs/github) that checks your application against [Snyk's open source vulnerability database](https://snyk.io/vuln/) for any known vulnerabilities in your dependencies. Install the CLI as follows:
 
 ```bash
 $ npm install -g snyk

--- a/src/content/pages/en/resources/community.mdx
+++ b/src/content/pages/en/resources/community.mdx
@@ -57,7 +57,7 @@ a feature request open a ticket in the [issue queue](https://github.com/expressj
 View dozens of Express application [examples](https://github.com/expressjs/express/tree/master/examples)
 in the repository covering everything from API design and authentication to template engine integration.
 
-## Github Discussions
+## GitHub Discussions
 
 The [GitHub Discussions](https://github.com/expressjs/discussions) section is an excellent space to engage in conversations about the development and maintenance of Express, as well as to share ideas and discuss topics related to its usage.
 

--- a/src/content/pages/en/resources/contributing.mdx
+++ b/src/content/pages/en/resources/contributing.mdx
@@ -116,7 +116,7 @@ maximum of 10. If the TC should drop below 5 members the active TC members shoul
 someone new. If a TC member is stepping down, they are encouraged (but not required) to
 nominate someone to take their place.
 
-TC members will be added as admin's on the Github orgs, npm orgs, and other resources as
+TC members will be added as admin's on the GitHub orgs, npm orgs, and other resources as
 necessary to be effective in the role.
 
 To remain "active" a TC member should have participation within the last 12 months and miss


### PR DESCRIPTION
Github -> GitHub