### PR TITLE
i18n: fixed ES landing title

### DIFF
--- a/src/i18n/ui/es.json
+++ b/src/i18n/ui/es.json
@@ -179,7 +179,7 @@
     "download": "Descargar"
   },
   "hero": {
-    "tagline": "Marco web para Node.js rápido, sin opinión y minimalista",
+    "tagline": "El framework web rápido, minimalista y sin imposiciones para Node.js",
     "getStarted": "Empezar",
     "kawaiiLogoAlt": "Logo de Express.js kawaii",
     "videoPause": "Pausar vídeo de fondo",


### PR DESCRIPTION
Description:
The current landing page title for express.js on spanish (es) is wrong. It's translating literally the word "framework" into "marco" which does not make any sense for spanish speaking web developers.

The proposal is to keep the word "framework" in english which is widely known in spanish speaking countries for web development also, I proposed a small tweak of words to better explain the word "unopinionated" in spanish.

Current landing page title in spanish:
<img width="1340" height="712" alt="Screenshot 2026-05-21 at 22 19 14" src="https://github.com/user-attachments/assets/a477f16e-bcb0-4c0b-9231-fe926afe2855" />

Proposed change:
<img width="1341" height="632" alt="Screenshot 2026-05-21 at 22 21 11" src="https://github.com/user-attachments/assets/a8247d8e-2ad2-4d7b-a8da-6dfab2dffce2" />


<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
