### PR TITLE
fix: version switcher 404 on non versioned pages

### DIFF
--- a/src/components/patterns/Sidebar/SidebarVersionManager.ts
+++ b/src/components/patterns/Sidebar/SidebarVersionManager.ts
@@ -10,15 +10,12 @@ export class SidebarVersionManager {
   }
 
   setup(): void {
-    const versionSwitchers = this.sidebar.querySelectorAll(
-      '[data-version-switcher] select, [data-version-select]'
-    );
+    const versionSwitchers = this.sidebar.querySelectorAll('[data-version-switcher]');
 
     versionSwitchers.forEach((switcher) => {
-      switcher.addEventListener('change', (e) => {
-        const select = e.target as HTMLSelectElement;
-        this.handleVersionChange(select.value);
-      });
+      switcher.addEventListener('select-change', ((e: CustomEvent<{ value: string }>) => {
+        this.handleVersionChange(e.detail.value);
+      }) as EventListener);
     });
   }
 
@@ -128,18 +125,5 @@ export class SidebarVersionManager {
 
   updatePath(path: string[]): void {
     this.activeSubmenuPath = path;
-  }
-
-  getVersion(): string {
-    return this.currentVersion;
-  }
-
-  setVersion(version: string): void {
-    const versionSelects =
-      this.sidebar.querySelectorAll<HTMLSelectElement>('[data-version-select]');
-    versionSelects.forEach((select) => {
-      select.value = version;
-    });
-    this.handleVersionChange(version);
   }
 }

--- a/src/components/patterns/VersionSwitcher/VersionSwitcher.astro
+++ b/src/components/patterns/VersionSwitcher/VersionSwitcher.astro
@@ -72,42 +72,6 @@ const selectOptions: SelectOption[] = versions.map((version) => ({
     size="md"
     variant="default"
     fullWidth
-    data-version-select
     aria-label={t('version.selectLabel')}
   />
 </Flex>
-
-<script>
-  function handleVersionChange(event: Event) {
-    const customEvent = event as CustomEvent<{ value: string }>;
-    const newVersion = customEvent.detail.value;
-    const currentPath = window.location.pathname;
-
-    const pathParts = currentPath.split('/').filter(Boolean);
-
-    const versionIndex = pathParts.findIndex((part) => /^\d+x$/.test(part));
-
-    if (versionIndex !== -1) {
-      pathParts[versionIndex] = newVersion;
-    } else if (pathParts.length >= 2) {
-      pathParts.splice(1, 0, newVersion);
-    }
-
-    window.location.href = '/' + pathParts.join('/');
-  }
-
-  function initVersionSwitcher() {
-    const versionSwitchers = document.querySelectorAll('[data-version-switcher]');
-
-    versionSwitchers.forEach((versionSwitcher) => {
-      const selectContainer = versionSwitcher.querySelector('[data-select-container]');
-      if (!selectContainer) return;
-
-      selectContainer.removeEventListener('select-change', handleVersionChange);
-      selectContainer.addEventListener('select-change', handleVersionChange);
-    });
-  }
-
-  initVersionSwitcher();
-  document.addEventListener('astro:page-load', initVersionSwitcher);
-</script>


### PR DESCRIPTION
closes #2330 

# Problem

There were two different handlers for version switching, and the buggy one was handling the version switch.

In the "buggy" one, it assumed we were on a versioned page, which was not always the case. So when switching from the blog `en/blog`, it would update the URL to be  `/en/4x/blog` and we'd 404

# Fix

Drop the other dumber handler, wire up the `SidebarVersionManager` to listen to the correct event.

The `SidebarVersionManager` correctly implements the case where we are on a non versioned page and switch versions from the sidebar, it will drop us into the sidebar section we have open at the correct version. But it was listening for the wrong event, so never had a chance to trigger the correct logic.

The other handler was dumber and did not have that logic, but was the one handling the event.