### PR TITLE
docs: improve and restructure the error handling guides

### DIFF
--- a/src/content/docs/en/4x/guide/error-handling.mdx
+++ b/src/content/docs/en/4x/guide/error-handling.mdx
@@ -62,7 +62,7 @@ app.get('/', (req: Request, res: Response, next: NextFunction) => {
 });
 ```
 
-Errors from rejected promises are not passed to `next` automatically, and this includes `async` functions: if an `async` route handler throws or awaits a rejected promise, the request will hang. You must catch the error yourself and pass it to Express:
+Errors from rejected promises are not passed to `next` automatically, and this includes `async` functions: if an `async` route handler throws or awaits a rejected promise, the rejection is unhandled, which crashes the process on current Node.js versions. You must catch the error yourself and pass it to Express:
 
 ```js
 app.get('/user/:id', async (req, res, next) => {

--- a/src/content/docs/en/4x/guide/error-handling.mdx
+++ b/src/content/docs/en/4x/guide/error-handling.mdx
@@ -62,14 +62,16 @@ app.get('/', (req: Request, res: Response, next: NextFunction) => {
 });
 ```
 
-Starting with Express 5, route handlers and middleware that return a Promise
-will call `next(value)` automatically when they reject or throw an error.
-For example:
+Errors from rejected promises are not passed to `next` automatically, and this includes `async` functions: if an `async` route handler throws or awaits a rejected promise, the request will hang. You must catch the error yourself and pass it to Express:
 
 ```js
 app.get('/user/:id', async (req, res, next) => {
-  const user = await getUserById(req.params.id);
-  res.send(user);
+  try {
+    const user = await getUserById(req.params.id);
+    res.send(user);
+  } catch (err) {
+    next(err);
+  }
 });
 ```
 
@@ -77,14 +79,22 @@ app.get('/user/:id', async (req, res, next) => {
 import { type Request, type Response, type NextFunction } from 'express';
 
 app.get('/user/:id', async (req: Request, res: Response, next: NextFunction) => {
-  const user = await getUserById(req.params.id);
-  res.send(user);
+  try {
+    const user = await getUserById(req.params.id);
+    res.send(user);
+  } catch (err) {
+    next(err);
+  }
 });
 ```
 
-If `getUserById` throws an error or rejects, `next` will be called with either
-the thrown error or the rejected value. If no rejected value is provided, `next`
-will be called with a default Error object provided by the Express router.
+<Alert type="info">
+
+Consider [updating to Express 5](/guide/migrating-5), where route handlers and middleware that
+return a Promise call `next(value)` automatically when they reject or throw an error, making the
+`try...catch` above unnecessary.
+
+</Alert>
 
 If you pass anything to the `next()` function (except the string `'route'`),
 Express regards the current request as being an error and will skip any

--- a/src/content/docs/en/4x/guide/error-handling.mdx
+++ b/src/content/docs/en/4x/guide/error-handling.mdx
@@ -180,9 +180,7 @@ app.get('/', (req: Request, res: Response, next: NextFunction) => {
 });
 ```
 
-Since promises automatically catch both synchronous errors and rejected promises,
-you can simply provide `next` as the final catch handler and Express will catch errors,
-because the catch handler is given the error as the first argument.
+If a callback in the promise chain throws, the chain turns that exception into a rejection, which travels down to the final `.catch`. There, passing `next` as the handler is enough: `.catch` calls it with the error as its first argument, which is exactly the argument `next` expects, so the error reaches Express.
 
 You could also use a chain of handlers to rely on synchronous error
 catching, by reducing the asynchronous code to something trivial. For example:
@@ -219,7 +217,7 @@ app.get('/', [
 ]);
 ```
 
-The above example has a couple of trivial statements from the `readFile`
+The above example contains a couple of trivial statements following the `readFile`
 call. If `readFile` causes an error, then it passes the error to Express, otherwise you
 quickly return to the world of synchronous error handling in the next handler
 in the chain. Then, the example above tries to process the data. If this fails, then the
@@ -424,7 +422,7 @@ function logErrors(err: Error, req: Request, res: Response, next: NextFunction) 
 
 Also in this example, `clientErrorHandler` is defined as follows; in this case, the error is explicitly passed along to the next one.
 
-Notice that when _not_ calling "next" in an error-handling function, you are responsible for writing (and ending) the response. Otherwise, those requests will "hang" and will not be eligible for garbage collection.
+Notice that when you do not call `next` in an error-handling function, you are responsible for writing (and ending) the response. Otherwise, those requests will "hang" and will not be eligible for garbage collection.
 
 ```js
 function clientErrorHandler(err, req, res, next) {

--- a/src/content/docs/en/5x/guide/error-handling.mdx
+++ b/src/content/docs/en/5x/guide/error-handling.mdx
@@ -110,7 +110,7 @@ app.get('/', (req, res, next) => {
 });
 ```
 
-Since promises automatically catch both synchronous errors and rejected promises,
+Since promises automatically handle both synchronous errors and rejected promises,
 you can simply provide `next` as the final catch handler and Express will catch errors,
 because the catch handler is given the error as the first argument.
 
@@ -132,7 +132,7 @@ app.get('/', [
 ]);
 ```
 
-The above example has a couple of trivial statements from the `readFile`
+The above example contains a couple of trivial statements following the `readFile`
 call. If `readFile` causes an error, then it passes the error to Express, otherwise you
 quickly return to the world of synchronous error handling in the next handler
 in the chain. Then, the example above tries to process the data. If this fails, then the
@@ -258,7 +258,7 @@ function logErrors(err, req, res, next) {
 
 Also in this example, `clientErrorHandler` is defined as follows; in this case, the error is explicitly passed along to the next one.
 
-Notice that when _not_ calling "next" in an error-handling function, you are responsible for writing (and ending) the response. Otherwise, those requests will "hang" and will not be eligible for garbage collection.
+Notice that when you do not call "next" in an error-handling function, you are responsible for writing (and ending) the response. Otherwise, those requests will "hang" and will not be eligible for garbage collection.
 
 ```js
 function clientErrorHandler(err, req, res, next) {

--- a/src/content/docs/en/5x/guide/error-handling.mdx
+++ b/src/content/docs/en/5x/guide/error-handling.mdx
@@ -180,9 +180,7 @@ app.get('/', (req: Request, res: Response, next: NextFunction) => {
 });
 ```
 
-Since promises automatically handle both synchronous errors and rejected promises,
-you can simply provide `next` as the final catch handler and Express will catch errors,
-because the catch handler is given the error as the first argument.
+If a callback in the promise chain throws, the chain turns that exception into a rejection, which travels down to the final `.catch`. There, passing `next` as the handler is enough: `.catch` calls it with the error as its first argument, which is exactly the argument `next` expects, so the error reaches Express.
 
 You could also use a chain of handlers to rely on synchronous error
 catching, by reducing the asynchronous code to something trivial. For example:
@@ -424,7 +422,7 @@ function logErrors(err: Error, req: Request, res: Response, next: NextFunction) 
 
 Also in this example, `clientErrorHandler` is defined as follows; in this case, the error is explicitly passed along to the next one.
 
-Notice that when you do not call "next" in an error-handling function, you are responsible for writing (and ending) the response. Otherwise, those requests will "hang" and will not be eligible for garbage collection.
+Notice that when you do not call `next` in an error-handling function, you are responsible for writing (and ending) the response. Otherwise, those requests will "hang" and will not be eligible for garbage collection.
 
 ```js
 function clientErrorHandler(err, req, res, next) {

--- a/src/content/docs/en/5x/guide/error-handling.mdx
+++ b/src/content/docs/en/5x/guide/error-handling.mdx
@@ -14,6 +14,8 @@ handler so you don't need to write your own to get started.
 It's important to ensure that Express catches all errors that occur while
 running route handlers and middleware.
 
+### Errors in synchronous code
+
 Errors that occur in synchronous code inside route handlers and middleware
 require no extra work. If synchronous code throws an error, then Express will
 catch and process it. For example:
@@ -32,9 +34,95 @@ app.get('/', (req: Request, res: Response) => {
 });
 ```
 
-For errors returned from asynchronous functions invoked by route handlers
-and middleware, you must pass them to the `next()` function, where Express will
-catch and process them. For example:
+### Errors in asynchronous code
+
+The recommended way to write asynchronous handlers is with `async` functions.
+Route handlers and middleware that return a Promise call `next(value)`
+automatically when they reject or throw an error, and `async` functions always
+return a Promise, so their errors reach Express with no extra work. For example:
+
+```js
+app.get('/user/:id', async (req, res) => {
+  const user = await getUserById(req.params.id);
+  res.send(user);
+});
+```
+
+```ts
+import { type Request, type Response } from 'express';
+
+app.get('/user/:id', async (req: Request, res: Response) => {
+  const user = await getUserById(req.params.id);
+  res.send(user);
+});
+```
+
+If `getUserById` throws an error or rejects, `next` will be called with either
+the thrown error or the rejected value. If no rejected value is provided, `next`
+will be called with a default Error object provided by the Express router.
+
+If you pass anything to the `next()` function (except the string `'route'`),
+Express regards the current request as being an error and will skip any
+remaining non-error handling routing and middleware functions.
+
+### Working with promise chains
+
+If you build a promise chain instead of using an `async` function, return the
+promise from the handler and Express will likewise call `next` automatically
+when it rejects:
+
+```js
+app.get('/', (req, res) => {
+  return Promise.resolve().then(() => {
+    throw new Error('BROKEN'); // Express will catch this and call next.
+  });
+});
+```
+
+```ts
+import { type Request, type Response } from 'express';
+
+app.get('/', (req: Request, res: Response) => {
+  return Promise.resolve().then(() => {
+    throw new Error('BROKEN'); // Express will catch this and call next.
+  });
+});
+```
+
+If the promise is not returned, Express does not know it exists, and you must
+route the error yourself by providing `next` as the final catch handler.
+Without it, the rejection would be unhandled and crash the process:
+
+```js
+app.get('/', (req, res, next) => {
+  Promise.resolve()
+    .then(() => {
+      throw new Error('BROKEN');
+    })
+    .catch(next); // Errors will be passed to Express.
+});
+```
+
+```ts
+import { type Request, type Response, type NextFunction } from 'express';
+
+app.get('/', (req: Request, res: Response, next: NextFunction) => {
+  Promise.resolve()
+    .then(() => {
+      throw new Error('BROKEN');
+    })
+    .catch(next); // Errors will be passed to Express.
+});
+```
+
+This works because if a callback in the promise chain throws, the chain turns that exception into a rejection, which travels down to the final `.catch`. There, `.catch` calls its handler with the error as the first argument, which is exactly the argument `next` expects, so the error reaches Express.
+
+### Working with callback APIs
+
+Errors produced by callback-based APIs, such as those in `node:fs`, are not
+thrown and are not part of any promise. The callback receives them as its first
+argument, and you must pass them to the `next()` function yourself, where
+Express will catch and process them. For example:
 
 ```js
 app.get('/', (req, res, next) => {
@@ -61,34 +149,6 @@ app.get('/', (req: Request, res: Response, next: NextFunction) => {
   });
 });
 ```
-
-Route handlers and middleware that return a Promise call `next(value)`
-automatically when they reject or throw an error. This includes `async`
-functions, which always return a Promise. For example:
-
-```js
-app.get('/user/:id', async (req, res, next) => {
-  const user = await getUserById(req.params.id);
-  res.send(user);
-});
-```
-
-```ts
-import { type Request, type Response, type NextFunction } from 'express';
-
-app.get('/user/:id', async (req: Request, res: Response, next: NextFunction) => {
-  const user = await getUserById(req.params.id);
-  res.send(user);
-});
-```
-
-If `getUserById` throws an error or rejects, `next` will be called with either
-the thrown error or the rejected value. If no rejected value is provided, `next`
-will be called with a default Error object provided by the Express router.
-
-If you pass anything to the `next()` function (except the string `'route'`),
-Express regards the current request as being an error and will skip any
-remaining non-error handling routing and middleware functions.
 
 If the callback in a sequence provides no data, only errors, you can simplify
 this code as follows:
@@ -120,77 +180,6 @@ app.get('/', [
 In the above example, `next` is provided as the callback for `fs.writeFile`,
 which is called with or without errors. If there is no error, the second
 handler is executed, otherwise Express catches and processes the error.
-
-You must catch errors that occur in asynchronous code invoked by route handlers or
-middleware and pass them to Express for processing. For example:
-
-```js
-app.get('/', (req, res, next) => {
-  setTimeout(() => {
-    try {
-      throw new Error('BROKEN');
-    } catch (err) {
-      next(err);
-    }
-  }, 100);
-});
-```
-
-```ts
-import { type Request, type Response, type NextFunction } from 'express';
-
-app.get('/', (req: Request, res: Response, next: NextFunction) => {
-  setTimeout(() => {
-    try {
-      throw new Error('BROKEN');
-    } catch (err) {
-      next(err);
-    }
-  }, 100);
-});
-```
-
-The above example uses a `try...catch` block to catch errors in the
-asynchronous code and pass them to Express. If the `try...catch`
-block were omitted, Express would not catch the error since it is not part of the synchronous
-handler code.
-
-Use promises to avoid the overhead of the `try...catch` block or when using functions
-that return promises. For example:
-
-```js
-app.get('/', (req, res, next) => {
-  Promise.resolve()
-    .then(() => {
-      throw new Error('BROKEN');
-    })
-    .catch(next); // Errors will be passed to Express.
-});
-```
-
-```ts
-import { type Request, type Response, type NextFunction } from 'express';
-
-app.get('/', (req: Request, res: Response, next: NextFunction) => {
-  Promise.resolve()
-    .then(() => {
-      throw new Error('BROKEN');
-    })
-    .catch(next); // Errors will be passed to Express.
-});
-```
-
-If a callback in the promise chain throws, the chain turns that exception into a rejection, which travels down to the final `.catch`. There, passing `next` as the handler is enough: `.catch` calls it with the error as its first argument, which is exactly the argument `next` expects, so the error reaches Express.
-
-Note that the handler above does not return the promise chain, so Express does not know it exists, and attaching `.catch(next)` is what routes the error. Without the `.catch(next)`, the rejection would be unhandled and crash the process. If you return the promise instead, Express watches it and calls `next` automatically when it rejects, so the `.catch` is no longer needed:
-
-```js
-app.get('/', (req, res) => {
-  return Promise.resolve().then(() => {
-    throw new Error('BROKEN'); // Express will catch this and call next.
-  });
-});
-```
 
 You could also use a chain of handlers to rely on synchronous error
 catching, by reducing the asynchronous code to something trivial. For example:
@@ -234,6 +223,41 @@ in the chain. Then, the example above tries to process the data. If this fails, 
 synchronous error handler will catch it. If you had done this processing inside
 the `readFile` callback, then the application might exit and the Express error
 handlers would not run.
+
+Finally, for asynchronous code that provides no error-first callback, such as a
+timer, catch errors inside the asynchronous code itself and pass them to
+Express:
+
+```js
+app.get('/', (req, res, next) => {
+  setTimeout(() => {
+    try {
+      throw new Error('BROKEN');
+    } catch (err) {
+      next(err);
+    }
+  }, 100);
+});
+```
+
+```ts
+import { type Request, type Response, type NextFunction } from 'express';
+
+app.get('/', (req: Request, res: Response, next: NextFunction) => {
+  setTimeout(() => {
+    try {
+      throw new Error('BROKEN');
+    } catch (err) {
+      next(err);
+    }
+  }, 100);
+});
+```
+
+The above example uses a `try...catch` block to catch errors in the
+asynchronous code and pass them to Express. If the `try...catch`
+block were omitted, Express would not catch the error since it is not part of the synchronous
+handler code.
 
 Whichever method you use, if you want Express error handlers to be called in and the
 application to survive, you must ensure that Express receives the error.

--- a/src/content/docs/en/5x/guide/error-handling.mdx
+++ b/src/content/docs/en/5x/guide/error-handling.mdx
@@ -180,7 +180,7 @@ app.get('/', (req: Request, res: Response, next: NextFunction) => {
 });
 ```
 
-Since promises automatically catch both synchronous errors and rejected promises,
+Since promises automatically handle both synchronous errors and rejected promises,
 you can simply provide `next` as the final catch handler and Express will catch errors,
 because the catch handler is given the error as the first argument.
 
@@ -219,7 +219,7 @@ app.get('/', [
 ]);
 ```
 
-The above example has a couple of trivial statements from the `readFile`
+The above example contains a couple of trivial statements following the `readFile`
 call. If `readFile` causes an error, then it passes the error to Express, otherwise you
 quickly return to the world of synchronous error handling in the next handler
 in the chain. Then, the example above tries to process the data. If this fails, then the
@@ -424,7 +424,7 @@ function logErrors(err: Error, req: Request, res: Response, next: NextFunction) 
 
 Also in this example, `clientErrorHandler` is defined as follows; in this case, the error is explicitly passed along to the next one.
 
-Notice that when _not_ calling "next" in an error-handling function, you are responsible for writing (and ending) the response. Otherwise, those requests will "hang" and will not be eligible for garbage collection.
+Notice that when you do not call "next" in an error-handling function, you are responsible for writing (and ending) the response. Otherwise, those requests will "hang" and will not be eligible for garbage collection.
 
 ```js
 function clientErrorHandler(err, req, res, next) {

--- a/src/content/docs/en/5x/guide/error-handling.mdx
+++ b/src/content/docs/en/5x/guide/error-handling.mdx
@@ -62,9 +62,9 @@ app.get('/', (req: Request, res: Response, next: NextFunction) => {
 });
 ```
 
-Starting with Express 5, route handlers and middleware that return a Promise
-will call `next(value)` automatically when they reject or throw an error.
-For example:
+Route handlers and middleware that return a Promise call `next(value)`
+automatically when they reject or throw an error. This includes `async`
+functions, which always return a Promise. For example:
 
 ```js
 app.get('/user/:id', async (req, res, next) => {
@@ -181,6 +181,16 @@ app.get('/', (req: Request, res: Response, next: NextFunction) => {
 ```
 
 If a callback in the promise chain throws, the chain turns that exception into a rejection, which travels down to the final `.catch`. There, passing `next` as the handler is enough: `.catch` calls it with the error as its first argument, which is exactly the argument `next` expects, so the error reaches Express.
+
+Note that the handler above does not return the promise chain, so Express does not know it exists, and attaching `.catch(next)` is what routes the error. Without the `.catch(next)`, the rejection would be unhandled and crash the process. If you return the promise instead, Express watches it and calls `next` automatically when it rejects, so the `.catch` is no longer needed:
+
+```js
+app.get('/', (req, res) => {
+  return Promise.resolve().then(() => {
+    throw new Error('BROKEN'); // Express will catch this and call next.
+  });
+});
+```
 
 You could also use a chain of handlers to rely on synchronous error
 catching, by reducing the asynchronous code to something trivial. For example:


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

=> SUMMARY

improving wording for better readability in express 5/error/handling guide.

=> CHANGES

1.  line 113: catch -> handle

2.  line 135: has a couple of trivial statements from the `readfile` call -> contains a couple of trivial statements following the `readfile` call

3.  line 261: not calling -> you do not call 
<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
