### PR TITLE
docs(middleware): add @inferdi/express

### DIFF
--- a/src/content/pages/en/resources/middleware/index.mdx
+++ b/src/content/pages/en/resources/middleware/index.mdx
@@ -40,4 +40,5 @@ These are some additional popular middleware modules.
 | Middleware module                                   | Description                                                                                                                                  |
 | --------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
 | [helmet](https://github.com/helmetjs/helmet)        | Helps secure your apps by setting various HTTP headers.                                                                                      |
+| [`@inferdi/express`](https://github.com/inferdi/inferdi/tree/main/packages/express) | Type-safe request-scoped dependency injection for Express 5 with explicit InferDI scopes, zero decorators, and compile-time checked dependencies. |
 | [passport](https://github.com/jaredhanson/passport) | Authentication using "strategies" such as OAuth, OpenID and many others. See [passportjs.org](https://passportjs.org/) for more information. |

--- a/src/content/pages/en/resources/middleware/index.mdx
+++ b/src/content/pages/en/resources/middleware/index.mdx
@@ -37,8 +37,8 @@ These are some additional popular middleware modules.
   Expressjs project team.
 </Alert>
 
-| Middleware module                                   | Description                                                                                                                                  |
-| --------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| [helmet](https://github.com/helmetjs/helmet)        | Helps secure your apps by setting various HTTP headers.                                                                                      |
+| Middleware module                                                                   | Description                                                                                                                                       |
+| ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [helmet](https://github.com/helmetjs/helmet)                                        | Helps secure your apps by setting various HTTP headers.                                                                                           |
 | [`@inferdi/express`](https://github.com/inferdi/inferdi/tree/main/packages/express) | Type-safe request-scoped dependency injection for Express 5 with explicit InferDI scopes, zero decorators, and compile-time checked dependencies. |
-| [passport](https://github.com/jaredhanson/passport) | Authentication using "strategies" such as OAuth, OpenID and many others. See [passportjs.org](https://passportjs.org/) for more information. |
+| [passport](https://github.com/jaredhanson/passport)                                 | Authentication using "strategies" such as OAuth, OpenID and many others. See [passportjs.org](https://passportjs.org/) for more information.      |


### PR DESCRIPTION
## Summary

- Adds `@inferdi/express` to the Additional middleware modules list.
- `@inferdi/express` provides request-scoped dependency injection for Express 5 using explicit InferDI scopes.

## Test plan

- [x] Updated only `src/content/pages/en/resources/middleware/index.mdx`.
- [x] Did not edit localized pages directly; translations are handled through Crowdin.
- [x] Link points to the package documentation in the InferDI monorepo.