### PR TITLE
fix: remove broken prisma-fullstack example link

### DIFF
--- a/src/content/docs/en/5x/starter/examples.mdx
+++ b/src/content/docs/en/5x/starter/examples.mdx
@@ -45,5 +45,4 @@ Expressjs project team.
 
 </Alert>
 
-- [prisma-fullstack](https://github.com/prisma/prisma-examples/tree/latest/pulse/fullstack-simple-chat) - Fullstack app with Express and Next.js using [Prisma](https://www.npmjs.com/package/prisma) as an ORM
 - [prisma-rest-api-ts](https://github.com/prisma/prisma-examples/tree/latest/orm/express) - REST API with Express in TypeScript using [Prisma](https://www.npmjs.com/package/prisma) as an ORM


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
## What

Removes the `prisma-fullstack` entry from the 5.x starter examples page
(`src/content/docs/en/5x/starter/examples.mdx`).

## Why

The link pointed to
`https://github.com/prisma/prisma-examples/tree/latest/pulse/fullstack-simple-chat`,
which no longer exists and returns a **404**. Prisma reorganized their
`prisma-examples` repository and removed the Pulse fullstack chat example.

## Changes

- Removed the broken `prisma-fullstack` list item.
- Left the `prisma-rest-api-ts` example untouched  that link still resolves correctly.

## Testing

- `npm run check` passes (types + formatting).
- Verified the removed URL returns 404 and the remaining URL resolves.

