### PR TITLE
Switch from directory to file format in Astro

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ on:
 # Cancel in progress workflows
 # in the scenario where we already had a run going for that PR/branch/tag but then triggered a new run
 concurrency:
-  group: '${{ github.workflow }} ✨ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  group: "${{ github.workflow }} ✨ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"
   cancel-in-progress: true
 
 permissions:
@@ -36,8 +36,8 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version-file: '.nvmrc'
-          cache: 'npm'
+          node-version-file: ".nvmrc"
+          cache: "npm"
 
       - name: Install Node.js dependencies
         run: npm ci
@@ -97,11 +97,11 @@ jobs:
         with:
           args: |
             --root-dir $PWD/dist
+            --fallback-extensions html
             --exclude-path dist/llms.txt
             --exclude-path dist/llms/
             --exclude-private
             --exclude-loopback
-            --remap "https://expressjs\.com\/((?:[^\/]+\/)*[^\/\.]+)\/?$ file://$PWD/dist/\$1/index.html"
-            --remap "https://expressjs\.com\/(.*\.html)$ file://$PWD/dist/\$1"
+            --remap "^https://expressjs\.com\/ file://$PWD/dist/"
             dist/
           fail: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ on:
 # Cancel in progress workflows
 # in the scenario where we already had a run going for that PR/branch/tag but then triggered a new run
 concurrency:
-  group: "${{ github.workflow }} ✨ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"
+  group: '${{ github.workflow }} ✨ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
   cancel-in-progress: true
 
 permissions:
@@ -36,8 +36,8 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version-file: ".nvmrc"
-          cache: "npm"
+          node-version-file: '.nvmrc'
+          cache: 'npm'
 
       - name: Install Node.js dependencies
         run: npm ci

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -5,7 +5,7 @@
 ^https://github\.com/
 
 # Exclude 404 pages
-dist/(.*/)?404((/index)?\.html|/)$
+dist/(.*/)?404((/index)?\.html|/)?$
 
 # Exclude Open Collective links
 ^https://opencollective\.com/

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -23,6 +23,9 @@ const site = NETLIFY_PREVIEW_SITE || 'https://expressjs.com';
 export default defineConfig({
   redirects,
   site,
+  build: {
+    format: 'file',
+  },
   markdown: {
     // Link localization (Markdown links + raw HTML/JSX `<a href>`). Configuration —
     // localized sections, versioned sections, default version, and the "global" pages

--- a/src/components/patterns/Sidebar/utils.ts
+++ b/src/components/patterns/Sidebar/utils.ts
@@ -12,7 +12,7 @@ export type SubmenuData = {
 };
 
 export function normalizePath(path: string): string {
-  return path.replace(/\/$/, '');
+  return path.replace(/(?:\/|\.html)$/, '');
 }
 
 export function isVersioned(versioned: VersionPrefix[] | undefined, version: string): boolean {

--- a/src/i18n/utils.ts
+++ b/src/i18n/utils.ts
@@ -1,7 +1,8 @@
 import { ui, defaultLang, languages } from './locales';
 
 export function getLangFromUrl(url: URL) {
-  const [, lang] = url.pathname.split('/');
+  const strippedPathname = url.pathname.replace(/\.html$/, '');
+  const [, lang] = strippedPathname.split('/');
   if (lang in ui) return lang as keyof typeof ui;
   return defaultLang;
 }
@@ -34,7 +35,7 @@ export function getLanguageCodes(): string[] {
  */
 export function createLanguagePathRegex(): RegExp {
   const codes = getLanguageCodes().join('|');
-  return new RegExp(`^/(${codes})/`);
+  return new RegExp(`^/(${codes})(?:/|$)`);
 }
 
 /**
@@ -43,9 +44,10 @@ export function createLanguagePathRegex(): RegExp {
 export function replaceLanguageInPath(path: string, newLang: string): string {
   const langRegex = createLanguagePathRegex();
 
-  if (langRegex.test(path)) {
-    return path.replace(langRegex, `/${newLang}/`);
+  const strippedPath = path.replace(/\.html$/, '');
+  if (langRegex.test(strippedPath)) {
+    return strippedPath.replace(langRegex, `/${newLang}/`);
   } else {
-    return `/${newLang}${path}`;
+    return `/${newLang}${strippedPath}`;
   }
 }

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -24,9 +24,9 @@ const pageTitle = title
   ? `${title} · Express.js`
   : 'Express.js · Node.js web application framework';
 
-const canonicalUrl = new URL(Astro.url.pathname, Astro.site || Astro.url.origin);
+const pathname = Astro.url.pathname.replace(/\.html$/, '');
+const canonicalUrl = new URL(pathname, Astro.site || Astro.url.origin);
 
-const pathname = Astro.url.pathname.replace(/\/$/, '');
 const segments = pathname.split('/').filter(Boolean);
 const langSegment = segments[0] || 'en';
 const restSegments = segments.slice(1);

--- a/src/utils/content.ts
+++ b/src/utils/content.ts
@@ -74,7 +74,7 @@ function resolveLabel(t: (key: string) => string, labelKey?: string, segment?: s
  * Build breadcrumbs
  */
 export function buildBreadcrumbs(pathname: string, t: (key: string) => string): BreadcrumbItem[] {
-  const segments = pathname.replace(/^\/|\/$/g, '').split('/');
+  const segments = pathname.replace(/^\/|\/$|\.html$/g, '').split('/');
 
   // Need at least lang + one content segment
   if (segments.length < 2) return [];


### PR DESCRIPTION
The "file" format generates `name.html` files instead of default `name/index.html`. This would make old links work, even without redirects on Cloudflare level, while still allowing the current link format with no extension. The only observable difference between current version and this PR is that the URLs no longer end with a `/` (GitHub/Netlify serve a 301).

References:

- https://docs.astro.build/en/reference/configuration-reference/#buildformat
- #2332
- @jonchurch's [suggestion on Slack](https://openjs-foundation.slack.com/archives/C090970SCLE/p1779221992561499?thread_ts=1779218541.473839&cid=C090970SCLE)

<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
