### PR TITLE
Fix RSS Feed 404 URLs

### DIFF
--- a/src/pages/feed.xml.ts
+++ b/src/pages/feed.xml.ts
@@ -19,7 +19,7 @@ export const GET: APIRoute = async (context) => {
     description: 'News and updates about express.js',
     site: site.href,
     items: sortedBlog.map((post) => ({
-      link: `/blog/${post.id}/`,
+      link: `/en/blog/${post.id}/`,
       title: post.data.title,
       pubDate: getPubDateFromId(post.id),
       description: post.data.description,

--- a/src/utils/rss.ts
+++ b/src/utils/rss.ts
@@ -39,7 +39,7 @@ export function shouldIncludeInFeed(id: string): boolean {
 }
 
 export function getLinkedTitleContent(title: string, id: string, site: URL): string {
-  const link = new URL(`/blog/${id}/`, site).href;
+  const link = new URL(`/en/blog/${id}/`, site).href;
 
   return `<a href="${link}">${title}</a>`;
 }


### PR DESCRIPTION
I read some articles on the expressjs.com blog and choose to subscribe to the RSS feed in Thunderbird. There I have noticed, that the links in the RSS feed of expressjs.com/feed.xml only point to 404 pages. The URLs are missing the language code. So I have added the `/en/` URL part, as there is only one feed provided and I guess the english one is the most universal.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.