### PR TITLE
docs(5x): clarify next() usage in route handler examples

### DIFF
--- a/src/content/docs/en/5x/guide/routing.mdx
+++ b/src/content/docs/en/5x/guide/routing.mdx
@@ -242,6 +242,9 @@ app.get(
 );
 ```
 
+In this example:
+The callback does not end the request-response cycle, That's why it should call `next()` in order to pass control to the next callback. Otherwise the request will be just left hanging and the client will wait indefinitely for a response.
+
 An array of callback functions can handle a route. For example:
 
 ```js


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

=> Overview

Adds important note about `next()` behaviour in route handler callback examples.

=> Changes

1.  Explains why `next()` should be called when request-response cycle does not end.
2.  Explains why the client's request remains hanging while client waits for a response.


<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
