### PR TITLE
docs: add TypeScript section to express-generator page

### DIFF
--- a/src/content/docs/en/4x/starter/generator.mdx
+++ b/src/content/docs/en/4x/starter/generator.mdx
@@ -123,3 +123,7 @@ The app structure created by the generator is just one of many ways to structure
 Feel free to use this structure or modify it to best suit your needs.
 
 </Alert>
+
+## TypeScript
+
+The official `express-generator` outputs a JavaScript skeleton. For a TypeScript scaffold, see community alternatives such as [`express-generator-typescript`](https://github.com/seanpmaxwell/express-generator-typescript).

--- a/src/content/docs/en/5x/starter/generator.mdx
+++ b/src/content/docs/en/5x/starter/generator.mdx
@@ -123,3 +123,7 @@ The app structure created by the generator is just one of many ways to structure
 Feel free to use this structure or modify it to best suit your needs.
 
 </Alert>
+
+## TypeScript
+
+The official `express-generator` outputs a JavaScript skeleton. For a TypeScript scaffold, see community alternatives such as [`express-generator-typescript`](https://github.com/seanpmaxwell/express-generator-typescript).


### PR DESCRIPTION
Fixes expressjs/express#7231.

## Summary

The [Express application generator](https://expressjs.com/en/starter/generator.html) page does not mention TypeScript. Adds a short `TypeScript` subsection to the end of the generator docs (both 4x and 5x), noting that the official `express-generator` outputs a JavaScript skeleton and pointing to `express-generator-typescript` as a community alternative, exactly as suggested in the issue.

Scoped narrowly:

- No endorsement of the community project beyond "see community alternatives such as…", to avoid implying Express officially blesses any third-party generator.
- Same text applied to `src/content/docs/en/4x/starter/generator.mdx` and `src/content/docs/en/5x/starter/generator.mdx` so both versions stay in sync.

## Checks run locally

- `npm run check` (format:check + lint) — clean
- `npm run build` — 1222 pages built, no errors

Happy to expand the section (e.g. a small tsconfig.json or App.ts snippet) if maintainers prefer a heavier addition.
