### PR TITLE
chore(5x): remove deprecated --save flag from install examples

### DIFF
--- a/src/components/patterns/Hero/Hero.astro
+++ b/src/components/patterns/Hero/Hero.astro
@@ -12,8 +12,8 @@ const t = useTranslations(lang);
 
 const expressPackage = await getEntry('npm', 'express');
 const EXPRESS_VERSION = expressPackage?.data.version ?? '5.x';
-const INSTALL_COMMAND = 'npm install express --save';
-const EXAMPLE_CODE = `const express = require('express')
+const INSTALL_COMMAND = 'npm install express';
+const EXAMPLE_CODE = `const express = require('express');
 const app = express()
 const port = 3000
 

--- a/src/content/docs/en/5x/starter/installing.mdx
+++ b/src/content/docs/en/5x/starter/installing.mdx
@@ -39,9 +39,3 @@ To install Express temporarily and not add it to the dependencies list:
 ```bash
 npm install express --no-save
 ```
-
-<Alert type="info">
-  For npm version 5.0.0 and above, <code>npm install express</code> automatically adds the package
-  to your <code>dependencies</code>. Explicit use of the <code>--save</code> flag is optional and
-  mainly kept for reference purposes.
-</Alert>

--- a/src/content/docs/en/5x/starter/installing.mdx
+++ b/src/content/docs/en/5x/starter/installing.mdx
@@ -39,3 +39,9 @@ To install Express temporarily and not add it to the dependencies list:
 ```bash
 npm install express --no-save
 ```
+
+<Alert type="info">
+  For npm version 5.0.0 and above, <code>npm install express</code> automatically adds the package
+  to your <code>dependencies</code>. Explicit use of the <code>--save</code> flag is optional and
+  mainly kept for reference purposes.
+</Alert>

--- a/tests/e2e/homepage.spec.ts
+++ b/tests/e2e/homepage.spec.ts
@@ -133,7 +133,7 @@ test.describe('Homepage Content', () => {
   test('should display the installation command', async ({ page }) => {
     const installCode = page.getByTestId('install-command');
     await expect(installCode).toBeVisible();
-    await expect(installCode).toContainText(/npm install express --save/i);
+    await expect(installCode).toContainText(/npm install express/i);
   });
 
   test('should have a working "Get Started" call to action', async ({ page }) => {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

I removed the --save flag from the npm install express command on the homepage and added a note explaining the default dependency behavior for npm 5+. I also updated the related tests.

I did this because while exploring the site, I noticed npm install express was written in three different places with different commands. This can be confusing for users wondering what the difference is and which one is correct. I updated the commands to be consistent and added a note to make the behavior clear. 


<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
