### PR TITLE
docs: remove prisma-fullstack example link(it not exist)

### DIFF
--- a/src/content/docs/en/5x/starter/examples.mdx
+++ b/src/content/docs/en/5x/starter/examples.mdx
@@ -45,5 +45,4 @@ Expressjs project team.
 
 </Alert>
 
-- [prisma-fullstack](https://github.com/prisma/prisma-examples/tree/latest/pulse/fullstack-simple-chat) - Fullstack app with Express and Next.js using [Prisma](https://www.npmjs.com/package/prisma) as an ORM
 - [prisma-rest-api-ts](https://github.com/prisma/prisma-examples/tree/latest/orm/express) - REST API with Express in TypeScript using [Prisma](https://www.npmjs.com/package/prisma) as an ORM


### PR DESCRIPTION
It link jump to this: 
<img width="1458" height="982" alt="image" src="https://github.com/user-attachments/assets/da1ce9b6-1e9e-45c7-8b9e-2497786757cc" />

And I have not found the same full-stack use express:

<img width="522" height="468" alt="image" src="https://github.com/user-attachments/assets/1b024c91-d4e7-40c2-bd42-24f58b83b57a" />


<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
