### PR TITLE
docs: mention TypeScript generator option

### DIFF
--- a/src/content/docs/en/4x/starter/generator.mdx
+++ b/src/content/docs/en/4x/starter/generator.mdx
@@ -93,6 +93,11 @@ PS> $env:DEBUG='myapp:*'; npm start
 
 Then, load `http://localhost:3000/` in your browser to access the app.
 
+## TypeScript apps
+
+The official `express-generator` package creates a JavaScript application skeleton.
+For a TypeScript starter, use a community generator such as [`express-generator-typescript`](https://github.com/seanpmaxwell/express-generator-typescript).
+
 The generated app has the following directory structure:
 
 ```bash

--- a/src/content/docs/en/5x/starter/generator.mdx
+++ b/src/content/docs/en/5x/starter/generator.mdx
@@ -93,6 +93,11 @@ PS> $env:DEBUG='myapp:*'; npm start
 
 Then, load `http://localhost:3000/` in your browser to access the app.
 
+## TypeScript apps
+
+The official `express-generator` package creates a JavaScript application skeleton.
+For a TypeScript starter, use a community generator such as [`express-generator-typescript`](https://github.com/seanpmaxwell/express-generator-typescript).
+
 The generated app has the following directory structure:
 
 ```bash


### PR DESCRIPTION
Refs expressjs/express#7231

Adds a short note to the English Express application generator docs for both 4.x and 5.x explaining that the official generator creates a JavaScript skeleton and linking to the community TypeScript generator suggested in the issue.

Checks:
- npm run check
- npm run build