### PR TITLE
fix: Alert component in plain .md files

### DIFF
--- a/src/content/blog/2025-07-31-security-releases.mdx
+++ b/src/content/blog/2025-07-31-security-releases.mdx
@@ -12,7 +12,8 @@ import Alert from '@components/primitives/Alert/Alert.astro';
 The Express team has released a new patch version of [Multer](https://www.npmjs.com/package/multer) addressing a high-severity security vulnerability, and a new minor version of [on-headers](https://www.npmjs.com/package/on-headers) addressing a low-severity security vulnerability.
 
 <Alert type="warning">
-We recommend upgrading to the latest version of Multer and On-headers immediately to secure your applications.
+  We recommend upgrading to the latest version of Multer and On-headers immediately to secure your
+  applications.
 </Alert>
 
 The following vulnerabilities have been addressed:

--- a/src/content/pages/en/resources/middleware/index.mdx
+++ b/src/content/pages/en/resources/middleware/index.mdx
@@ -3,6 +3,8 @@ title: Express middleware
 description: Explore a list of Express.js middleware modules maintained by the Express team and the community, including built-in middleware and popular third-party modules.
 ---
 
+import Alert from '@components/primitives/Alert/Alert.astro';
+
 The Express middleware modules listed here are maintained by the
 [Expressjs team](https://github.com/orgs/expressjs/people).
 


### PR DESCRIPTION
Two plain `.md` files used the `Alert` component and one of them (`resources/middleware/index.md`) was missing an import.

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
