### PR TITLE
docs: mention TypeScript option on the generator page

### DIFF
--- a/src/content/docs/en/4x/starter/generator.mdx
+++ b/src/content/docs/en/4x/starter/generator.mdx
@@ -123,3 +123,13 @@ The app structure created by the generator is just one of many ways to structure
 Feel free to use this structure or modify it to best suit your needs.
 
 </Alert>
+
+## Generating a TypeScript app
+
+`express-generator` scaffolds a JavaScript app. For a TypeScript skeleton, the community-maintained [`express-generator-typescript`](https://github.com/seanpmaxwell/express-generator-typescript) tool runs the same way:
+
+```bash
+$ npx express-generator-typescript myapp
+```
+
+It produces a project with a comparable structure plus `tsconfig.json` and build scripts. This tool is maintained by the community, not the Express team.

--- a/src/content/docs/en/5x/starter/generator.mdx
+++ b/src/content/docs/en/5x/starter/generator.mdx
@@ -123,3 +123,13 @@ The app structure created by the generator is just one of many ways to structure
 Feel free to use this structure or modify it to best suit your needs.
 
 </Alert>
+
+## Generating a TypeScript app
+
+`express-generator` scaffolds a JavaScript app. For a TypeScript skeleton, the community-maintained [`express-generator-typescript`](https://github.com/seanpmaxwell/express-generator-typescript) tool runs the same way:
+
+```bash
+$ npx express-generator-typescript myapp
+```
+
+It produces a project with a comparable structure plus `tsconfig.json` and build scripts. This tool is maintained by the community, not the Express team.


### PR DESCRIPTION
Closes expressjs/express#7231.

The generator page doesn't mention TypeScript anywhere, and `express-generator` only scaffolds JavaScript. The issue suggested pointing to the community `express-generator-typescript` project, so I added a short section to that effect on both the 4x and 5x English pages.

I kept it to a couple of sentences and a one-line command, and flagged that the tool is community-maintained rather than official. Left the translated pages alone.