### PR TITLE
fix: clarify differences in res.jsonp() behavior and security measures

### DIFF
--- a/src/content/api/4x/api/response/index.mdx
+++ b/src/content/api/4x/api/response/index.mdx
@@ -386,8 +386,17 @@ res.status(500).json({ error: 'message' });
 
 ### res.jsonp([body])
 
-Sends a JSON response with JSONP support. This method is identical to `res.json()`,
-except that it opts-in to JSONP callback support.
+Sends a JSON response with JSONP support. When the request has no JSONP callback
+query parameter, this method behaves like `res.json()`. When the callback parameter
+is present, the response differs from `res.json()` in the following ways:
+
+- The JSON response body is wrapped in a call to the named callback function
+  (for example, `callback({ "user": "tobi" })`).
+- The `Content-Type` is set to `text/javascript` instead of `application/json`.
+  This cannot be overridden, since browsers will not execute JSONP responses
+  served with any other content type.
+- An `X-Content-Type-Options: nosniff` header is added, and the body is prefixed
+  with `/**/` as a security mitigation against the Rosetta Flash JSONP attack.
 
 ```js
 res.jsonp(null);

--- a/src/content/api/5x/api/response/index.mdx
+++ b/src/content/api/5x/api/response/index.mdx
@@ -376,8 +376,17 @@ res.status(500).json({ error: 'message' });
 
 ### res.jsonp([body])
 
-Sends a JSON response with JSONP support. This method is identical to `res.json()`,
-except that it opts-in to JSONP callback support.
+Sends a JSON response with JSONP support. When the request has no JSONP callback
+query parameter, this method behaves like `res.json()`. When the callback parameter
+is present, the response differs from `res.json()` in the following ways:
+
+- The JSON response body is wrapped in a call to the named callback function
+  (for example, `callback({ "user": "tobi" })`).
+- The `Content-Type` is set to `text/javascript` instead of `application/json`.
+  This cannot be overridden, since browsers will not execute JSONP responses
+  served with any other content type.
+- An `X-Content-Type-Options: nosniff` header is added, and the body is prefixed
+  with `/**/` as a security mitigation against the Rosetta Flash JSONP attack.
 
 ```js
 res.jsonp(null);


### PR DESCRIPTION
# Problem

The `res.jsonp` API reference says the method is "identical to `res.json()`, except that it opts-in to JSONP callback support". As discussed in #1330, that's understating things: when the callback query parameter is present, `res.jsonp` also forces the `Content-Type` to `text/javascript` (and per @dougwilson's confirmation, this can't be overridden because no other content type will execute as JSONP in a browser), adds `X-Content-Type-Options: nosniff`, and prefixes the body with `/**/` as a security mitigation against the Rosetta Flash JSONP attack.

# Fix

Replace the misleading "identical" line with a short bulleted description of the actual differences, in both the 4x and 5x API references. The existing examples and "jsonp callback name" override section are unchanged.



closes #1330