### PR TITLE
Fix broken sidebar menu links

### DIFF
--- a/src/config/menu/api.ts
+++ b/src/config/menu/api.ts
@@ -117,8 +117,14 @@ export const apiMenu: Menu = {
                 omitFrom: ['3x'],
               },
               {
+                href: '/api/application#applisten',
+                label: 'app.listen()',
+                omitFrom: ['4x', '5x'],
+              },
+              {
                 href: '/api/application#applistenport-host-backlog-callback',
                 label: 'app.listen()',
+                omitFrom: ['3x'],
               },
               {
                 href: '/api/application#appmethodpath-callback--callback-',
@@ -148,7 +154,16 @@ export const apiMenu: Menu = {
                 omitFrom: ['3x'],
               },
               { href: '/api/application#appsetname-value', label: 'app.set()' },
-              { href: '/api/application#appusepath-callback--callback', label: 'app.use()' },
+              {
+                href: '/api/application#appusepath-function',
+                label: 'app.use()',
+                omitFrom: ['4x', '5x'],
+              },
+              {
+                href: '/api/application#appusepath-callback--callback',
+                label: 'app.use()',
+                omitFrom: ['3x'],
+              },
               {
                 href: '/api/application#appverbpath-callback-callback',
                 label: 'app.VERB()',
@@ -292,17 +307,17 @@ export const apiMenu: Menu = {
                 label: 'req.acceptsLanguages()',
                 omitFrom: ['3x'],
               },
-              { href: '/api/request#reqgetfield', label: 'req.get()', omitFrom: ['3x'] },
-              {
-                href: '/api/request#reqheaderfield',
-                label: 'req.header()',
-                omitFrom: ['4x', '5x'],
-              },
+              { href: '/api/request#reqgetfield', label: 'req.get()' },
               { href: '/api/request#reqistype', label: 'req.is()' },
               {
                 href: '/api/request#reqparamname',
                 label: 'req.param()',
-                omitFrom: ['5x'],
+                omitFrom: ['4x', '5x'],
+              },
+              {
+                href: '/api/request#reqparamname--defaultvalue',
+                label: 'req.param()',
+                omitFrom: ['3x', '5x'],
               },
               {
                 href: '/api/request#reqrangesize-options',
@@ -362,8 +377,14 @@ export const apiMenu: Menu = {
               { href: '/api/response#resclearcookiename--options', label: 'res.clearCookie()' },
               { href: '/api/response#rescookiename-value--options', label: 'res.cookie()' },
               {
+                href: '/api/response#resdownloadpath-filename-fn',
+                label: 'res.download()',
+                omitFrom: ['4x', '5x'],
+              },
+              {
                 href: '/api/response#resdownloadpath--filename--options--fn',
                 label: 'res.download()',
+                omitFrom: ['3x'],
               },
               {
                 href: '/api/response#resenddata-encoding-callback',
@@ -372,13 +393,28 @@ export const apiMenu: Menu = {
               },
               { href: `/api/response#resformatobject`, label: 'res.format()' },
               { href: '/api/response#resgetfield', label: 'res.get()' },
-              { href: `/api/response#resjsonbody`, label: 'res.json()' },
-              { href: '/api/response#resjsonpbody', label: 'res.jsonp()' },
+              {
+                href: `/api/response#resjsonstatusbody-body`,
+                label: 'res.json()',
+                omitFrom: ['4x', '5x'],
+              },
+              { href: `/api/response#resjsonbody`, label: 'res.json()', omitFrom: ['3x'] },
+              {
+                href: '/api/response#resjsonpstatusbody-body',
+                label: 'res.jsonp()',
+                omitFrom: ['4x', '5x'],
+              },
+              { href: '/api/response#resjsonpbody', label: 'res.jsonp()', omitFrom: ['3x'] },
               { href: '/api/response#reslinkslinks', label: 'res.links()' },
               { href: '/api/response#reslocationpath', label: 'res.location()' },
               { href: '/api/response#resredirectstatus-path', label: 'res.redirect()' },
               { href: `/api/response#resrenderview--locals--callback`, label: 'res.render()' },
-              { href: `/api/response#ressendbody`, label: 'res.send()' },
+              {
+                href: `/api/response#ressendbodystatus-body`,
+                label: 'res.send()',
+                omitFrom: ['4x', '5x'],
+              },
+              { href: `/api/response#ressendbody`, label: 'res.send()', omitFrom: ['3x'] },
               {
                 href: '/api/response#ressendfilepath-options-fn',
                 label: 'res.sendfile()',

--- a/src/content/api/3x/api/application/index.mdx
+++ b/src/content/api/3x/api/application/index.mdx
@@ -488,7 +488,7 @@ app.post('/forum/:fid/thread/:tid', middleware, function () {
 });
 ```
 
-### app.all(path, [callback...], callback)
+### app.all(path, callback [, callback ...])
 
 This method functions just like the `app.VERB()` methods,
 however it matches all HTTP verbs.
@@ -521,7 +521,7 @@ the example is much like before, however only restricting paths prefixed with
 app.all('/api/*', requireAuthentication);
 ```
 
-### app.render(view, [options], callback)
+### app.render(view, [locals], callback)
 
 Render a `view` with a callback responding with
 the rendered string. This is the app-level variant of `res.render()`,

--- a/src/content/api/3x/api/response/index.mdx
+++ b/src/content/api/3x/api/response/index.mdx
@@ -62,7 +62,7 @@ res.attachment('path/to/logo.png');
 // Content-Type: image/png
 ```
 
-### res.clearCookie(name, [options])
+### res.clearCookie(name [, options])
 
 Clear cookie `name`. The `path` option defaults to "/".
 
@@ -71,7 +71,7 @@ res.cookie('name', 'tobi', { path: '/admin' });
 res.clearCookie('name', { path: '/admin' });
 ```
 
-### res.cookie(name, value, [options])
+### res.cookie(name, value [, options])
 
 Set cookie `name` to `value`, which may be a string or object converted to JSON. The `path`
 option defaults to "/".
@@ -264,7 +264,7 @@ Link: <http://api.example.com/users?page=2> rel="next",
       <http://api.example.com/users?page=5> rel="last"
 ```
 
-### res.location()
+### res.location(path)
 
 Set the location header.
 
@@ -276,7 +276,7 @@ res.location('../login');
 res.location('back');
 ```
 
-You can use the same kind of `urls` as in `res.redirect()`.
+You can use the same kind of `path` as in `res.redirect()`.
 
 For example, if your application is mounted at `/blog`,
 the following would set the `location` header to
@@ -286,10 +286,11 @@ the following would set the `location` header to
 res.location('admin');
 ```
 
-### res.redirect([status], url)
+### res.redirect([status,] path)
 
-Redirect to the given `url` with optional `status` code
-defaulting to 302 "Found".
+Redirects to the URL derived from the specified `path`, with specified `status`, a positive integer
+that corresponds to an [HTTP status code](https://www.rfc-editor.org/rfc/rfc9110#name-status-codes).
+If not specified, `status` defaults to "302 "Found".
 
 ```js
 res.redirect('/foo/bar');
@@ -338,7 +339,7 @@ the Referer (or Referrer), defaulting to `/` when missing.
 res.redirect('back');
 ```
 
-### res.render(view, [locals], callback)
+### res.render(view [, locals] [, callback])
 
 Render a `view` with a callback responding with
 the rendered string. When an error occurs `next(err)`
@@ -440,7 +441,7 @@ app.get('/user/:uid/photos/:file', function (req, res) {
 });
 ```
 
-### res.set(field, [value])
+### res.set(field [, value])
 
 Set header `field` to `value`, or pass an object to set multiple fields at once.
 

--- a/src/content/api/4x/api/response/index.mdx
+++ b/src/content/api/4x/api/response/index.mdx
@@ -472,7 +472,7 @@ or the referring URL, and the URL specified in the `Location` header; and redire
 ### res.redirect([status,] path)
 
 Redirects to the URL derived from the specified `path`, with specified `status`, a positive integer
-that corresponds to an [HTTP status code](https://www.rfc-editor.org/rfc/rfc9110#name-status-codes) .
+that corresponds to an [HTTP status code](https://www.rfc-editor.org/rfc/rfc9110#name-status-codes).
 If not specified, `status` defaults to "302 "Found".
 
 ```js


### PR DESCRIPTION
Fixes #2359

With this and #2324 (and #2356, which should not be necessary for this, and updates to the external docs referenced in #2324), lychee with `--include-fragments` (and excluded language versions other than English) reports 0 errors.

One broken menu item in 4.x:
- `/en/4x/api/request#reqparamname`: separated 4.x and 3.x cases, as 4.x allows a default value (at least according to docs content)

Broken menu items in 3.x:
- `/en/3x/api/application#appallpath-callback--callback-`: moved optional parameter to last pos to match 4.x and 5.x header
- `/en/3x/api/application#applistenport-host-backlog-callback`: separated 3.x from 4.x/5.x
- `/en/3x/api/application#apprenderview-locals-callback`: renamed `options` to locals (see https://github.com/expressjs/expressjs.com/commit/9162fa120c6b14b640a9746eaebe743f1bf63203)
- `/en/3x/api/application#appusepath-callback--callback`: separated 3.x from 4.x/5.x as according to API docs 3.x allows only one function per .use call
- `/en/3x/api/request#reqheaderfield`: merged with 4.x/5.x `req.get()` menu header, because it has been this way in old docs and I could not find `req.header()` outside `req.get()` description:
  https://github.com/expressjs/expressjs.com/blob/2d4df3f05fbd5d5f211f5938395ae965e8714d60/_includes/api/en/3x/req-header.md?plain=1#L1-L16
  https://github.com/expressjs/expressjs.com/blob/9e957d4e2c46a9042e1b4bcf9fcee686e3db5a71/en/api/req-header.jade#L1-L17
- `/en/3x/api/response#resclearcookiename--options`: used header from 4.x/5.x (comma moved into [])
- `/en/3x/api/response#rescookiename-value--options`: used header from 4.x/5.x (comma moved into [])
- `/en/3x/api/response#resdownloadpath--filename--options--fn`: separated 3.x from 4.x/5.x, because signature is different
- `/en/3x/api/response#resjsonbody`: separated 3.x from 4.x/5.x, because 3.x allows optional status
- `/en/3x/api/response#resjsonpbody`: separated 3.x from 4.x/5.x, because 3.x allows optional status
- `/en/3x/api/response#reslocationpath`: renamed 3.x to match 4.x/5.x header
- `/en/3x/api/response#resredirectstatus-path`: renamed 3.x to match 4.x/5.x header and updated docs content to match (copied from 4.x)
- `/en/3x/api/response#resrenderview--locals--callback`: changed header to match 4.x (callback is optional); the 3.x docs are not great and somewhat differ from [JSDoc](https://github.com/expressjs/express/blob/cb59086305367d9fcd7d63b53cfca1a3e4ef77d7/lib/response.js#L808-L846)
- `/en/3x/api/response#ressendbody`: separated 3.x from 4.x/5.x, because 3.x allows optional status
- `/en/3x/api/response#ressetfield--value`: used header from 4.x/5.x (comma moved into [])

<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
