### PR TITLE
feat: add Signature and Param components for API method documentation

### DIFF
--- a/src/components/patterns/Signature/Param.astro
+++ b/src/components/patterns/Signature/Param.astro
@@ -1,0 +1,67 @@
+---
+/**
+ * Param
+ *
+ * A single parameter / attribute / option inside a `Signature`. Renders a
+ * styled box with the name, an optional type token, an optional default value
+ * and an optional "Added in" version. The description is the default slot, so it
+ * stays MDX (keeping localized links working).
+ *
+ * @example
+ * <Param name="depth" type="Number" default="32" since="v4.20.0">
+ *   Configures the maximum depth…
+ * </Param>
+ */
+import './Signature.css';
+
+interface Props {
+  /** Parameter name, rendered in monospace. */
+  name: string;
+  /** Type, rendered as a type token (e.g. `Boolean`, `Function`, `Compiler`). */
+  type?: string;
+  /** Default value, rendered as inline code. */
+  default?: string;
+  /** Whether the parameter is optional. */
+  optional?: boolean;
+  /** Version the parameter was added in, e.g. `"v4.20.0"`. */
+  since?: string;
+}
+
+const { name, type, default: defaultValue, optional = false, since } = Astro.props;
+---
+
+<div class="param">
+  <div class="param__head">
+    <code class="param__name">{name}</code>
+    {optional && <span class="param__flag">optional</span>}
+  </div>
+
+  {
+    (type || defaultValue !== undefined || since) && (
+      <div class="param__meta">
+        {type && (
+          <span class="param__meta-item">
+            <span class="param__label">Type:</span>
+            <code class="type-tag">{type}</code>
+          </span>
+        )}
+        {defaultValue !== undefined && (
+          <span class="param__meta-item">
+            <span class="param__label">Default:</span>
+            <code class="param__value">{defaultValue}</code>
+          </span>
+        )}
+        {since && (
+          <span class="param__meta-item">
+            <span class="param__label">Added in:</span>
+            <code class="param__value">{since}</code>
+          </span>
+        )}
+      </div>
+    )
+  }
+
+  <div class="param__desc">
+    <slot />
+  </div>
+</div>

--- a/src/components/patterns/Signature/Param.astro
+++ b/src/components/patterns/Signature/Param.astro
@@ -3,13 +3,28 @@
  * Param
  *
  * A single parameter / attribute / option inside a `Signature`. Renders a
- * styled box with the name, an optional type token, an optional default value
- * and an optional "Added in" version. The description is the default slot, so it
- * stays MDX (keeping localized links working).
+ * two-column row — the name on the left, the type / default / description on
+ * the right. The description is the default slot, so it stays MDX (keeping
+ * localized links working).
+ *
+ * Nested options (e.g. the properties of an `options` object) go in the
+ * `properties` slot, where they render as a bordered nested table under this
+ * param — keeping them in the same table instead of a separate one. (The slot
+ * is named `properties`, not `children`, to avoid clashing with the special
+ * `children` prop in MDX.)
  *
  * @example
  * <Param name="depth" type="Number" default="32" since="v4.20.0">
  *   Configures the maximum depth…
+ * </Param>
+ *
+ * @example
+ * <Param name="options" type="Object" optional>
+ *   Configures how files are served.
+ *
+ *   <Fragment slot="properties">
+ *     <Param name="dotfiles" type="String" default="undefined">…</Param>
+ *   </Fragment>
  * </Param>
  */
 import './Signature.css';
@@ -28,40 +43,54 @@ interface Props {
 }
 
 const { name, type, default: defaultValue, optional = false, since } = Astro.props;
+
+const hasProperties = Astro.slots.has('properties');
+
+// Show optionality on the type itself, by appending `| undefined`.
+const displayType = optional && type ? `${type} | undefined` : type;
 ---
 
 <div class="param">
   <div class="param__head">
     <code class="param__name">{name}</code>
-    {optional && <span class="param__flag">optional</span>}
   </div>
 
-  {
-    (type || defaultValue !== undefined || since) && (
-      <div class="param__meta">
-        {type && (
-          <span class="param__meta-item">
-            <span class="param__label">Type:</span>
-            <code class="type-tag">{type}</code>
-          </span>
-        )}
-        {defaultValue !== undefined && (
-          <span class="param__meta-item">
-            <span class="param__label">Default:</span>
-            <code class="param__value">{defaultValue}</code>
-          </span>
-        )}
-        {since && (
-          <span class="param__meta-item">
-            <span class="param__label">Added in:</span>
-            <code class="param__value">{since}</code>
-          </span>
-        )}
-      </div>
-    )
-  }
+  <div class="param__body">
+    {
+      (displayType || defaultValue !== undefined || since) && (
+        <div class="param__meta">
+          {displayType && (
+            <span class="param__meta-item">
+              <span class="param__label">Type:</span>
+              <code class="type-tag">{displayType}</code>
+            </span>
+          )}
+          {defaultValue !== undefined && (
+            <span class="param__meta-item">
+              <span class="param__label">Default:</span>
+              <code class="param__value">{defaultValue}</code>
+            </span>
+          )}
+          {since && (
+            <span class="param__meta-item">
+              <span class="param__label">Added in:</span>
+              <code class="param__value">{since}</code>
+            </span>
+          )}
+        </div>
+      )
+    }
 
-  <div class="param__desc">
-    <slot />
+    <div class="param__desc">
+      <slot />
+    </div>
+
+    {
+      hasProperties && (
+        <div class="signature__params param__children">
+          <slot name="properties" />
+        </div>
+      )
+    }
   </div>
 </div>

--- a/src/components/patterns/Signature/Signature.astro
+++ b/src/components/patterns/Signature/Signature.astro
@@ -44,7 +44,9 @@ const hasFooter = Boolean(type) || hasReturns || Boolean(since);
     hasAttributes && (
       <div class="signature__attributes">
         <h4 class="signature__attributes-title">{attributesTitle}</h4>
-        <slot name="attributes" />
+        <div class="signature__params">
+          <slot name="attributes" />
+        </div>
       </div>
     )
   }

--- a/src/components/patterns/Signature/Signature.astro
+++ b/src/components/patterns/Signature/Signature.astro
@@ -1,0 +1,79 @@
+---
+/**
+ * Signature
+ *
+ * Shows the arguments and return value of an API method, or the type of an API
+ * property, plus an optional "Added in" version. It only renders the structured
+ * data — write the member title as a normal Markdown heading above it and the
+ * prose description around it.
+ *
+ * Colors follow the site theme via design tokens (light/dark aware).
+ *
+ * @example
+ * <Signature returns="Function" since="v4.16.0">
+ *   <Fragment slot="attributes">
+ *     <Param name="limit" type="Number | String" default='"100kb"'>…</Param>
+ *   </Fragment>
+ * </Signature>
+ *
+ * <Signature type="Boolean" since="v4.5.0" />
+ */
+import './Signature.css';
+
+interface Props {
+  /** Return type for a method. Use the `returns` slot for richer content. */
+  returns?: string;
+  /** Type for a property. */
+  type?: string;
+  /** Version the member was added in, e.g. `"v4.16.0"`. */
+  since?: string;
+  /** Heading text for the arguments section. */
+  attributesTitle?: string;
+}
+
+const { returns, type, since, attributesTitle = 'Arguments' } = Astro.props;
+
+const hasReturnsSlot = Astro.slots.has('returns');
+const hasReturns = hasReturnsSlot || Boolean(returns);
+const hasAttributes = Astro.slots.has('attributes');
+const hasFooter = Boolean(type) || hasReturns || Boolean(since);
+---
+
+<section class="signature">
+  {
+    hasAttributes && (
+      <div class="signature__attributes">
+        <h4 class="signature__attributes-title">{attributesTitle}</h4>
+        <slot name="attributes" />
+      </div>
+    )
+  }
+
+  {
+    hasFooter && (
+      <div class="signature__footer">
+        {type && (
+          <p class="signature__line">
+            <span class="signature__line-label">Type:</span>
+            <code class="type-tag">{type}</code>
+          </p>
+        )}
+        {hasReturns && (
+          <p class="signature__line">
+            <span class="signature__line-arrow" aria-hidden="true">
+              ↵
+            </span>
+            <span class="signature__line-label">Returns:</span>
+            {hasReturnsSlot ? <slot name="returns" /> : <code class="type-tag">{returns}</code>}
+          </p>
+        )}
+        {since && (
+          <p class="signature__line">
+            <span class="signature__line-label">Added in:</span>
+            <code class="type-tag">{since}</code>
+          </p>
+        )}
+      </div>
+    )
+  }
+</section>

--- a/src/components/patterns/Signature/Signature.css
+++ b/src/components/patterns/Signature/Signature.css
@@ -69,49 +69,88 @@
   }
 
   /* ============================================
-     Param — a row inside the box
+     Params — one shared two-column grid so the
+     names and descriptions line up across every
+     row, like a single table inside the box:
+     the name on the left, the type / default /
+     description on the right.
      ============================================ */
-  .param {
-    padding: var(--space-3) var(--space-4);
+  .signature__params {
+    display: grid;
+    grid-template-columns: minmax(8rem, 14rem) minmax(0, 1fr);
   }
 
-  .param + .param {
+  /* Each Param spreads its two cells straight into the shared grid. */
+  .param {
+    display: contents;
+  }
+
+  .param__head,
+  .param__body {
+    padding: var(--space-3) var(--space-4);
     border-top: var(--border-width-1) solid var(--color-border-secondary);
+  }
+
+  /* No divider above the first row. */
+  .param:first-child > .param__head,
+  .param:first-child > .param__body {
+    border-top: 0;
+  }
+
+  /* Stack the name over the description on narrow viewports. */
+  @media (max-width: 40rem) {
+    .signature__params {
+      display: block;
+    }
+
+    .param {
+      display: block;
+      border-top: var(--border-width-1) solid var(--color-border-secondary);
+    }
+
+    .param:first-child {
+      border-top: 0;
+    }
+
+    .param__head,
+    .param__body {
+      border-top: 0;
+    }
+
+    .param__head {
+      padding-bottom: var(--space-2);
+    }
+
+    .param__body {
+      padding-top: 0;
+    }
   }
 
   .param__head {
     display: flex;
-    align-items: center;
-    flex-wrap: wrap;
-    gap: var(--space-3);
+    flex-direction: column;
+    align-items: flex-start;
+    gap: var(--space-2);
   }
 
   .param__name {
+    display: inline-block;
     color: var(--color-text-primary);
     font-family: var(--font-family-mono);
     font-size: var(--font-size-base);
     font-weight: var(--font-weight-semibold);
+    /* Let long option names wrap inside the name column instead of overflowing. */
+    max-width: 100%;
+    overflow-wrap: anywhere;
   }
 
-  .param__flag {
-    padding: 0 var(--space-2);
-    border-radius: var(--radius-full);
-    background-color: light-dark(var(--amber-100), var(--amber-900));
-    color: light-dark(var(--amber-800), var(--amber-200));
-    font-size: var(--font-size-xs);
-    font-weight: var(--font-weight-medium);
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
-  }
-
-  /* Meta: labelled "Type:" / "Default:" / "Added in:" pairs, one per line
-     (label inline with its value). */
+  /* Meta: labelled "Type:" / "Default:" / "Added in:" pairs, flowing inline
+     at the top of the description column (wrapping when there is no room). */
   .param__meta {
     display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-    gap: var(--space-2);
-    margin-top: var(--space-2);
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--space-2) var(--space-4);
   }
 
   .param__meta-item {
@@ -132,7 +171,6 @@
   }
 
   .param__desc {
-    margin-top: var(--space-5);
     color: var(--color-text-secondary);
 
     /* Collapse the outer margins of content rendered from the MDX slot. */
@@ -143,5 +181,20 @@
     & > :last-child {
       margin-bottom: 0;
     }
+  }
+
+  /* Space the description from the meta row only when both are present. */
+  .param__meta + .param__desc {
+    margin-top: var(--space-3);
+  }
+
+  /* An object's properties: the same two-column grid, wrapped in its own
+     complete border so it is clear they belong to the param above and are not
+     top-level arguments. */
+  .param__children {
+    margin-top: var(--space-3);
+    border: var(--border-width-1) solid var(--color-border-secondary);
+    border-radius: var(--radius-sm);
+    overflow: hidden;
   }
 }

--- a/src/components/patterns/Signature/Signature.css
+++ b/src/components/patterns/Signature/Signature.css
@@ -1,0 +1,147 @@
+@layer patterns {
+  /* ============================================
+     Type token — shared by returns and params
+     ============================================ */
+  .type-tag {
+    display: inline-block;
+    padding: var(--space-0-5) var(--space-2);
+    /* A crisp "chip" using palette tokens — good contrast in light and dark. */
+    border: var(--border-width-1) solid var(--color-border-secondary);
+    border-radius: var(--radius-sm);
+    background-color: var(--color-bg-secondary);
+    color: var(--color-text-primary);
+    font-family: var(--font-family-mono);
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-medium);
+    line-height: var(--line-height-tight);
+  }
+
+  /* ============================================
+     Signature — a single box holding the
+     arguments and the return value / type
+     ============================================ */
+  .signature {
+    margin: var(--space-6) 0;
+    border: var(--border-width-1) solid var(--color-border-secondary);
+    border-radius: var(--radius-base);
+    overflow: hidden;
+    background-color: var(--color-bg-primary);
+  }
+
+  .signature__attributes-title {
+    margin: 0;
+    padding: var(--space-2) var(--space-4);
+    border-bottom: var(--border-width-1) solid var(--color-border-secondary);
+    background-color: var(--color-bg-tertiary);
+    color: var(--color-text-secondary);
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-semibold);
+  }
+
+  /* Footer: Type / Returns / Added in, grouped in one strip that follows the
+     theme (light gray in light mode, ~#222 in dark mode). */
+  .signature__footer {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+    padding: var(--space-3) var(--space-4);
+    border-top: var(--border-width-1) solid var(--color-border-secondary);
+    background-color: var(--color-bg-tertiary);
+  }
+
+  /* When the box only has the footer (e.g. a property), there is no divider. */
+  .signature__footer:first-child {
+    border-top: 0;
+  }
+
+  .signature__line {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: var(--space-2);
+    margin: 0;
+  }
+
+  .signature__line-arrow,
+  .signature__line-label {
+    color: var(--color-text-secondary);
+    font-weight: var(--font-weight-medium);
+  }
+
+  /* ============================================
+     Param — a row inside the box
+     ============================================ */
+  .param {
+    padding: var(--space-3) var(--space-4);
+  }
+
+  .param + .param {
+    border-top: var(--border-width-1) solid var(--color-border-secondary);
+  }
+
+  .param__head {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: var(--space-3);
+  }
+
+  .param__name {
+    color: var(--color-text-primary);
+    font-family: var(--font-family-mono);
+    font-size: var(--font-size-base);
+    font-weight: var(--font-weight-semibold);
+  }
+
+  .param__flag {
+    padding: 0 var(--space-2);
+    border-radius: var(--radius-full);
+    background-color: light-dark(var(--amber-100), var(--amber-900));
+    color: light-dark(var(--amber-800), var(--amber-200));
+    font-size: var(--font-size-xs);
+    font-weight: var(--font-weight-medium);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+
+  /* Meta: labelled "Type:" / "Default:" / "Added in:" pairs, one per line
+     (label inline with its value). */
+  .param__meta {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: var(--space-2);
+    margin-top: var(--space-2);
+  }
+
+  .param__meta-item {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+  }
+
+  .param__label {
+    color: var(--color-text-secondary);
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-semibold);
+  }
+
+  .param__value {
+    font-family: var(--font-family-mono);
+    color: var(--color-text-primary);
+  }
+
+  .param__desc {
+    margin-top: var(--space-5);
+    color: var(--color-text-secondary);
+
+    /* Collapse the outer margins of content rendered from the MDX slot. */
+    & > :first-child {
+      margin-top: 0;
+    }
+
+    & > :last-child {
+      margin-bottom: 0;
+    }
+  }
+}

--- a/src/components/patterns/Signature/index.ts
+++ b/src/components/patterns/Signature/index.ts
@@ -1,0 +1,2 @@
+export { default as Signature } from './Signature.astro';
+export { default as Param } from './Param.astro';

--- a/src/config/menu/api.ts
+++ b/src/config/menu/api.ts
@@ -23,18 +23,9 @@ export const apiMenu: Menu = {
           ariaLabel: 'menu.aria.api',
         },
         {
+          href: '/api/express#methods',
           label: 'menu.items.methods',
           ariaLabel: 'menu.aria.api',
-          submenu: {
-            items: [
-              { href: '/api/express#expressjsonoptions', label: 'express.json()' },
-              { href: '/api/express#expressrawoptions', label: 'express.raw()' },
-              { href: '/api/express#expressrouteroptions', label: 'express.Router()' },
-              { href: '/api/express#expressstaticroot-options', label: 'express.static()' },
-              { href: '/api/express#expresstextoptions', label: 'express.text()' },
-              { href: '/api/express#expressurlencodedoptions', label: 'express.urlencoded()' },
-            ],
-          },
         },
       ],
     },
@@ -48,114 +39,20 @@ export const apiMenu: Menu = {
           ariaLabel: 'menu.aria.application',
         },
         {
+          href: '/api/application#properties',
           label: 'menu.items.properties',
           ariaLabel: 'menu.aria.application',
-          submenu: {
-            items: [
-              { href: `/api/application#applocals`, label: 'app.locals' },
-              {
-                href: '/api/application#appmountpath',
-                label: 'app.mountpath',
-                omitFrom: ['3x'],
-              },
-              {
-                href: '/api/application#approuter',
-                label: 'app.router',
-                omitFrom: ['3x', '4x'],
-              },
-              {
-                href: '/api/application#approutes',
-                label: 'app.routes',
-                omitFrom: ['4x', '5x'],
-              },
-              {
-                href: '/api/application#settings',
-                label: 'app.settings',
-                omitFrom: ['4x', '5x'],
-              },
-            ],
-          },
         },
         {
+          href: '/api/application#events',
           label: 'menu.items.events',
           ariaLabel: 'menu.aria.application',
           omitFrom: ['3x'],
-          submenu: {
-            items: [
-              {
-                href: `/api/application#apponmount-callbackparent`,
-                label: "app.on('mount')",
-              },
-            ],
-          },
         },
         {
+          href: '/api/application#methods',
           label: 'menu.items.methods',
           ariaLabel: 'menu.aria.application',
-          submenu: {
-            items: [
-              { href: `/api/application#appallpath-callback--callback-`, label: 'app.all()' },
-              {
-                href: '/api/application#appconfigureenv-callback',
-                label: 'app.configure()',
-                omitFrom: ['4x', '5x'],
-              },
-              {
-                href: `/api/application#appdeletepath-callback--callback-`,
-                label: 'app.delete()',
-                omitFrom: ['3x'],
-              },
-              { href: '/api/application#appdisablename', label: 'app.disable()' },
-              { href: '/api/application#appdisabledname', label: 'app.disabled()' },
-              { href: '/api/application#appenablename', label: 'app.enable()' },
-              { href: '/api/application#appenabledname', label: 'app.enabled()' },
-              { href: '/api/application#appengineext-callback', label: 'app.engine()' },
-              { href: '/api/application#appgetname', label: 'app.get(name)' },
-              {
-                href: '/api/application#appgetpath-callback--callback-',
-                label: 'app.get(path)',
-                omitFrom: ['3x'],
-              },
-              {
-                href: '/api/application#applistenport-host-backlog-callback',
-                label: 'app.listen()',
-              },
-              {
-                href: '/api/application#appmethodpath-callback--callback-',
-                label: 'app.METHOD()',
-                omitFrom: ['3x'],
-              },
-              { href: '/api/application#appparamname-callback', label: 'app.param()' },
-              {
-                href: '/api/application#apppath',
-                label: 'app.path()',
-                omitFrom: ['3x'],
-              },
-              {
-                href: '/api/application#apppostpath-callback--callback-',
-                label: 'app.post()',
-                omitFrom: ['3x'],
-              },
-              {
-                href: '/api/application#appputpath-callback--callback-',
-                label: 'app.put()',
-                omitFrom: ['3x'],
-              },
-              { href: '/api/application#apprenderview-locals-callback', label: 'app.render()' },
-              {
-                href: '/api/application#approutepath',
-                label: 'app.route()',
-                omitFrom: ['3x'],
-              },
-              { href: '/api/application#appsetname-value', label: 'app.set()' },
-              { href: '/api/application#appusepath-callback--callback', label: 'app.use()' },
-              {
-                href: '/api/application#appverbpath-callback-callback',
-                label: 'app.VERB()',
-                omitFrom: ['4x', '5x'],
-              },
-            ],
-          },
         },
       ],
     },
@@ -196,121 +93,14 @@ export const apiMenu: Menu = {
           ariaLabel: 'menu.aria.request',
         },
         {
+          href: '/api/request#properties',
           label: 'menu.items.properties',
           ariaLabel: 'menu.aria.request',
-          submenu: {
-            items: [
-              {
-                href: '/api/request#reqaccepted',
-                label: 'req.accepted',
-                omitFrom: ['4x', '5x'],
-              },
-              {
-                href: '/api/request#reqacceptedcharsets',
-                label: 'req.acceptedCharsets',
-                omitFrom: ['4x', '5x'],
-              },
-              {
-                href: '/api/request#reqacceptedlanguages',
-                label: 'req.acceptedLanguages',
-                omitFrom: ['4x', '5x'],
-              },
-              {
-                href: '/api/request#reqapp',
-                label: 'req.app',
-                omitFrom: ['3x'],
-              },
-              {
-                href: '/api/request#reqbaseurl',
-                label: 'req.baseUrl',
-                omitFrom: ['3x'],
-              },
-              { href: `/api/request#reqbody`, label: 'req.body' },
-              { href: `/api/request#reqcookies`, label: 'req.cookies' },
-              {
-                href: '/api/request#reqfiles',
-                label: 'req.files',
-                omitFrom: ['4x', '5x'],
-              },
-              { href: '/api/request#reqfresh', label: 'req.fresh' },
-              {
-                href: '/api/request#reqhost',
-                label: 'req.host',
-                omitFrom: ['4x'],
-              },
-              {
-                href: '/api/request#reqhostname',
-                label: 'req.hostname',
-                omitFrom: ['3x'],
-              },
-              { href: `/api/request#reqip`, label: 'req.ip' },
-              { href: '/api/request#reqips', label: 'req.ips' },
-              { href: `/api/request#reqmethod`, label: 'req.method', omitFrom: ['3x'] },
-              { href: '/api/request#reqoriginalurl', label: 'req.originalUrl' },
-              { href: '/api/request#reqparams', label: 'req.params' },
-              { href: '/api/request#reqpath', label: 'req.path' },
-              { href: '/api/request#reqprotocol', label: 'req.protocol' },
-              { href: `/api/request#reqquery`, label: 'req.query' },
-              { href: '/api/request#reqres', label: 'req.res' },
-              { href: '/api/request#reqroute', label: 'req.route' },
-              { href: '/api/request#reqsecure', label: 'req.secure' },
-              { href: '/api/request#reqsignedcookies', label: 'req.signedCookies' },
-              { href: '/api/request#reqstale', label: 'req.stale' },
-              { href: '/api/request#reqsubdomains', label: 'req.subdomains' },
-              { href: '/api/request#reqxhr', label: 'req.xhr' },
-            ],
-          },
         },
         {
+          href: '/api/request#methods',
           label: 'menu.items.methods',
           ariaLabel: 'menu.aria.request',
-          submenu: {
-            items: [
-              { href: `/api/request#reqacceptstypes`, label: 'req.accepts()' },
-              {
-                href: '/api/request#reqacceptscharsetcharset',
-                label: 'req.acceptsCharset()',
-                omitFrom: ['4x', '5x'],
-              },
-              {
-                href: '/api/request#reqacceptscharsetscharset--',
-                label: 'req.acceptsCharsets()',
-                omitFrom: ['3x'],
-              },
-              {
-                href: '/api/request#reqacceptsencodingsencoding--',
-                label: 'req.acceptsEncodings()',
-                omitFrom: ['3x'],
-              },
-              {
-                href: '/api/request#reqacceptslanguagelang',
-                label: 'req.acceptsLanguage()',
-                omitFrom: ['4x', '5x'],
-              },
-              {
-                href: '/api/request#reqacceptslanguageslang-',
-                label: 'req.acceptsLanguages()',
-                omitFrom: ['3x'],
-              },
-              { href: '/api/request#reqgetfield', label: 'req.get()', omitFrom: ['3x'] },
-              {
-                href: '/api/request#reqheaderfield',
-                label: 'req.header()',
-                omitFrom: ['4x', '5x'],
-              },
-              { href: '/api/request#reqistype', label: 'req.is()' },
-              {
-                href: '/api/request#reqparamname',
-                label: 'req.param()',
-                omitFrom: ['5x'],
-              },
-              {
-                href: '/api/request#reqrangesize-options',
-                label: 'req.range()',
-                omitFrom: ['3x'],
-              },
-            ],
-          },
         },
       ],
     },
@@ -324,86 +114,14 @@ export const apiMenu: Menu = {
           ariaLabel: 'menu.aria.response',
         },
         {
+          href: '/api/response#properties',
           label: 'menu.items.properties',
           ariaLabel: 'menu.aria.response',
-          submenu: {
-            items: [
-              {
-                href: '/api/response#resapp',
-                label: 'res.app',
-                omitFrom: ['3x'],
-              },
-              {
-                href: '/api/response#rescharset',
-                label: 'res.charset',
-                omitFrom: ['4x', '5x'],
-              },
-              {
-                href: '/api/response#resheaderssent',
-                label: 'res.headersSent',
-                omitFrom: ['3x'],
-              },
-              { href: '/api/response#reslocals', label: 'res.locals' },
-              { href: '/api/response#resreq', label: 'res.req' },
-            ],
-          },
         },
         {
+          href: '/api/response#methods',
           label: 'menu.items.methods',
           ariaLabel: 'menu.aria.response',
-          submenu: {
-            items: [
-              {
-                href: '/api/response#resappendfield--value',
-                label: 'res.append()',
-                omitFrom: ['3x'],
-              },
-              { href: '/api/response#resattachmentfilename', label: 'res.attachment()' },
-              { href: '/api/response#resclearcookiename--options', label: 'res.clearCookie()' },
-              { href: '/api/response#rescookiename-value--options', label: 'res.cookie()' },
-              {
-                href: '/api/response#resdownloadpath--filename--options--fn',
-                label: 'res.download()',
-              },
-              {
-                href: '/api/response#resenddata-encoding-callback',
-                label: 'res.end()',
-                omitFrom: ['3x'],
-              },
-              { href: `/api/response#resformatobject`, label: 'res.format()' },
-              { href: '/api/response#resgetfield', label: 'res.get()' },
-              { href: `/api/response#resjsonbody`, label: 'res.json()' },
-              { href: '/api/response#resjsonpbody', label: 'res.jsonp()' },
-              { href: '/api/response#reslinkslinks', label: 'res.links()' },
-              { href: '/api/response#reslocationpath', label: 'res.location()' },
-              { href: '/api/response#resredirectstatus-path', label: 'res.redirect()' },
-              { href: `/api/response#resrenderview--locals--callback`, label: 'res.render()' },
-              { href: `/api/response#ressendbody`, label: 'res.send()' },
-              {
-                href: '/api/response#ressendfilepath-options-fn',
-                label: 'res.sendfile()',
-                omitFrom: ['4x', '5x'],
-              },
-              {
-                href: '/api/response#ressendfilepath--options--fn',
-                label: 'res.sendFile()',
-                omitFrom: ['3x'],
-              },
-              {
-                href: '/api/response#ressendstatusstatuscode',
-                label: 'res.sendStatus()',
-                omitFrom: ['3x'],
-              },
-              { href: '/api/response#ressetfield--value', label: 'res.set()' },
-              { href: `/api/response#resstatuscode`, label: 'res.status()' },
-              { href: '/api/response#restypetype', label: 'res.type()' },
-              {
-                href: '/api/response#resvaryfield',
-                label: 'res.vary()',
-                omitFrom: ['3x'],
-              },
-            ],
-          },
         },
       ],
     },
@@ -418,24 +136,9 @@ export const apiMenu: Menu = {
           ariaLabel: 'menu.aria.router',
         },
         {
+          href: '/api/router#methods',
           label: 'menu.items.methods',
           ariaLabel: 'menu.aria.router',
-          submenu: {
-            items: [
-              { href: `/api/router#routeroptions`, label: 'Router()' },
-              { href: `/api/router#routerallpath-callback--callback`, label: 'router.all()' },
-              {
-                href: `/api/router#routermethodpath-callback--callback`,
-                label: 'router.METHOD()',
-              },
-              { href: '/api/router#routerparamname-callback', label: 'router.param()' },
-              { href: '/api/router#routerroutepath', label: 'router.route()' },
-              {
-                href: `/api/router#routerusepath-function--function`,
-                label: 'router.use()',
-              },
-            ],
-          },
         },
       ],
     },

--- a/src/content/api/4x/api/application/index.mdx
+++ b/src/content/api/4x/api/application/index.mdx
@@ -1061,7 +1061,7 @@ Sub-apps will not inherit the value of `view cache` in production (when `NODE_EN
     <Param name="env" type="String" default='process.env.NODE_ENV (NODE_ENV environment variable) or "development" if NODE_ENV is not set.'>
       Environment mode. Be sure to set to "production" in a production environment; see [Production best practices: performance and reliability](/advanced/best-practice-performance#things-to-do-in-your-environment--setup).
     </Param>
-    <Param name="etag" type="Varied" default="weak">
+    <Param name="etag" type="Boolean | String | Function" default="weak">
       Set the ETag response header. For possible values, see the `etag` options table below. [More about the HTTP ETag header](https://en.wikipedia.org/wiki/HTTP_ETag).
     </Param>
     <Param name="jsonp callback name" type="String" default='"callback"'>
@@ -1070,13 +1070,13 @@ Sub-apps will not inherit the value of `view cache` in production (when `NODE_EN
     <Param name="json escape" type="Boolean" default="N/A (undefined)">
       Enable escaping JSON responses from the `res.json`, `res.jsonp`, and `res.send` APIs. This will escape the characters `<`, `>`, and `&` as Unicode escape sequences in JSON. The purpose of this is to assist with [mitigating certain types of persistent XSS attacks](https://blog.mozilla.org/security/2017/07/18/web-service-audits-firefox-accounts/) when clients sniff responses for HTML. **NOTE**: Sub-apps will inherit the value of this setting.
     </Param>
-    <Param name="json replacer" type="Varied" default="N/A (undefined)">
+    <Param name="json replacer" type="Function | Array" default="N/A (undefined)">
       The ['replacer' argument used by `JSON.stringify`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#the_replacer_parameter). **NOTE**: Sub-apps will inherit the value of this setting.
     </Param>
-    <Param name="json spaces" type="Varied" default="N/A (undefined)">
+    <Param name="json spaces" type="Number | String" default="N/A (undefined)">
       The ['space' argument used by `JSON.stringify`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#the_space_parameter). This is typically set to the number of spaces to use to indent prettified JSON. **NOTE**: Sub-apps will inherit the value of this setting.
     </Param>
-    <Param name="query parser" type="Varied" default='"extended"'>
+    <Param name="query parser" type="Boolean | String | Function" default='"extended"'>
       Disable query parsing by setting the value to `false`, or set the query parser to use either "simple" or "extended" or a custom query string parsing function. The simple query parser is based on Node's native query parser, [querystring](https://nodejs.org/api/querystring.html). The extended query parser is based on [qs](https://www.npmjs.com/package/qs). A custom query string parsing function will receive the complete query string, and must return an object of query keys and their values.
     </Param>
     <Param name="strict routing" type="Boolean" default="N/A (undefined)">
@@ -1085,7 +1085,7 @@ Sub-apps will not inherit the value of `view cache` in production (when `NODE_EN
     <Param name="subdomain offset" type="Number" default="2">
       The number of dot-separated parts of the host to remove to access subdomain.
     </Param>
-    <Param name="trust proxy" type="Varied" default="false (disabled)">
+    <Param name="trust proxy" type="Boolean | String | Number | Function | Array" default="false (disabled)">
       Indicates the app is behind a front-facing proxy, and to use the `X-Forwarded-*` headers to determine the connection and the IP address of the client. NOTE: `X-Forwarded-*` headers are easily spoofed and the detected IP addresses are unreliable. When enabled, Express attempts to determine the IP address of the client connected through the front-facing proxy, or series of proxies. The `req.ips` property, then contains an array of IP addresses the client is connected through. To enable it, use the values described in the trust proxy options table below. The `trust proxy` setting is implemented using the [proxy-addr](https://www.npmjs.com/package/proxy-addr) package. For more information, see its documentation. **NOTE**: Sub-apps _will_ inherit the value of this setting, even though it has a default value.
     </Param>
     <Param name="views" type="String or Array" default="process.cwd() + '/views'">

--- a/src/content/api/4x/api/application/index.mdx
+++ b/src/content/api/4x/api/application/index.mdx
@@ -185,8 +185,8 @@ app.use('/admin', admin);
       callbacks can invoke `next('route')` to bypass the remaining route callback(s). You can use
       this mechanism to impose pre-conditions on a route, then pass control to subsequent routes if
       there is no reason to proceed with the current route. Since [router](/api/router/) and
-      [app](#overview) implement the middleware interface, you can use them as you would any other
-      middleware function. For examples, see [Middleware callback function
+      [app](/api/application/) implement the middleware interface, you can use them as you would any
+      other middleware function. For examples, see [Middleware callback function
       examples](#middleware-callback-function-examples).
     </Param>
   </Fragment>
@@ -249,8 +249,8 @@ app.all('/api/*', requireAuthentication);
       callbacks can invoke `next('route')` to bypass the remaining route callback(s). You can use
       this mechanism to impose pre-conditions on a route, then pass control to subsequent routes if
       there is no reason to proceed with the current route. Since [router](/api/router/) and
-      [app](#overview) implement the middleware interface, you can use them as you would any other
-      middleware function. For examples, see [Middleware callback function
+      [app](/api/application/) implement the middleware interface, you can use them as you would any
+      other middleware function. For examples, see [Middleware callback function
       examples](#middleware-callback-function-examples).
     </Param>
   </Fragment>
@@ -442,8 +442,8 @@ app.get('title');
       callbacks can invoke `next('route')` to bypass the remaining route callback(s). You can use
       this mechanism to impose pre-conditions on a route, then pass control to subsequent routes if
       there is no reason to proceed with the current route. Since [router](/api/router/) and
-      [app](#overview) implement the middleware interface, you can use them as you would any other
-      middleware function. For examples, see [Middleware callback function
+      [app](/api/application/) implement the middleware interface, you can use them as you would any
+      other middleware function. For examples, see [Middleware callback function
       examples](#middleware-callback-function-examples).
     </Param>
   </Fragment>
@@ -545,8 +545,8 @@ All the forms of Node's [http.Server.listen()](https://nodejs.org/api/http.html#
       callbacks can invoke `next('route')` to bypass the remaining route callback(s). You can use
       this mechanism to impose pre-conditions on a route, then pass control to subsequent routes if
       there is no reason to proceed with the current route. Since [router](/api/router/) and
-      [app](#overview) implement the middleware interface, you can use them as you would any other
-      middleware function. For examples, see [Middleware callback function
+      [app](/api/application/) implement the middleware interface, you can use them as you would any
+      other middleware function. For examples, see [Middleware callback function
       examples](#middleware-callback-function-examples).
     </Param>
   </Fragment>
@@ -871,8 +871,8 @@ it is usually better to use [req.baseUrl](/api/request/#reqbaseurl) to get the c
       callbacks can invoke `next('route')` to bypass the remaining route callback(s). You can use
       this mechanism to impose pre-conditions on a route, then pass control to subsequent routes if
       there is no reason to proceed with the current route. Since [router](/api/router/) and
-      [app](#overview) implement the middleware interface, you can use them as you would any other
-      middleware function. For examples, see [Middleware callback function
+      [app](/api/application/) implement the middleware interface, you can use them as you would any
+      other middleware function. For examples, see [Middleware callback function
       examples](#middleware-callback-function-examples).
     </Param>
   </Fragment>
@@ -905,8 +905,8 @@ app.post('/', function (req, res) {
       callbacks can invoke `next('route')` to bypass the remaining route callback(s). You can use
       this mechanism to impose pre-conditions on a route, then pass control to subsequent routes if
       there is no reason to proceed with the current route. Since [router](/api/router/) and
-      [app](#overview) implement the middleware interface, you can use them as you would any other
-      middleware function. For examples, see [Middleware callback function
+      [app](/api/application/) implement the middleware interface, you can use them as you would any
+      other middleware function. For examples, see [Middleware callback function
       examples](#middleware-callback-function-examples).
     </Param>
   </Fragment>
@@ -1195,8 +1195,8 @@ app.set('etag', function (body, encoding) {
       callbacks can invoke `next('route')` to bypass the remaining route callback(s). You can use
       this mechanism to impose pre-conditions on a route, then pass control to subsequent routes if
       there is no reason to proceed with the current route. Since [router](/api/router/) and
-      [app](#overview) implement the middleware interface, you can use them as you would any other
-      middleware function. For examples, see [Middleware callback function
+      [app](/api/application/) implement the middleware interface, you can use them as you would any
+      other middleware function. For examples, see [Middleware callback function
       examples](#middleware-callback-function-examples).
     </Param>
   </Fragment>

--- a/src/content/api/4x/api/application/index.mdx
+++ b/src/content/api/4x/api/application/index.mdx
@@ -4,6 +4,8 @@ description: Learn about the properties of the Express application object.
 ---
 
 import Alert from '@components/primitives/Alert/Alert.astro';
+import Signature from '@components/patterns/Signature/Signature.astro';
+import Param from '@components/patterns/Signature/Param.astro';
 
 The `app` object conventionally denotes the Express application.
 Create it by calling the top-level `express()` function exported by the Express module:
@@ -21,10 +23,10 @@ app.listen(3000);
 
 The `app` object has methods for
 
-- Routing HTTP requests; see for example, [app.METHOD](#appmethodpath-callback--callback-) and [app.param](#appparamname-callback).
-- Configuring middleware; see [app.route](#approutepath).
-- Rendering HTML views; see [app.render](#apprenderview-locals-callback).
-- Registering a template engine; see [app.engine](#appengineext-callback).
+- Routing HTTP requests; see for example, [app.METHOD](#appmethod) and [app.param](#appparam).
+- Configuring middleware; see [app.route](#approute).
+- Rendering HTML views; see [app.render](#apprender).
+- Registering a template engine; see [app.engine](#appengine).
 
 It also has settings (properties) that affect how the application behaves;
 for more information, see [Application Settings](#application-settings).
@@ -38,6 +40,8 @@ The Express application object can be referred from the [request object](/api/re
 ## Properties
 
 ### app.locals
+
+<Signature type="Object" />
 
 The `app.locals` object has properties that are local variables within the application,
 and will be available in templates rendered with [res.render](/api/response/#resrenderview--locals--callback).
@@ -74,6 +78,8 @@ app.locals.email = 'me@myapp.com';
 ```
 
 ### app.mountpath
+
+<Signature type="String | String[]" />
 
 The `app.mountpath` property contains one or more path patterns on which a sub-app was mounted.
 
@@ -123,13 +129,20 @@ app.use(['/adm*n', '/manager'], admin); // load the 'admin' router on '/adm*n' a
 
 ## Events
 
-### app.on('mount', callback(parent))
+### app.on('mount')
+
+<Signature>
+  <Fragment slot="attributes">
+    <Param name="callback" type="Function">
+      The listener called when the `mount` event fires. It receives the parent app as its only
+      argument: `callback(parent)`.
+    </Param>
+  </Fragment>
+</Signature>
 
 The `mount` event is fired on a sub-app, when it is mounted on a parent app. The parent app is passed to the callback function.
 
 <Alert type="info">
-**NOTE**
-
 Sub-apps will:
 
 - Not inherit the value of settings that have a default value. You must set the value in the sub-app.
@@ -156,17 +169,31 @@ app.use('/admin', admin);
 
 ## Methods
 
-### app.all(path, callback [, callback ...])
+### app.all()
 
-This method is like the standard [app.METHOD()](#appmethodpath-callback--callback-) methods,
+<Signature>
+  <Fragment slot="attributes">
+    <Param name="path" type="String | RegExp | Array">
+      The path for which the middleware function is invoked; can be any of: a string representing a
+      path, a path pattern, a regular expression pattern to match paths, or an array of combinations
+      of any of the above. For examples, see [Path examples](#path-examples).
+    </Param>
+    <Param name="callback" type="Function | Function[]">
+      Callback functions; can be: a middleware function, a series of middleware functions (separated
+      by commas), an array of middleware functions, or a combination of all of the above. You can
+      provide multiple callback functions that behave just like middleware, except that these
+      callbacks can invoke `next('route')` to bypass the remaining route callback(s). You can use
+      this mechanism to impose pre-conditions on a route, then pass control to subsequent routes if
+      there is no reason to proceed with the current route. Since [router](/api/router/) and
+      [app](#overview) implement the middleware interface, you can use them as you would any other
+      middleware function. For examples, see [Middleware callback function
+      examples](#middleware-callback-function-examples).
+    </Param>
+  </Fragment>
+</Signature>
+
+This method is like the standard [app.METHOD()](#appmethod) methods,
 except it matches all HTTP verbs.
-
-#### Arguments
-
-| Argument   | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | Default           |
-| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
-| `path`     | The path for which the middleware function is invoked; can be any of: a string representing a path, a path pattern, a regular expression pattern to match paths, or an array of combinations of any of the above. For examples, see [Path examples](#path-examples).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | `'/'` (root path) |
-| `callback` | Callback functions; can be: a middleware function, a series of middleware functions (separated by commas), an array of middleware functions, or a combination of all of the above. You can provide multiple callback functions that behave just like middleware, except that these callbacks can invoke `next('route')` to bypass the remaining route callback(s). You can use this mechanism to impose pre-conditions on a route, then pass control to subsequent routes if there is no reason to proceed with the current route. Since [router](/api/router/) and [app](#overview) implement the middleware interface, you can use them as you would any other middleware function. For examples, see [Middleware callback function examples](#middleware-callback-function-examples). | None              |
 
 #### Examples
 
@@ -206,17 +233,31 @@ The example is similar to the ones above, but it only restricts paths that start
 app.all('/api/*', requireAuthentication);
 ```
 
-### app.delete(path, callback [, callback ...])
+### app.delete()
+
+<Signature>
+  <Fragment slot="attributes">
+    <Param name="path" type="String | RegExp | Array">
+      The path for which the middleware function is invoked; can be any of: a string representing a
+      path, a path pattern, a regular expression pattern to match paths, or an array of combinations
+      of any of the above. For examples, see [Path examples](#path-examples).
+    </Param>
+    <Param name="callback" type="Function | Function[]">
+      Callback functions; can be: a middleware function, a series of middleware functions (separated
+      by commas), an array of middleware functions, or a combination of all of the above. You can
+      provide multiple callback functions that behave just like middleware, except that these
+      callbacks can invoke `next('route')` to bypass the remaining route callback(s). You can use
+      this mechanism to impose pre-conditions on a route, then pass control to subsequent routes if
+      there is no reason to proceed with the current route. Since [router](/api/router/) and
+      [app](#overview) implement the middleware interface, you can use them as you would any other
+      middleware function. For examples, see [Middleware callback function
+      examples](#middleware-callback-function-examples).
+    </Param>
+  </Fragment>
+</Signature>
 
 Routes HTTP DELETE requests to the specified path with the specified callback functions.
 For more information, see the [routing guide](/guide/routing/).
-
-#### Arguments
-
-| Argument   | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | Default           |
-| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
-| `path`     | The path for which the middleware function is invoked; can be any of: a string representing a path, a path pattern, a regular expression pattern to match paths, or an array of combinations of any of the above. For examples, see [Path examples](#path-examples).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | `'/'` (root path) |
-| `callback` | Callback functions; can be: a middleware function, a series of middleware functions (separated by commas), an array of middleware functions, or a combination of all of the above. You can provide multiple callback functions that behave just like middleware, except that these callbacks can invoke `next('route')` to bypass the remaining route callback(s). You can use this mechanism to impose pre-conditions on a route, then pass control to subsequent routes if there is no reason to proceed with the current route. Since [router](/api/router/) and [app](#overview) implement the middleware interface, you can use them as you would any other middleware function. For examples, see [Middleware callback function examples](#middleware-callback-function-examples). | None              |
 
 #### Example
 
@@ -226,7 +267,16 @@ app.delete('/', function (req, res) {
 });
 ```
 
-### app.disable(name)
+### app.disable()
+
+<Signature returns="Application">
+  <Fragment slot="attributes">
+    <Param name="name" type="String">
+      The name of the Boolean setting to disable; one of the properties from the [app settings
+      table](#application-settings).
+    </Param>
+  </Fragment>
+</Signature>
 
 Sets the Boolean setting `name` to `false`, where `name` is one of the properties from the [app settings table](#application-settings).
 Calling `app.set('foo', false)` for a Boolean property is the same as calling `app.disable('foo')`.
@@ -239,7 +289,16 @@ app.get('trust proxy');
 // => false
 ```
 
-### app.disabled(name)
+### app.disabled()
+
+<Signature returns="Boolean">
+  <Fragment slot="attributes">
+    <Param name="name" type="String">
+      The name of the Boolean setting to test; one of the properties from the [app settings
+      table](#application-settings).
+    </Param>
+  </Fragment>
+</Signature>
 
 Returns `true` if the Boolean setting `name` is disabled (`false`), where `name` is one of the properties from
 the [app settings table](#application-settings).
@@ -253,7 +312,16 @@ app.disabled('trust proxy');
 // => false
 ```
 
-### app.enable(name)
+### app.enable()
+
+<Signature returns="Application">
+  <Fragment slot="attributes">
+    <Param name="name" type="String">
+      The name of the Boolean setting to enable; one of the properties from the [app settings
+      table](#application-settings).
+    </Param>
+  </Fragment>
+</Signature>
 
 Sets the Boolean setting `name` to `true`, where `name` is one of the properties from the [app settings table](#application-settings).
 Calling `app.set('foo', true)` for a Boolean property is the same as calling `app.enable('foo')`.
@@ -264,7 +332,16 @@ app.get('trust proxy');
 // => true
 ```
 
-### app.enabled(name)
+### app.enabled()
+
+<Signature returns="Boolean">
+  <Fragment slot="attributes">
+    <Param name="name" type="String">
+      The name of the setting to test; one of the properties from the [app settings
+      table](#application-settings).
+    </Param>
+  </Fragment>
+</Signature>
 
 Returns `true` if the setting `name` is enabled (`true`), where `name` is one of the
 properties from the [app settings table](#application-settings).
@@ -278,7 +355,18 @@ app.enabled('trust proxy');
 // => true
 ```
 
-### app.engine(ext, callback)
+### app.engine()
+
+<Signature returns="Application">
+  <Fragment slot="attributes">
+    <Param name="ext" type="String">
+      The file extension the template engine is registered for (for example, `pug` or `html`).
+    </Param>
+    <Param name="callback" type="Function">
+      The template engine function used to render files with the given extension.
+    </Param>
+  </Fragment>
+</Signature>
 
 Registers the given template engine `callback` as `ext`.
 
@@ -317,6 +405,15 @@ app.engine('html', engines.hogan);
 
 ### app.get(name)
 
+<Signature returns="any">
+  <Fragment slot="attributes">
+    <Param name="name" type="String">
+      The name of the setting to read; one of the strings in the [app settings
+      table](#application-settings).
+    </Param>
+  </Fragment>
+</Signature>
+
 Returns the value of `name` app setting, where `name` is one of the strings in the
 [app settings table](#application-settings). For example:
 
@@ -329,16 +426,30 @@ app.get('title');
 // => "My Site"
 ```
 
-### app.get(path, callback [, callback ...])
+### app.get()
+
+<Signature>
+  <Fragment slot="attributes">
+    <Param name="path" type="String | RegExp | Array">
+      The path for which the middleware function is invoked; can be any of: a string representing a
+      path, a path pattern, a regular expression pattern to match paths, or an array of combinations
+      of any of the above. For examples, see [Path examples](#path-examples).
+    </Param>
+    <Param name="callback" type="Function | Function[]">
+      Callback functions; can be: a middleware function, a series of middleware functions (separated
+      by commas), an array of middleware functions, or a combination of all of the above. You can
+      provide multiple callback functions that behave just like middleware, except that these
+      callbacks can invoke `next('route')` to bypass the remaining route callback(s). You can use
+      this mechanism to impose pre-conditions on a route, then pass control to subsequent routes if
+      there is no reason to proceed with the current route. Since [router](/api/router/) and
+      [app](#overview) implement the middleware interface, you can use them as you would any other
+      middleware function. For examples, see [Middleware callback function
+      examples](#middleware-callback-function-examples).
+    </Param>
+  </Fragment>
+</Signature>
 
 Routes HTTP GET requests to the specified path with the specified callback functions.
-
-#### Arguments
-
-| Argument   | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | Default           |
-| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
-| `path`     | The path for which the middleware function is invoked; can be any of: a string representing a path, a path pattern, a regular expression pattern to match paths, or an array of combinations of any of the above. For examples, see [Path examples](#path-examples).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | `'/'` (root path) |
-| `callback` | Callback functions; can be: a middleware function, a series of middleware functions (separated by commas), an array of middleware functions, or a combination of all of the above. You can provide multiple callback functions that behave just like middleware, except that these callbacks can invoke `next('route')` to bypass the remaining route callback(s). You can use this mechanism to impose pre-conditions on a route, then pass control to subsequent routes if there is no reason to proceed with the current route. Since [router](/api/router/) and [app](#overview) implement the middleware interface, you can use them as you would any other middleware function. For examples, see [Middleware callback function examples](#middleware-callback-function-examples). | None              |
 
 For more information, see the [routing guide](/guide/routing/).
 
@@ -350,21 +461,31 @@ app.get('/', function (req, res) {
 });
 ```
 
-### app.listen(path, [callback])
+### app.listen()
 
-Starts a UNIX socket and listens for connections on the given path.
-This method is identical to Node's [http.Server.listen()](https://nodejs.org/api/http.html#http_server_listen).
+<Signature returns="http.Server">
+  <Fragment slot="attributes">
+    <Param name="port" type="Number" optional>
+      The TCP port to listen on. If omitted or `0`, the OS assigns an arbitrary unused port.
+    </Param>
+    <Param name="host" type="String" optional>
+      The host on which to accept connections.
+    </Param>
+    <Param name="backlog" type="Number" optional>
+      The maximum length of the queue of pending connections.
+    </Param>
+    <Param name="path" type="String" optional>
+      The path of a UNIX socket to listen on, as an alternative to host and port.
+    </Param>
+    <Param name="callback" type="Function" optional>
+      A function to call once the server is listening.
+    </Param>
+  </Fragment>
+</Signature>
 
-```js
-var express = require('express');
-var app = express();
-app.listen('/tmp/sock');
-```
-
-### app.listen([port[, host[, backlog]]][, callback])
-
-Binds and listens for connections on the specified host and port.
-This method is identical to Node's [http.Server.listen()](https://nodejs.org/api/http.html#http_server_listen).
+Binds and listens for connections on the specified host and port, or starts a
+UNIX socket and listens for connections on the given path. This method is
+identical to Node's [http.Server.listen()](https://nodejs.org/api/http.html#http_server_listen).
 
 If port is omitted or is 0, the operating system will assign an arbitrary unused
 port, which is useful for cases like automated tasks (tests, etc.).
@@ -372,7 +493,9 @@ port, which is useful for cases like automated tasks (tests, etc.).
 ```js
 var express = require('express');
 var app = express();
-app.listen(3000);
+
+app.listen(3000); // bind and listen on a TCP port
+app.listen('/tmp/sock'); // or listen on a UNIX socket
 ```
 
 The `app` returned by `express()` is in fact a JavaScript
@@ -406,18 +529,32 @@ All the forms of Node's [http.Server.listen()](https://nodejs.org/api/http.html#
 
 </Alert>
 
-### app.METHOD(path, callback [, callback ...])
+### app.METHOD()
+
+<Signature>
+  <Fragment slot="attributes">
+    <Param name="path" type="String | RegExp | Array">
+      The path for which the middleware function is invoked; can be any of: a string representing a
+      path, a path pattern, a regular expression pattern to match paths, or an array of combinations
+      of any of the above. For examples, see [Path examples](#path-examples).
+    </Param>
+    <Param name="callback" type="Function | Function[]">
+      Callback functions; can be: a middleware function, a series of middleware functions (separated
+      by commas), an array of middleware functions, or a combination of all of the above. You can
+      provide multiple callback functions that behave just like middleware, except that these
+      callbacks can invoke `next('route')` to bypass the remaining route callback(s). You can use
+      this mechanism to impose pre-conditions on a route, then pass control to subsequent routes if
+      there is no reason to proceed with the current route. Since [router](/api/router/) and
+      [app](#overview) implement the middleware interface, you can use them as you would any other
+      middleware function. For examples, see [Middleware callback function
+      examples](#middleware-callback-function-examples).
+    </Param>
+  </Fragment>
+</Signature>
 
 Routes an HTTP request, where METHOD is the HTTP method of the request, such as GET,
 PUT, POST, and so on, in lowercase. Thus, the actual methods are `app.get()`,
 `app.post()`, `app.put()`, and so on. See [Routing methods](#routing-methods) below for the complete list.
-
-#### Arguments
-
-| Argument   | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | Default           |
-| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
-| `path`     | The path for which the middleware function is invoked; can be any of: a string representing a path, a path pattern, a regular expression pattern to match paths, or an array of combinations of any of the above. For examples, see [Path examples](#path-examples).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | `'/'` (root path) |
-| `callback` | Callback functions; can be: a middleware function, a series of middleware functions (separated by commas), an array of middleware functions, or a combination of all of the above. You can provide multiple callback functions that behave just like middleware, except that these callbacks can invoke `next('route')` to bypass the remaining route callback(s). You can use this mechanism to impose pre-conditions on a route, then pass control to subsequent routes if there is no reason to proceed with the current route. Since [router](/api/router/) and [app](#overview) implement the middleware interface, you can use them as you would any other middleware function. For examples, see [Middleware callback function examples](#middleware-callback-function-examples). | None              |
 
 #### Routing methods
 
@@ -516,11 +653,24 @@ The `app.get()` function is automatically called for the HTTP `HEAD` method in a
 
 The method, `app.all()`, is not derived from any HTTP method and loads middleware at
 the specified path for _all_ HTTP request methods.
-For more information, see [app.all](#appallpath-callback--callback-).
+For more information, see [app.all](#appall).
 
 For more information on routing, see the [routing guide](/guide/routing/).
 
-### app.param([name], callback)
+### app.param()
+
+<Signature>
+  <Fragment slot="attributes">
+    <Param name="name" type="String | String[]" optional>
+      The name of the route parameter, or an array of names.
+    </Param>
+    <Param name="callback" type="Function">
+      The trigger called as `callback(req, res, next, value, name)`: the request object, the
+      response object, the next middleware, the value of the parameter, and the name of the
+      parameter, in that order.
+    </Param>
+  </Fragment>
+</Signature>
 
 Add callback triggers to [route parameters](/guide/routing/#route-parameters), where `name` is the name of the parameter or an array of them, and `callback` is the callback function. The parameters of the callback function are the request object, the response object, the next middleware, the value of the parameter and the name of the parameter, in that order.
 
@@ -685,6 +835,8 @@ router.get('[[\s\S]]*', function (req, res, next) {
 
 ### app.path()
 
+<Signature returns="String" />
+
 Returns the canonical path of the app, a string.
 
 ```js
@@ -703,17 +855,31 @@ console.dir(blogAdmin.path()); // '/blog/admin'
 The behavior of this method can become very complicated in complex cases of mounted apps:
 it is usually better to use [req.baseUrl](/api/request/#reqbaseurl) to get the canonical path of the app.
 
-### app.post(path, callback [, callback ...])
+### app.post()
+
+<Signature>
+  <Fragment slot="attributes">
+    <Param name="path" type="String | RegExp | Array">
+      The path for which the middleware function is invoked; can be any of: a string representing a
+      path, a path pattern, a regular expression pattern to match paths, or an array of combinations
+      of any of the above. For examples, see [Path examples](#path-examples).
+    </Param>
+    <Param name="callback" type="Function | Function[]">
+      Callback functions; can be: a middleware function, a series of middleware functions (separated
+      by commas), an array of middleware functions, or a combination of all of the above. You can
+      provide multiple callback functions that behave just like middleware, except that these
+      callbacks can invoke `next('route')` to bypass the remaining route callback(s). You can use
+      this mechanism to impose pre-conditions on a route, then pass control to subsequent routes if
+      there is no reason to proceed with the current route. Since [router](/api/router/) and
+      [app](#overview) implement the middleware interface, you can use them as you would any other
+      middleware function. For examples, see [Middleware callback function
+      examples](#middleware-callback-function-examples).
+    </Param>
+  </Fragment>
+</Signature>
 
 Routes HTTP POST requests to the specified path with the specified callback functions.
 For more information, see the [routing guide](/guide/routing).
-
-#### Arguments
-
-| Argument   | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | Default           |
-| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
-| `path`     | The path for which the middleware function is invoked; can be any of: a string representing a path, a path pattern, a regular expression pattern to match paths, or an array of combinations of any of the above. For examples, see [Path examples](#path-examples).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | `'/'` (root path) |
-| `callback` | Callback functions; can be: a middleware function, a series of middleware functions (separated by commas), an array of middleware functions, or a combination of all of the above. You can provide multiple callback functions that behave just like middleware, except that these callbacks can invoke `next('route')` to bypass the remaining route callback(s). You can use this mechanism to impose pre-conditions on a route, then pass control to subsequent routes if there is no reason to proceed with the current route. Since [router](/api/router/) and [app](#overview) implement the middleware interface, you can use them as you would any other middleware function. For examples, see [Middleware callback function examples](#middleware-callback-function-examples). | None              |
 
 #### Example
 
@@ -723,16 +889,30 @@ app.post('/', function (req, res) {
 });
 ```
 
-### app.put(path, callback [, callback ...])
+### app.put()
+
+<Signature>
+  <Fragment slot="attributes">
+    <Param name="path" type="String | RegExp | Array">
+      The path for which the middleware function is invoked; can be any of: a string representing a
+      path, a path pattern, a regular expression pattern to match paths, or an array of combinations
+      of any of the above. For examples, see [Path examples](#path-examples).
+    </Param>
+    <Param name="callback" type="Function | Function[]">
+      Callback functions; can be: a middleware function, a series of middleware functions (separated
+      by commas), an array of middleware functions, or a combination of all of the above. You can
+      provide multiple callback functions that behave just like middleware, except that these
+      callbacks can invoke `next('route')` to bypass the remaining route callback(s). You can use
+      this mechanism to impose pre-conditions on a route, then pass control to subsequent routes if
+      there is no reason to proceed with the current route. Since [router](/api/router/) and
+      [app](#overview) implement the middleware interface, you can use them as you would any other
+      middleware function. For examples, see [Middleware callback function
+      examples](#middleware-callback-function-examples).
+    </Param>
+  </Fragment>
+</Signature>
 
 Routes HTTP PUT requests to the specified path with the specified callback functions.
-
-#### Arguments
-
-| Argument   | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | Default           |
-| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
-| `path`     | The path for which the middleware function is invoked; can be any of: a string representing a path, a path pattern, a regular expression pattern to match paths, or an array of combinations of any of the above. For examples, see [Path examples](#path-examples).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | `'/'` (root path) |
-| `callback` | Callback functions; can be: a middleware function, a series of middleware functions (separated by commas), an array of middleware functions, or a combination of all of the above. You can provide multiple callback functions that behave just like middleware, except that these callbacks can invoke `next('route')` to bypass the remaining route callback(s). You can use this mechanism to impose pre-conditions on a route, then pass control to subsequent routes if there is no reason to proceed with the current route. Since [router](/api/router/) and [app](#overview) implement the middleware interface, you can use them as you would any other middleware function. For examples, see [Middleware callback function examples](#middleware-callback-function-examples). | None              |
 
 #### Example
 
@@ -742,7 +922,21 @@ app.put('/', function (req, res) {
 });
 ```
 
-### app.render(view, [locals], callback)
+### app.render()
+
+<Signature>
+  <Fragment slot="attributes">
+    <Param name="view" type="String">
+      The name of the view to render.
+    </Param>
+    <Param name="locals" type="Object" optional>
+      An object whose properties define local variables for the view.
+    </Param>
+    <Param name="callback" type="Function">
+      The callback invoked as `callback(err, html)` with the rendered HTML.
+    </Param>
+  </Fragment>
+</Signature>
 
 Returns the rendered HTML of a view via the `callback` function. It accepts an optional parameter
 that is an object containing local variables for the view. It is like [res.render()](/api/response/#resrenderview--locals--callback),
@@ -788,7 +982,15 @@ app.render('email', { name: 'Tobi' }, function (err, html) {
 });
 ```
 
-### app.route(path)
+### app.route()
+
+<Signature returns="Route">
+  <Fragment slot="attributes">
+    <Param name="path" type="String">
+      The path of the route to create.
+    </Param>
+  </Fragment>
+</Signature>
 
 Returns an instance of a single route, which you can then use to handle HTTP verbs with optional middleware.
 Use `app.route()` to avoid duplicate route names (and thus typo errors).
@@ -810,7 +1012,19 @@ app
   });
 ```
 
-### app.set(name, value)
+### app.set()
+
+<Signature returns="Application">
+  <Fragment slot="attributes">
+    <Param name="name" type="String">
+      The name of the setting to assign. Certain names configure the server's behavior; see the [app
+      settings table](#application-settings).
+    </Param>
+    <Param name="value" type="any">
+      The value to assign to the setting.
+    </Param>
+  </Fragment>
+</Signature>
 
 Assigns setting `name` to `value`. You may store any value that you want,
 but certain names can be used to configure the behavior of the server. These
@@ -839,23 +1053,55 @@ Note that sub-apps will:
 Exceptions: Sub-apps will inherit the value of `trust proxy` even though it has a default value (for backward-compatibility);
 Sub-apps will not inherit the value of `view cache` in production (when `NODE_ENV` is "production").
 
-| Property                 | Type            | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | Default                                                                                             |
-| ------------------------ | --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
-| `case sensitive routing` | Boolean         | Enable case sensitivity. When enabled, "/Foo" and "/foo" are different routes. When disabled, "/Foo" and "/foo" are treated the same. **NOTE**: Sub-apps will inherit the value of this setting.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | N/A (undefined)                                                                                     |
-| `env`                    | String          | Environment mode. Be sure to set to "production" in a production environment; see [Production best practices: performance and reliability](/advanced/best-practice-performance#things-to-do-in-your-environment--setup).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | `process.env.NODE_ENV` (`NODE_ENV` environment variable) or "development" if `NODE_ENV` is not set. |
-| `etag`                   | Varied          | Set the ETag response header. For possible values, see the `etag` options table below. [More about the HTTP ETag header](https://en.wikipedia.org/wiki/HTTP_ETag).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | `weak`                                                                                              |
-| `jsonp callback name`    | String          | Specifies the default JSONP callback name.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | "callback"                                                                                          |
-| `json escape`            | Boolean         | Enable escaping JSON responses from the `res.json`, `res.jsonp`, and `res.send` APIs. This will escape the characters `<`, `>`, and `&` as Unicode escape sequences in JSON. The purpose of this is to assist with [mitigating certain types of persistent XSS attacks](https://blog.mozilla.org/security/2017/07/18/web-service-audits-firefox-accounts/) when clients sniff responses for HTML. **NOTE**: Sub-apps will inherit the value of this setting.                                                                                                                                                                                                                                                                                                                                                                                   | N/A (undefined)                                                                                     |
-| `json replacer`          | Varied          | The ['replacer' argument used by `JSON.stringify`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#the_replacer_parameter). **NOTE**: Sub-apps will inherit the value of this setting.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | N/A (undefined)                                                                                     |
-| `json spaces`            | Varied          | The ['space' argument used by `JSON.stringify`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#the_space_parameter). This is typically set to the number of spaces to use to indent prettified JSON. **NOTE**: Sub-apps will inherit the value of this setting.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | N/A (undefined)                                                                                     |
-| `query parser`           | Varied          | Disable query parsing by setting the value to `false`, or set the query parser to use either "simple" or "extended" or a custom query string parsing function. The simple query parser is based on Node's native query parser, [querystring](https://nodejs.org/api/querystring.html). The extended query parser is based on [qs](https://www.npmjs.com/package/qs). A custom query string parsing function will receive the complete query string, and must return an object of query keys and their values.                                                                                                                                                                                                                                                                                                                                  | "extended"                                                                                          |
-| `strict routing`         | Boolean         | Enable strict routing. When enabled, the router treats "/foo" and "/foo/" as different. Otherwise, the router treats "/foo" and "/foo/" as the same. **NOTE**: Sub-apps will inherit the value of this setting.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | N/A (undefined)                                                                                     |
-| `subdomain offset`       | Number          | The number of dot-separated parts of the host to remove to access subdomain.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | 2                                                                                                   |
-| `trust proxy`            | Varied          | Indicates the app is behind a front-facing proxy, and to use the `X-Forwarded-*` headers to determine the connection and the IP address of the client. NOTE: `X-Forwarded-*` headers are easily spoofed and the detected IP addresses are unreliable. When enabled, Express attempts to determine the IP address of the client connected through the front-facing proxy, or series of proxies. The `req.ips` property, then contains an array of IP addresses the client is connected through. To enable it, use the values described in the trust proxy options table below. The `trust proxy` setting is implemented using the [proxy-addr](https://www.npmjs.com/package/proxy-addr) package. For more information, see its documentation. **NOTE**: Sub-apps _will_ inherit the value of this setting, even though it has a default value. | `false` (disabled)                                                                                  |
-| `views`                  | String or Array | A directory or an array of directories for the application's views. If an array, the views are looked up in the order they occur in the array.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | `process.cwd() + '/views'`                                                                          |
-| `view cache`             | Boolean         | Enables view template compilation caching. **NOTE**: Sub-apps will not inherit the value of this setting in production (when `NODE_ENV` is "production").                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      | `true` in production, otherwise undefined.                                                          |
-| `view engine`            | String          | The default engine extension to use when omitted. **NOTE**: Sub-apps will inherit the value of this setting.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | N/A (undefined)                                                                                     |
-| `x-powered-by`           | Boolean         | Enables the "X-Powered-By: Express" HTTP header.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | `true`                                                                                              |
+<Signature attributesTitle="Settings">
+  <Fragment slot="attributes">
+    <Param name="case sensitive routing" type="Boolean" default="N/A (undefined)">
+      Enable case sensitivity. When enabled, "/Foo" and "/foo" are different routes. When disabled, "/Foo" and "/foo" are treated the same. **NOTE**: Sub-apps will inherit the value of this setting.
+    </Param>
+    <Param name="env" type="String" default='process.env.NODE_ENV (NODE_ENV environment variable) or "development" if NODE_ENV is not set.'>
+      Environment mode. Be sure to set to "production" in a production environment; see [Production best practices: performance and reliability](/advanced/best-practice-performance#things-to-do-in-your-environment--setup).
+    </Param>
+    <Param name="etag" type="Varied" default="weak">
+      Set the ETag response header. For possible values, see the `etag` options table below. [More about the HTTP ETag header](https://en.wikipedia.org/wiki/HTTP_ETag).
+    </Param>
+    <Param name="jsonp callback name" type="String" default='"callback"'>
+      Specifies the default JSONP callback name.
+    </Param>
+    <Param name="json escape" type="Boolean" default="N/A (undefined)">
+      Enable escaping JSON responses from the `res.json`, `res.jsonp`, and `res.send` APIs. This will escape the characters `<`, `>`, and `&` as Unicode escape sequences in JSON. The purpose of this is to assist with [mitigating certain types of persistent XSS attacks](https://blog.mozilla.org/security/2017/07/18/web-service-audits-firefox-accounts/) when clients sniff responses for HTML. **NOTE**: Sub-apps will inherit the value of this setting.
+    </Param>
+    <Param name="json replacer" type="Varied" default="N/A (undefined)">
+      The ['replacer' argument used by `JSON.stringify`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#the_replacer_parameter). **NOTE**: Sub-apps will inherit the value of this setting.
+    </Param>
+    <Param name="json spaces" type="Varied" default="N/A (undefined)">
+      The ['space' argument used by `JSON.stringify`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#the_space_parameter). This is typically set to the number of spaces to use to indent prettified JSON. **NOTE**: Sub-apps will inherit the value of this setting.
+    </Param>
+    <Param name="query parser" type="Varied" default='"extended"'>
+      Disable query parsing by setting the value to `false`, or set the query parser to use either "simple" or "extended" or a custom query string parsing function. The simple query parser is based on Node's native query parser, [querystring](https://nodejs.org/api/querystring.html). The extended query parser is based on [qs](https://www.npmjs.com/package/qs). A custom query string parsing function will receive the complete query string, and must return an object of query keys and their values.
+    </Param>
+    <Param name="strict routing" type="Boolean" default="N/A (undefined)">
+      Enable strict routing. When enabled, the router treats "/foo" and "/foo/" as different. Otherwise, the router treats "/foo" and "/foo/" as the same. **NOTE**: Sub-apps will inherit the value of this setting.
+    </Param>
+    <Param name="subdomain offset" type="Number" default="2">
+      The number of dot-separated parts of the host to remove to access subdomain.
+    </Param>
+    <Param name="trust proxy" type="Varied" default="false (disabled)">
+      Indicates the app is behind a front-facing proxy, and to use the `X-Forwarded-*` headers to determine the connection and the IP address of the client. NOTE: `X-Forwarded-*` headers are easily spoofed and the detected IP addresses are unreliable. When enabled, Express attempts to determine the IP address of the client connected through the front-facing proxy, or series of proxies. The `req.ips` property, then contains an array of IP addresses the client is connected through. To enable it, use the values described in the trust proxy options table below. The `trust proxy` setting is implemented using the [proxy-addr](https://www.npmjs.com/package/proxy-addr) package. For more information, see its documentation. **NOTE**: Sub-apps _will_ inherit the value of this setting, even though it has a default value.
+    </Param>
+    <Param name="views" type="String or Array" default="process.cwd() + '/views'">
+      A directory or an array of directories for the application's views. If an array, the views are looked up in the order they occur in the array.
+    </Param>
+    <Param name="view cache" type="Boolean" default="true in production, otherwise undefined.">
+      Enables view template compilation caching. **NOTE**: Sub-apps will not inherit the value of this setting in production (when `NODE_ENV` is "production").
+    </Param>
+    <Param name="view engine" type="String" default="N/A (undefined)">
+      The default engine extension to use when omitted. **NOTE**: Sub-apps will inherit the value of this setting.
+    </Param>
+    <Param name="x-powered-by" type="Boolean" default="true">
+      Enables the "X-Powered-By: Express" HTTP header.
+    </Param>
+  </Fragment>
+</Signature>
 
 #### Options for `trust proxy` setting
 
@@ -915,11 +1161,17 @@ app.set('trust proxy', function (ip) {
 
 The ETag functionality is implemented using the [etag](https://www.npmjs.com/package/etag) package. For more information, see its documentation.
 
-| Type     | Value                                                                                    |
-| -------- | ---------------------------------------------------------------------------------------- |
-| Boolean  | `true` enables weak ETag. This is the default setting. `false` disables ETag altogether. |
-| String   | If "strong", enables strong ETag. If "weak", enables weak ETag.                          |
-| Function | Custom ETag function implementation. Use this only if you know what you are doing.       |
+<Signature attributesTitle="Values">
+  <Fragment slot="attributes">
+    <Param name="Boolean">
+      `true` enables weak ETag. This is the default setting. `false` disables ETag altogether.
+    </Param>
+    <Param name="String">If "strong", enables strong ETag. If "weak", enables weak ETag.</Param>
+    <Param name="Function">
+      Custom ETag function implementation. Use this only if you know what you are doing.
+    </Param>
+  </Fragment>
+</Signature>
 
 ```js
 app.set('etag', function (body, encoding) {
@@ -927,18 +1179,32 @@ app.set('etag', function (body, encoding) {
 });
 ```
 
-### app.use([path,] callback [, callback...])
+### app.use()
+
+<Signature>
+  <Fragment slot="attributes">
+    <Param name="path" type="String | RegExp | Array" optional>
+      The path for which the middleware function is invoked; can be any of: a string representing a
+      path, a path pattern, a regular expression pattern to match paths, or an array of combinations
+      of any of the above. For examples, see [Path examples](#path-examples).
+    </Param>
+    <Param name="callback" type="Function | Function[]">
+      Callback functions; can be: a middleware function, a series of middleware functions (separated
+      by commas), an array of middleware functions, or a combination of all of the above. You can
+      provide multiple callback functions that behave just like middleware, except that these
+      callbacks can invoke `next('route')` to bypass the remaining route callback(s). You can use
+      this mechanism to impose pre-conditions on a route, then pass control to subsequent routes if
+      there is no reason to proceed with the current route. Since [router](/api/router/) and
+      [app](#overview) implement the middleware interface, you can use them as you would any other
+      middleware function. For examples, see [Middleware callback function
+      examples](#middleware-callback-function-examples).
+    </Param>
+  </Fragment>
+</Signature>
 
 Mounts the specified [middleware](/guide/using-middleware) function or functions
 at the specified path:
 the middleware function is executed when the base of the requested path matches `path`.
-
-#### Arguments
-
-| Argument   | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | Default           |
-| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
-| `path`     | The path for which the middleware function is invoked; can be any of: a string representing a path, a path pattern, a regular expression pattern to match paths, or an array of combinations of any of the above. For examples, see [Path examples](#path-examples).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | `'/'` (root path) |
-| `callback` | Callback functions; can be: a middleware function, a series of middleware functions (separated by commas), an array of middleware functions, or a combination of all of the above. You can provide multiple callback functions that behave just like middleware, except that these callbacks can invoke `next('route')` to bypass the remaining route callback(s). You can use this mechanism to impose pre-conditions on a route, then pass control to subsequent routes if there is no reason to proceed with the current route. Since [router](/api/router/) and [app](#overview) implement the middleware interface, you can use them as you would any other middleware function. For examples, see [Middleware callback function examples](#middleware-callback-function-examples). | None              |
 
 #### Description
 

--- a/src/content/api/4x/api/application/index.mdx
+++ b/src/content/api/4x/api/application/index.mdx
@@ -44,7 +44,7 @@ The Express application object can be referred from the [request object](/api/re
 <Signature type="Object" />
 
 The `app.locals` object has properties that are local variables within the application,
-and will be available in templates rendered with [res.render](/api/response/#resrenderview--locals--callback).
+and will be available in templates rendered with [res.render](/api/response/#resrender).
 
 <Alert type="warning">
 
@@ -939,7 +939,7 @@ app.put('/', function (req, res) {
 </Signature>
 
 Returns the rendered HTML of a view via the `callback` function. It accepts an optional parameter
-that is an object containing local variables for the view. It is like [res.render()](/api/response/#resrenderview--locals--callback),
+that is an object containing local variables for the view. It is like [res.render()](/api/response/#resrender),
 except it cannot send the rendered view to the client on its own.
 
 <Alert type="info">

--- a/src/content/api/4x/api/express/index.mdx
+++ b/src/content/api/4x/api/express/index.mdx
@@ -20,37 +20,44 @@ var app = express();
 
 <Signature returns="Function" since="v4.16.0">
   <Fragment slot="attributes">
-    <Param name="inflate" type="Boolean" default="true">
-      Enables or disables handling deflated (compressed) bodies; when disabled, deflated bodies are
-      rejected.
+    <Param name="options" type="Object" optional>
+      Configures how the JSON body is parsed; it accepts the properties below.
+
+      <Fragment slot="properties">
+        <Param name="inflate" type="Boolean" default="true">
+          Enables or disables handling deflated (compressed) bodies; when disabled, deflated bodies
+          are rejected.
+        </Param>
+        <Param name="limit" type="Number | String" default='"100kb"'>
+          Controls the maximum request body size. If this is a number, then the value specifies the
+          number of bytes; if it is a string, the value is passed to the
+          [bytes](https://www.npmjs.com/package/bytes) library for parsing.
+        </Param>
+        <Param name="reviver" type="Function" default="null">
+          The `reviver` option is passed directly to `JSON.parse` as the second argument. You can
+          find more information on this argument [in the MDN documentation about
+          JSON.parse](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse#the_reviver_parameter).
+        </Param>
+        <Param name="strict" type="Boolean" default="true">
+          Enables or disables only accepting arrays and objects; when disabled will accept anything
+          `JSON.parse` accepts.
+        </Param>
+        <Param name="type" type="String | String[] | Function" default='"application/json"'>
+          This is used to determine what media type the middleware will parse. This option can be a
+          string, array of strings, or a function. If not a function, `type` option is passed
+          directly to the [type-is](https://www.npmjs.com/package/type-is#readme) library and this
+          can be an extension name (like `json`), a mime type (like `application/json`), or a mime
+          type with a wildcard (like `*/*` or `*/json`). If a function, the `type` option is called
+          as `fn(req)` and the request is parsed if it returns a truthy value.
+        </Param>
+        <Param name="verify" type="Function" default="undefined">
+          This option, if supplied, is called as `verify(req, res, buf, encoding)`, where `buf` is a
+          `Buffer` of the raw request body and `encoding` is the encoding of the request. The
+          parsing can be aborted by throwing an error.
+        </Param>
+      </Fragment>
     </Param>
-    <Param name="limit" type="Number | String" default='"100kb"'>
-      Controls the maximum request body size. If this is a number, then the value specifies the
-      number of bytes; if it is a string, the value is passed to the
-      [bytes](https://www.npmjs.com/package/bytes) library for parsing.
-    </Param>
-    <Param name="reviver" type="Function" default="null">
-      The `reviver` option is passed directly to `JSON.parse` as the second argument. You can find
-      more information on this argument [in the MDN documentation about
-      JSON.parse](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse#the_reviver_parameter).
-    </Param>
-    <Param name="strict" type="Boolean" default="true">
-      Enables or disables only accepting arrays and objects; when disabled will accept anything
-      `JSON.parse` accepts.
-    </Param>
-    <Param name="type" type="String | String[] | Function" default='"application/json"'>
-      This is used to determine what media type the middleware will parse. This option can be a
-      string, array of strings, or a function. If not a function, `type` option is passed directly
-      to the [type-is](https://www.npmjs.com/package/type-is#readme) library and this can be an
-      extension name (like `json`), a mime type (like `application/json`), or a mime type with a
-      wildcard (like `*/*` or `*/json`). If a function, the `type` option is called as `fn(req)` and
-      the request is parsed if it returns a truthy value.
-    </Param>
-    <Param name="verify" type="Function" default="undefined">
-      This option, if supplied, is called as `verify(req, res, buf, encoding)`, where `buf` is a
-      `Buffer` of the raw request body and `encoding` is the encoding of the request. The parsing
-      can be aborted by throwing an error.
-    </Param>
+
   </Fragment>
 </Signature>
 
@@ -81,28 +88,35 @@ may not be a function and instead a string or other user-input.
 
 <Signature returns="Function" since="v4.17.0">
   <Fragment slot="attributes">
-    <Param name="inflate" type="Boolean" default="true">
-      Enables or disables handling deflated (compressed) bodies; when disabled, deflated bodies are
-      rejected.
+    <Param name="options" type="Object" optional>
+      Configures how the request body is parsed; it accepts the properties below.
+
+      <Fragment slot="properties">
+        <Param name="inflate" type="Boolean" default="true">
+          Enables or disables handling deflated (compressed) bodies; when disabled, deflated bodies
+          are rejected.
+        </Param>
+        <Param name="limit" type="Number | String" default='"100kb"'>
+          Controls the maximum request body size. If this is a number, then the value specifies the
+          number of bytes; if it is a string, the value is passed to the
+          [bytes](https://www.npmjs.com/package/bytes) library for parsing.
+        </Param>
+        <Param name="type" type="String | String[] | Function" default='"application/octet-stream"'>
+          This is used to determine what media type the middleware will parse. This option can be a
+          string, array of strings, or a function. If not a function, `type` option is passed
+          directly to the [type-is](https://www.npmjs.com/package/type-is#readme) library and this
+          can be an extension name (like `bin`), a mime type (like `application/octet-stream`), or a
+          mime type with a wildcard (like `*/*` or `application/*`). If a function, the `type`
+          option is called as `fn(req)` and the request is parsed if it returns a truthy value.
+        </Param>
+        <Param name="verify" type="Function" default="undefined">
+          This option, if supplied, is called as `verify(req, res, buf, encoding)`, where `buf` is a
+          `Buffer` of the raw request body and `encoding` is the encoding of the request. The
+          parsing can be aborted by throwing an error.
+        </Param>
+      </Fragment>
     </Param>
-    <Param name="limit" type="Number | String" default='"100kb"'>
-      Controls the maximum request body size. If this is a number, then the value specifies the
-      number of bytes; if it is a string, the value is passed to the
-      [bytes](https://www.npmjs.com/package/bytes) library for parsing.
-    </Param>
-    <Param name="type" type="String | String[] | Function" default='"application/octet-stream"'>
-      This is used to determine what media type the middleware will parse. This option can be a
-      string, array of strings, or a function. If not a function, `type` option is passed directly
-      to the [type-is](https://www.npmjs.com/package/type-is#readme) library and this can be an
-      extension name (like `bin`), a mime type (like `application/octet-stream`), or a mime type
-      with a wildcard (like `*/*` or `application/*`). If a function, the `type` option is called as
-      `fn(req)` and the request is parsed if it returns a truthy value.
-    </Param>
-    <Param name="verify" type="Function" default="undefined">
-      This option, if supplied, is called as `verify(req, res, buf, encoding)`, where `buf` is a
-      `Buffer` of the raw request body and `encoding` is the encoding of the request. The parsing
-      can be aborted by throwing an error.
-    </Param>
+
   </Fragment>
 </Signature>
 
@@ -303,32 +317,39 @@ app.use(express.static('public', options));
 
 <Signature returns="Function" since="v4.17.0">
   <Fragment slot="attributes">
-    <Param name="defaultCharset" type="String" default='"utf-8"'>
-      Specify the default character set for the text content if the charset is not specified in the
-      `Content-Type` header of the request.
+    <Param name="options" type="Object" optional>
+      Configures how the text body is parsed; it accepts the properties below.
+
+      <Fragment slot="properties">
+        <Param name="defaultCharset" type="String" default='"utf-8"'>
+          Specify the default character set for the text content if the charset is not specified in
+          the `Content-Type` header of the request.
+        </Param>
+        <Param name="inflate" type="Boolean" default="true">
+          Enables or disables handling deflated (compressed) bodies; when disabled, deflated bodies
+          are rejected.
+        </Param>
+        <Param name="limit" type="Number | String" default='"100kb"'>
+          Controls the maximum request body size. If this is a number, then the value specifies the
+          number of bytes; if it is a string, the value is passed to the
+          [bytes](https://www.npmjs.com/package/bytes) library for parsing.
+        </Param>
+        <Param name="type" type="String | String[] | Function" default='"text/plain"'>
+          This is used to determine what media type the middleware will parse. This option can be a
+          string, array of strings, or a function. If not a function, `type` option is passed
+          directly to the [type-is](https://www.npmjs.com/package/type-is#readme) library and this
+          can be an extension name (like `txt`), a mime type (like `text/plain`), or a mime type
+          with a wildcard (like `*/*` or `text/*`). If a function, the `type` option is called as
+          `fn(req)` and the request is parsed if it returns a truthy value.
+        </Param>
+        <Param name="verify" type="Function" default="undefined">
+          This option, if supplied, is called as `verify(req, res, buf, encoding)`, where `buf` is a
+          `Buffer` of the raw request body and `encoding` is the encoding of the request. The
+          parsing can be aborted by throwing an error.
+        </Param>
+      </Fragment>
     </Param>
-    <Param name="inflate" type="Boolean" default="true">
-      Enables or disables handling deflated (compressed) bodies; when disabled, deflated bodies are
-      rejected.
-    </Param>
-    <Param name="limit" type="Number | String" default='"100kb"'>
-      Controls the maximum request body size. If this is a number, then the value specifies the
-      number of bytes; if it is a string, the value is passed to the
-      [bytes](https://www.npmjs.com/package/bytes) library for parsing.
-    </Param>
-    <Param name="type" type="String | String[] | Function" default='"text/plain"'>
-      This is used to determine what media type the middleware will parse. This option can be a
-      string, array of strings, or a function. If not a function, `type` option is passed directly
-      to the [type-is](https://www.npmjs.com/package/type-is#readme) library and this can be an
-      extension name (like `txt`), a mime type (like `text/plain`), or a mime type with a wildcard
-      (like `*/*` or `text/*`). If a function, the `type` option is called as `fn(req)` and the
-      request is parsed if it returns a truthy value.
-    </Param>
-    <Param name="verify" type="Function" default="undefined">
-      This option, if supplied, is called as `verify(req, res, buf, encoding)`, where `buf` is a
-      `Buffer` of the raw request body and `encoding` is the encoding of the request. The parsing
-      can be aborted by throwing an error.
-    </Param>
+
   </Fragment>
 </Signature>
 
@@ -359,48 +380,52 @@ Testing that `req.body` is a string before calling string methods is recommended
 
 <Signature returns="Function" since="v4.16.0">
   <Fragment slot="attributes">
-    <Param name="extended" type="Boolean" default="true">
-      This option allows to choose between parsing the URL-encoded data with the `querystring`
-      library (when `false`) or the `qs` library (when `true`). The "extended" syntax allows for
-      rich objects and arrays to be encoded into the URL-encoded format, allowing for a JSON-like
-      experience with URL-encoded. For more information, please [see the qs
-      library](https://www.npmjs.com/package/qs#readme).
+    <Param name="options" type="Object" optional>
+      Configures how the URL-encoded body is parsed; it accepts the properties below.
+
+      <Fragment slot="properties">
+        <Param name="extended" type="Boolean" default="true">
+          This option allows to choose between parsing the URL-encoded data with the `querystring`
+          library (when `false`) or the `qs` library (when `true`). The "extended" syntax allows for
+          rich objects and arrays to be encoded into the URL-encoded format, allowing for a
+          JSON-like experience with URL-encoded. For more information, please [see the qs
+          library](https://www.npmjs.com/package/qs#readme).
+        </Param>
+        <Param name="inflate" type="Boolean" default="true">
+          Enables or disables handling deflated (compressed) bodies; when disabled, deflated bodies
+          are rejected.
+        </Param>
+        <Param name="limit" type="Number | String" default='"100kb"'>
+          Controls the maximum request body size. If this is a number, then the value specifies the
+          number of bytes; if it is a string, the value is passed to the
+          [bytes](https://www.npmjs.com/package/bytes) library for parsing.
+        </Param>
+        <Param name="parameterLimit" type="Number" default="1000">
+          This option controls the maximum number of parameters that are allowed in the URL-encoded
+          data. If a request contains more parameters than this value, an error will be raised.
+        </Param>
+        <Param name="type" type="String | String[] | Function" default='"application/x-www-form-urlencoded"'>
+          This is used to determine what media type the middleware will parse. This option can be a
+          string, array of strings, or a function. If not a function, `type` option is passed
+          directly to the [type-is](https://www.npmjs.com/package/type-is#readme) library and this
+          can be an extension name (like `urlencoded`), a mime type (like
+          `application/x-www-form-urlencoded`), or a mime type with a wildcard (like
+          `*/x-www-form-urlencoded`). If a function, the `type` option is called as `fn(req)` and
+          the request is parsed if it returns a truthy value.
+        </Param>
+        <Param name="verify" type="Function" default="undefined">
+          This option, if supplied, is called as `verify(req, res, buf, encoding)`, where `buf` is a
+          `Buffer` of the raw request body and `encoding` is the encoding of the request. The
+          parsing can be aborted by throwing an error.
+        </Param>
+        <Param name="depth" type="Number" default="32" since="v4.20.0">
+          Configure the maximum depth of the `qs` library when `extended` is `true`. This allows you
+          to limit the amount of keys that are parsed and can be useful to prevent certain types of
+          abuse. It is recommended to keep this value as low as possible.
+        </Param>
+      </Fragment>
     </Param>
-    <Param name="inflate" type="Boolean" default="true">
-      Enables or disables handling deflated (compressed) bodies; when disabled, deflated bodies are
-      rejected.
-    </Param>
-    <Param name="limit" type="Number | String" default='"100kb"'>
-      Controls the maximum request body size. If this is a number, then the value specifies the
-      number of bytes; if it is a string, the value is passed to the
-      [bytes](https://www.npmjs.com/package/bytes) library for parsing.
-    </Param>
-    <Param name="parameterLimit" type="Number" default="1000">
-      This option controls the maximum number of parameters that are allowed in the URL-encoded
-      data. If a request contains more parameters than this value, an error will be raised.
-    </Param>
-    <Param
-      name="type"
-      type="String | String[] | Function"
-      default='"application/x-www-form-urlencoded"'
-    >
-      This is used to determine what media type the middleware will parse. This option can be a
-      string, array of strings, or a function. If not a function, `type` option is passed directly
-      to the [type-is](https://www.npmjs.com/package/type-is#readme) library and this can be an
-      extension name (like `urlencoded`), a mime type (like `application/x-www-form-urlencoded`), or
-      a mime type with a wildcard (like `*/x-www-form-urlencoded`). If a function, the `type` option
-      is called as `fn(req)` and the request is parsed if it returns a truthy value.
-    </Param>
-    <Param name="verify" type="Function" default="undefined">
-      This option, if supplied, is called as `verify(req, res, buf, encoding)`, where `buf` is a
-      `Buffer` of the raw request body and `encoding` is the encoding of the request. The parsing
-      can be aborted by throwing an error.
-    </Param>
-    <Param name="depth" type="Number" default="32" since="v4.20.0">
-      Configure the maximum depth of the `qs` library when `extended` is `true`. This allows you to
-      limit the amount of keys that are parsed and can be useful to prevent certain types of abuse.
-      Defaults to `32`. It is recommended to keep this value as low as possible.
-    </Param>
+
   </Fragment>
 </Signature>
 

--- a/src/content/api/4x/api/express/index.mdx
+++ b/src/content/api/4x/api/express/index.mdx
@@ -81,10 +81,28 @@ may not be a function and instead a string or other user-input.
 
 <Signature returns="Function" since="v4.17.0">
   <Fragment slot="attributes">
-    <Param name="inflate" type="Boolean" default="true">Enables or disables handling deflated (compressed) bodies; when disabled, deflated bodies are rejected.</Param>
-    <Param name="limit" type="Number | String" default='"100kb"'>Controls the maximum request body size. If this is a number, then the value specifies the number of bytes; if it is a string, the value is passed to the [bytes](https://www.npmjs.com/package/bytes) library for parsing.</Param>
-    <Param name="type" type="String | String[] | Function" default='"application/octet-stream"'>This is used to determine what media type the middleware will parse. This option can be a string, array of strings, or a function. If not a function, `type` option is passed directly to the [type-is](https://www.npmjs.com/package/type-is#readme) library and this can be an extension name (like `bin`), a mime type (like `application/octet-stream`), or a mime type with a wildcard (like `*/*` or `application/*`). If a function, the `type` option is called as `fn(req)` and the request is parsed if it returns a truthy value.</Param>
-    <Param name="verify" type="Function" default="undefined">This option, if supplied, is called as `verify(req, res, buf, encoding)`, where `buf` is a `Buffer` of the raw request body and `encoding` is the encoding of the request. The parsing can be aborted by throwing an error.</Param>
+    <Param name="inflate" type="Boolean" default="true">
+      Enables or disables handling deflated (compressed) bodies; when disabled, deflated bodies are
+      rejected.
+    </Param>
+    <Param name="limit" type="Number | String" default='"100kb"'>
+      Controls the maximum request body size. If this is a number, then the value specifies the
+      number of bytes; if it is a string, the value is passed to the
+      [bytes](https://www.npmjs.com/package/bytes) library for parsing.
+    </Param>
+    <Param name="type" type="String | String[] | Function" default='"application/octet-stream"'>
+      This is used to determine what media type the middleware will parse. This option can be a
+      string, array of strings, or a function. If not a function, `type` option is passed directly
+      to the [type-is](https://www.npmjs.com/package/type-is#readme) library and this can be an
+      extension name (like `bin`), a mime type (like `application/octet-stream`), or a mime type
+      with a wildcard (like `*/*` or `application/*`). If a function, the `type` option is called as
+      `fn(req)` and the request is parsed if it returns a truthy value.
+    </Param>
+    <Param name="verify" type="Function" default="undefined">
+      This option, if supplied, is called as `verify(req, res, buf, encoding)`, where `buf` is a
+      `Buffer` of the raw request body and `encoding` is the encoding of the request. The parsing
+      can be aborted by throwing an error.
+    </Param>
   </Fragment>
 </Signature>
 
@@ -115,9 +133,17 @@ Testing that `req.body` is a `Buffer` before calling buffer methods is recommend
 
 <Signature returns="Router">
   <Fragment slot="attributes">
-    <Param name="caseSensitive" type="Boolean" default="false">Enable case sensitivity. Disabled by default, treating `/Foo` and `/foo` as the same.</Param>
-    <Param name="mergeParams" type="Boolean" default="false" since="v4.5.0+">Preserve the `req.params` values from the parent router. If the parent and the child have conflicting param names, the child's value take precedence.</Param>
-    <Param name="strict" type="Boolean" default="false">Enable strict routing. Disabled by default, `/foo` and `/foo/` are treated the same by the router.</Param>
+    <Param name="caseSensitive" type="Boolean" default="false">
+      Enable case sensitivity. Disabled by default, treating `/Foo` and `/foo` as the same.
+    </Param>
+    <Param name="mergeParams" type="Boolean" default="false" since="v4.5.0+">
+      Preserve the `req.params` values from the parent router. If the parent and the child have
+      conflicting param names, the child's value take precedence.
+    </Param>
+    <Param name="strict" type="Boolean" default="false">
+      Enable strict routing. Disabled by default, `/foo` and `/foo/` are treated the same by the
+      router.
+    </Param>
   </Fragment>
 </Signature>
 
@@ -140,58 +166,59 @@ For more information, see [Router](/api/router/).
       The root directory from which to serve static assets.
     </Param>
     <Param name="options" type="Object" optional>
-      Configures how files are served; its properties are described below.
-    </Param>
-  </Fragment>
-</Signature>
+      Configures how files are served; it accepts the properties below. See also the [example
+      below](#example-of-expressstatic).
 
-The `options` object accepts the following properties. See also the [example below](#example-of-expressstatic).
+      <Fragment slot="properties">
+        <Param name="dotfiles" type="String" default="undefined">
+          Determines how dotfiles (files or directories that begin with a dot ".") are treated. See
+          [dotfiles](#dotfiles) below.
+        </Param>
+        <Param name="etag" type="Boolean" default="true">
+          Enable or disable etag generation. NOTE: `express.static` always sends weak ETags.
+        </Param>
+        <Param name="extensions" type="String[] | Boolean" default="false">
+          Sets file extension fallbacks: If a file is not found, search for files with the specified
+          extensions and serve the first one found. Example: `['html', 'htm']`.
+        </Param>
+        <Param name="fallthrough" type="Boolean" default="true">
+          Let client errors fall-through as unhandled requests, otherwise forward a client error.
+          See [fallthrough](#fallthrough) below.
+        </Param>
+        <Param name="immutable" type="Boolean" default="false">
+          Enable or disable the `immutable` directive in the `Cache-Control` response header. If
+          enabled, the `maxAge` option should also be specified to enable caching. The `immutable`
+          directive will prevent supported clients from making conditional requests during the life
+          of the `maxAge` option to check if the file has changed.
+        </Param>
+        <Param name="index" type="String | Boolean" default='"index.html"'>
+          Sends the specified directory index file. Set to `false` to disable directory indexing.
+        </Param>
+        <Param name="lastModified" type="Boolean" default="true">
+          Set the `Last-Modified` header to the last modified date of the file on the OS.
+        </Param>
+        <Param name="maxAge" type="Number" default="0">
+          Set the max-age property of the Cache-Control header in milliseconds or a string in [ms
+          format](https://www.npmjs.com/package/ms).
+        </Param>
+        <Param name="redirect" type="Boolean" default="true">
+          Redirect to trailing "/" when the pathname is a directory.
+        </Param>
+        <Param name="setHeaders" type="Function">
+          Function for setting HTTP headers to serve with the file. See [setHeaders](#setheaders)
+          below.
+        </Param>
+        <Param name="acceptRanges" type="Boolean" default="true">
+          Enable or disable accepting ranged requests. Disabling this will not send the
+          `Accept-Ranges` header and will ignore the contents of the Range request header.
+        </Param>
+        <Param name="cacheControl" type="Boolean" default="true">
+          Enable or disable setting the `Cache-Control` response header. Disabling this will ignore
+          the immutable and maxAge options.
+        </Param>
+      </Fragment>
+    </Param>
 
-<Signature attributesTitle="Options">
-  <Fragment slot="attributes">
-    <Param name="dotfiles" type="String" default="undefined">
-      Determines how dotfiles (files or directories that begin with a dot ".") are treated. See [dotfiles](#dotfiles) below.
-    </Param>
-    <Param name="etag" type="Boolean" default="true">
-      Enable or disable etag generation. NOTE: `express.static` always sends weak ETags.
-    </Param>
-    <Param name="extensions" type="String[] | Boolean" default="false">
-      Sets file extension fallbacks: If a file is not found, search for files with the specified
-      extensions and serve the first one found. Example: `['html', 'htm']`.
-    </Param>
-    <Param name="fallthrough" type="Boolean" default="true">
-      Let client errors fall-through as unhandled requests, otherwise forward a client error. See [fallthrough](#fallthrough) below.
-    </Param>
-    <Param name="immutable" type="Boolean" default="false">
-      Enable or disable the `immutable` directive in the `Cache-Control` response header. If
-      enabled, the `maxAge` option should also be specified to enable caching. The `immutable`
-      directive will prevent supported clients from making conditional requests during the life of
-      the `maxAge` option to check if the file has changed.
-    </Param>
-    <Param name="index" type="String | Boolean" default='"index.html"'>
-      Sends the specified directory index file. Set to `false` to disable directory indexing.
-    </Param>
-    <Param name="lastModified" type="Boolean" default="true">
-      Set the `Last-Modified` header to the last modified date of the file on the OS.
-    </Param>
-    <Param name="maxAge" type="Number" default="0">
-      Set the max-age property of the Cache-Control header in milliseconds or a string in [ms
-      format](https://www.npmjs.com/package/ms).
-    </Param>
-    <Param name="redirect" type="Boolean" default="true">
-      Redirect to trailing "/" when the pathname is a directory.
-    </Param>
-    <Param name="setHeaders" type="Function">
-      Function for setting HTTP headers to serve with the file. See [setHeaders](#setheaders) below.
-    </Param>
-    <Param name="acceptRanges" type="Boolean" default="true">
-      Enable or disable accepting ranged requests. Disabling this will not send the `Accept-Ranges`
-      header and will ignore the contents of the Range request header.
-    </Param>
-    <Param name="cacheControl" type="Boolean" default="true">
-      Enable or disable setting the `Cache-Control` response header. Disabling this will ignore the
-      immutable and maxAge options.
-    </Param>
   </Fragment>
 </Signature>
 
@@ -276,11 +303,32 @@ app.use(express.static('public', options));
 
 <Signature returns="Function" since="v4.17.0">
   <Fragment slot="attributes">
-    <Param name="defaultCharset" type="String" default='"utf-8"'>Specify the default character set for the text content if the charset is not specified in the `Content-Type` header of the request.</Param>
-    <Param name="inflate" type="Boolean" default="true">Enables or disables handling deflated (compressed) bodies; when disabled, deflated bodies are rejected.</Param>
-    <Param name="limit" type="Number | String" default='"100kb"'>Controls the maximum request body size. If this is a number, then the value specifies the number of bytes; if it is a string, the value is passed to the [bytes](https://www.npmjs.com/package/bytes) library for parsing.</Param>
-    <Param name="type" type="String | String[] | Function" default='"text/plain"'>This is used to determine what media type the middleware will parse. This option can be a string, array of strings, or a function. If not a function, `type` option is passed directly to the [type-is](https://www.npmjs.com/package/type-is#readme) library and this can be an extension name (like `txt`), a mime type (like `text/plain`), or a mime type with a wildcard (like `*/*` or `text/*`). If a function, the `type` option is called as `fn(req)` and the request is parsed if it returns a truthy value.</Param>
-    <Param name="verify" type="Function" default="undefined">This option, if supplied, is called as `verify(req, res, buf, encoding)`, where `buf` is a `Buffer` of the raw request body and `encoding` is the encoding of the request. The parsing can be aborted by throwing an error.</Param>
+    <Param name="defaultCharset" type="String" default='"utf-8"'>
+      Specify the default character set for the text content if the charset is not specified in the
+      `Content-Type` header of the request.
+    </Param>
+    <Param name="inflate" type="Boolean" default="true">
+      Enables or disables handling deflated (compressed) bodies; when disabled, deflated bodies are
+      rejected.
+    </Param>
+    <Param name="limit" type="Number | String" default='"100kb"'>
+      Controls the maximum request body size. If this is a number, then the value specifies the
+      number of bytes; if it is a string, the value is passed to the
+      [bytes](https://www.npmjs.com/package/bytes) library for parsing.
+    </Param>
+    <Param name="type" type="String | String[] | Function" default='"text/plain"'>
+      This is used to determine what media type the middleware will parse. This option can be a
+      string, array of strings, or a function. If not a function, `type` option is passed directly
+      to the [type-is](https://www.npmjs.com/package/type-is#readme) library and this can be an
+      extension name (like `txt`), a mime type (like `text/plain`), or a mime type with a wildcard
+      (like `*/*` or `text/*`). If a function, the `type` option is called as `fn(req)` and the
+      request is parsed if it returns a truthy value.
+    </Param>
+    <Param name="verify" type="Function" default="undefined">
+      This option, if supplied, is called as `verify(req, res, buf, encoding)`, where `buf` is a
+      `Buffer` of the raw request body and `encoding` is the encoding of the request. The parsing
+      can be aborted by throwing an error.
+    </Param>
   </Fragment>
 </Signature>
 
@@ -311,13 +359,48 @@ Testing that `req.body` is a string before calling string methods is recommended
 
 <Signature returns="Function" since="v4.16.0">
   <Fragment slot="attributes">
-    <Param name="extended" type="Boolean" default="true">This option allows to choose between parsing the URL-encoded data with the `querystring` library (when `false`) or the `qs` library (when `true`). The "extended" syntax allows for rich objects and arrays to be encoded into the URL-encoded format, allowing for a JSON-like experience with URL-encoded. For more information, please [see the qs library](https://www.npmjs.com/package/qs#readme).</Param>
-    <Param name="inflate" type="Boolean" default="true">Enables or disables handling deflated (compressed) bodies; when disabled, deflated bodies are rejected.</Param>
-    <Param name="limit" type="Number | String" default='"100kb"'>Controls the maximum request body size. If this is a number, then the value specifies the number of bytes; if it is a string, the value is passed to the [bytes](https://www.npmjs.com/package/bytes) library for parsing.</Param>
-    <Param name="parameterLimit" type="Number" default="1000">This option controls the maximum number of parameters that are allowed in the URL-encoded data. If a request contains more parameters than this value, an error will be raised.</Param>
-    <Param name="type" type="String | String[] | Function" default='"application/x-www-form-urlencoded"'>This is used to determine what media type the middleware will parse. This option can be a string, array of strings, or a function. If not a function, `type` option is passed directly to the [type-is](https://www.npmjs.com/package/type-is#readme) library and this can be an extension name (like `urlencoded`), a mime type (like `application/x-www-form-urlencoded`), or a mime type with a wildcard (like `*/x-www-form-urlencoded`). If a function, the `type` option is called as `fn(req)` and the request is parsed if it returns a truthy value.</Param>
-    <Param name="verify" type="Function" default="undefined">This option, if supplied, is called as `verify(req, res, buf, encoding)`, where `buf` is a `Buffer` of the raw request body and `encoding` is the encoding of the request. The parsing can be aborted by throwing an error.</Param>
-    <Param name="depth" type="Number" default="32" since="v4.20.0">Configure the maximum depth of the `qs` library when `extended` is `true`. This allows you to limit the amount of keys that are parsed and can be useful to prevent certain types of abuse. Defaults to `32`. It is recommended to keep this value as low as possible.</Param>
+    <Param name="extended" type="Boolean" default="true">
+      This option allows to choose between parsing the URL-encoded data with the `querystring`
+      library (when `false`) or the `qs` library (when `true`). The "extended" syntax allows for
+      rich objects and arrays to be encoded into the URL-encoded format, allowing for a JSON-like
+      experience with URL-encoded. For more information, please [see the qs
+      library](https://www.npmjs.com/package/qs#readme).
+    </Param>
+    <Param name="inflate" type="Boolean" default="true">
+      Enables or disables handling deflated (compressed) bodies; when disabled, deflated bodies are
+      rejected.
+    </Param>
+    <Param name="limit" type="Number | String" default='"100kb"'>
+      Controls the maximum request body size. If this is a number, then the value specifies the
+      number of bytes; if it is a string, the value is passed to the
+      [bytes](https://www.npmjs.com/package/bytes) library for parsing.
+    </Param>
+    <Param name="parameterLimit" type="Number" default="1000">
+      This option controls the maximum number of parameters that are allowed in the URL-encoded
+      data. If a request contains more parameters than this value, an error will be raised.
+    </Param>
+    <Param
+      name="type"
+      type="String | String[] | Function"
+      default='"application/x-www-form-urlencoded"'
+    >
+      This is used to determine what media type the middleware will parse. This option can be a
+      string, array of strings, or a function. If not a function, `type` option is passed directly
+      to the [type-is](https://www.npmjs.com/package/type-is#readme) library and this can be an
+      extension name (like `urlencoded`), a mime type (like `application/x-www-form-urlencoded`), or
+      a mime type with a wildcard (like `*/x-www-form-urlencoded`). If a function, the `type` option
+      is called as `fn(req)` and the request is parsed if it returns a truthy value.
+    </Param>
+    <Param name="verify" type="Function" default="undefined">
+      This option, if supplied, is called as `verify(req, res, buf, encoding)`, where `buf` is a
+      `Buffer` of the raw request body and `encoding` is the encoding of the request. The parsing
+      can be aborted by throwing an error.
+    </Param>
+    <Param name="depth" type="Number" default="32" since="v4.20.0">
+      Configure the maximum depth of the `qs` library when `extended` is `true`. This allows you to
+      limit the amount of keys that are parsed and can be useful to prevent certain types of abuse.
+      Defaults to `32`. It is recommended to keep this value as low as possible.
+    </Param>
   </Fragment>
 </Signature>
 

--- a/src/content/api/4x/api/express/index.mdx
+++ b/src/content/api/4x/api/express/index.mdx
@@ -4,6 +4,8 @@ description: Learn about the methods available on the top-level Express object.
 ---
 
 import Alert from '@components/primitives/Alert/Alert.astro';
+import Signature from '@components/patterns/Signature/Signature.astro';
+import Param from '@components/patterns/Signature/Param.astro';
 
 Creates an Express application. The `express()` function is a top-level function exported by the `express` module.
 
@@ -14,9 +16,43 @@ var app = express();
 
 ## Methods
 
-### express.json([options])
+### express.json()
 
-<Alert type="info">This middleware is available in Express v4.16.0 onwards.</Alert>
+<Signature returns="Function" since="v4.16.0">
+  <Fragment slot="attributes">
+    <Param name="inflate" type="Boolean" default="true">
+      Enables or disables handling deflated (compressed) bodies; when disabled, deflated bodies are
+      rejected.
+    </Param>
+    <Param name="limit" type="Number | String" default='"100kb"'>
+      Controls the maximum request body size. If this is a number, then the value specifies the
+      number of bytes; if it is a string, the value is passed to the
+      [bytes](https://www.npmjs.com/package/bytes) library for parsing.
+    </Param>
+    <Param name="reviver" type="Function" default="null">
+      The `reviver` option is passed directly to `JSON.parse` as the second argument. You can find
+      more information on this argument [in the MDN documentation about
+      JSON.parse](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse#the_reviver_parameter).
+    </Param>
+    <Param name="strict" type="Boolean" default="true">
+      Enables or disables only accepting arrays and objects; when disabled will accept anything
+      `JSON.parse` accepts.
+    </Param>
+    <Param name="type" type="String | String[] | Function" default='"application/json"'>
+      This is used to determine what media type the middleware will parse. This option can be a
+      string, array of strings, or a function. If not a function, `type` option is passed directly
+      to the [type-is](https://www.npmjs.com/package/type-is#readme) library and this can be an
+      extension name (like `json`), a mime type (like `application/json`), or a mime type with a
+      wildcard (like `*/*` or `*/json`). If a function, the `type` option is called as `fn(req)` and
+      the request is parsed if it returns a truthy value.
+    </Param>
+    <Param name="verify" type="Function" default="undefined">
+      This option, if supplied, is called as `verify(req, res, buf, encoding)`, where `buf` is a
+      `Buffer` of the raw request body and `encoding` is the encoding of the request. The parsing
+      can be aborted by throwing an error.
+    </Param>
+  </Fragment>
+</Signature>
 
 This is a built-in middleware function in Express. It parses incoming requests
 with JSON payloads and is based on
@@ -41,24 +77,16 @@ may not be a function and instead a string or other user-input.
 
 </Alert>
 
-<div class="table-scroller" markdown="1">
+### express.raw()
 
-The following table describes the properties of the optional `options` object.
-
-| Property  | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | Type     | Default              |
-| --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------- | -------------------- |
-| `inflate` | Enables or disables handling deflated (compressed) bodies; when disabled, deflated bodies are rejected.                                                                                                                                                                                                                                                                                                                                                                                                                        | Boolean  | `true`               |
-| `limit`   | Controls the maximum request body size. If this is a number, then the value specifies the number of bytes; if it is a string, the value is passed to the [bytes](https://www.npmjs.com/package/bytes) library for parsing.                                                                                                                                                                                                                                                                                                     | Mixed    | `"100kb"`            |
-| `reviver` | The `reviver` option is passed directly to `JSON.parse` as the second argument. You can find more information on this argument [in the MDN documentation about JSON.parse](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse#the_reviver_parameter).                                                                                                                                                                                                                                 | Function | `null`               |
-| `strict`  | Enables or disables only accepting arrays and objects; when disabled will accept anything `JSON.parse` accepts.                                                                                                                                                                                                                                                                                                                                                                                                                | Boolean  | `true`               |
-| `type`    | This is used to determine what media type the middleware will parse. This option can be a string, array of strings, or a function. If not a function, `type` option is passed directly to the [type-is](https://www.npmjs.com/package/type-is#readme) library and this can be an extension name (like `json`), a mime type (like `application/json`), or a mime type with a wildcard (like `*/*` or `*/json`). If a function, the `type` option is called as `fn(req)` and the request is parsed if it returns a truthy value. | Mixed    | `"application/json"` |
-| `verify`  | This option, if supplied, is called as `verify(req, res, buf, encoding)`, where `buf` is a `Buffer` of the raw request body and `encoding` is the encoding of the request. The parsing can be aborted by throwing an error.                                                                                                                                                                                                                                                                                                    | Function | `undefined`          |
-
-</div>
-
-### express.raw([options])
-
-<Alert type="info">This middleware is available in Express v4.17.0 onwards.</Alert>
+<Signature returns="Function" since="v4.17.0">
+  <Fragment slot="attributes">
+    <Param name="inflate" type="Boolean" default="true">Enables or disables handling deflated (compressed) bodies; when disabled, deflated bodies are rejected.</Param>
+    <Param name="limit" type="Number | String" default='"100kb"'>Controls the maximum request body size. If this is a number, then the value specifies the number of bytes; if it is a string, the value is passed to the [bytes](https://www.npmjs.com/package/bytes) library for parsing.</Param>
+    <Param name="type" type="String | String[] | Function" default='"application/octet-stream"'>This is used to determine what media type the middleware will parse. This option can be a string, array of strings, or a function. If not a function, `type` option is passed directly to the [type-is](https://www.npmjs.com/package/type-is#readme) library and this can be an extension name (like `bin`), a mime type (like `application/octet-stream`), or a mime type with a wildcard (like `*/*` or `application/*`). If a function, the `type` option is called as `fn(req)` and the request is parsed if it returns a truthy value.</Param>
+    <Param name="verify" type="Function" default="undefined">This option, if supplied, is called as `verify(req, res, buf, encoding)`, where `buf` is a `Buffer` of the raw request body and `encoding` is the encoding of the request. The parsing can be aborted by throwing an error.</Param>
+  </Fragment>
+</Signature>
 
 This is a built-in middleware function in Express. It parses incoming request
 payloads into a `Buffer` and is based on
@@ -83,20 +111,15 @@ Testing that `req.body` is a `Buffer` before calling buffer methods is recommend
 
 </Alert>
 
-The following table describes the properties of the optional `options` object.
+### express.Router()
 
-<div class="table-scroller" markdown="1">
-
-| Property  | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | Type     | Default                      |
-| --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ---------------------------- |
-| `inflate` | Enables or disables handling deflated (compressed) bodies; when disabled, deflated bodies are rejected.                                                                                                                                                                                                                                                                                                                                                                                                                                      | Boolean  | `true`                       |
-| `limit`   | Controls the maximum request body size. If this is a number, then the value specifies the number of bytes; if it is a string, the value is passed to the [bytes](https://www.npmjs.com/package/bytes) library for parsing.                                                                                                                                                                                                                                                                                                                   | Mixed    | `"100kb"`                    |
-| `type`    | This is used to determine what media type the middleware will parse. This option can be a string, array of strings, or a function. If not a function, `type` option is passed directly to the [type-is](https://www.npmjs.com/package/type-is#readme) library and this can be an extension name (like `bin`), a mime type (like `application/octet-stream`), or a mime type with a wildcard (like `*/*` or `application/*`). If a function, the `type` option is called as `fn(req)` and the request is parsed if it returns a truthy value. | Mixed    | `"application/octet-stream"` |
-| `verify`  | This option, if supplied, is called as `verify(req, res, buf, encoding)`, where `buf` is a `Buffer` of the raw request body and `encoding` is the encoding of the request. The parsing can be aborted by throwing an error.                                                                                                                                                                                                                                                                                                                  | Function | `undefined`                  |
-
-</div>
-
-### express.Router([options])
+<Signature returns="Router">
+  <Fragment slot="attributes">
+    <Param name="caseSensitive" type="Boolean" default="false">Enable case sensitivity. Disabled by default, treating `/Foo` and `/foo` as the same.</Param>
+    <Param name="mergeParams" type="Boolean" default="false" since="v4.5.0+">Preserve the `req.params` values from the parent router. If the parent and the child have conflicting param names, the child's value take precedence.</Param>
+    <Param name="strict" type="Boolean" default="false">Enable strict routing. Disabled by default, `/foo` and `/foo/` are treated the same by the router.</Param>
+  </Fragment>
+</Signature>
 
 Creates a new [router](/api/router/) object.
 
@@ -104,24 +127,73 @@ Creates a new [router](/api/router/) object.
 var router = express.Router([options]);
 ```
 
-The optional `options` parameter specifies the behavior of the router.
-
-<div class="table-scroller" markdown="1">
-
-| Property        | Description                                                                                                                                           | Default                                                                     | Availability |
-| --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- | ------------ |
-| `caseSensitive` | Enable case sensitivity.                                                                                                                              | Disabled by default, treating "/Foo" and "/foo" as the same.                |              |
-| `mergeParams`   | Preserve the `req.params` values from the parent router. If the parent and the child have conflicting param names, the child's value take precedence. | `false`                                                                     | 4.5.0+       |
-| `strict`        | Enable strict routing.                                                                                                                                | Disabled by default, "/foo" and "/foo/" are treated the same by the router. | &nbsp;       |
-
-</div>
-
 You can add middleware and HTTP method routes (such as `get`, `put`, `post`, and
 so on) to `router` just like an application.
 
 For more information, see [Router](/api/router/).
 
-### express.static(root, [options])
+### express.static()
+
+<Signature returns="Function">
+  <Fragment slot="attributes">
+    <Param name="root" type="String">
+      The root directory from which to serve static assets.
+    </Param>
+    <Param name="options" type="Object" optional>
+      Configures how files are served; its properties are described below.
+    </Param>
+  </Fragment>
+</Signature>
+
+The `options` object accepts the following properties. See also the [example below](#example-of-expressstatic).
+
+<Signature attributesTitle="Options">
+  <Fragment slot="attributes">
+    <Param name="dotfiles" type="String" default="undefined">
+      Determines how dotfiles (files or directories that begin with a dot ".") are treated. See [dotfiles](#dotfiles) below.
+    </Param>
+    <Param name="etag" type="Boolean" default="true">
+      Enable or disable etag generation. NOTE: `express.static` always sends weak ETags.
+    </Param>
+    <Param name="extensions" type="String[] | Boolean" default="false">
+      Sets file extension fallbacks: If a file is not found, search for files with the specified
+      extensions and serve the first one found. Example: `['html', 'htm']`.
+    </Param>
+    <Param name="fallthrough" type="Boolean" default="true">
+      Let client errors fall-through as unhandled requests, otherwise forward a client error. See [fallthrough](#fallthrough) below.
+    </Param>
+    <Param name="immutable" type="Boolean" default="false">
+      Enable or disable the `immutable` directive in the `Cache-Control` response header. If
+      enabled, the `maxAge` option should also be specified to enable caching. The `immutable`
+      directive will prevent supported clients from making conditional requests during the life of
+      the `maxAge` option to check if the file has changed.
+    </Param>
+    <Param name="index" type="String | Boolean" default='"index.html"'>
+      Sends the specified directory index file. Set to `false` to disable directory indexing.
+    </Param>
+    <Param name="lastModified" type="Boolean" default="true">
+      Set the `Last-Modified` header to the last modified date of the file on the OS.
+    </Param>
+    <Param name="maxAge" type="Number" default="0">
+      Set the max-age property of the Cache-Control header in milliseconds or a string in [ms
+      format](https://www.npmjs.com/package/ms).
+    </Param>
+    <Param name="redirect" type="Boolean" default="true">
+      Redirect to trailing "/" when the pathname is a directory.
+    </Param>
+    <Param name="setHeaders" type="Function">
+      Function for setting HTTP headers to serve with the file. See [setHeaders](#setheaders) below.
+    </Param>
+    <Param name="acceptRanges" type="Boolean" default="true">
+      Enable or disable accepting ranged requests. Disabling this will not send the `Accept-Ranges`
+      header and will ignore the contents of the Range request header.
+    </Param>
+    <Param name="cacheControl" type="Boolean" default="true">
+      Enable or disable setting the `Cache-Control` response header. Disabling this will ignore the
+      immutable and maxAge options.
+    </Param>
+  </Fragment>
+</Signature>
 
 This is a built-in middleware function in Express.
 It serves static files and is based on [serve-static](/resources/middleware/serve-static).
@@ -138,28 +210,6 @@ The `root` argument specifies the root directory from which to serve static asse
 The function determines the file to serve by combining `req.url` with the provided `root` directory.
 When a file is not found, instead of sending a 404 response, it calls `next()`
 to move on to the next middleware, allowing for stacking and fall-backs.
-
-The following table describes the properties of the `options` object.
-See also the [example below](#example-of-expressstatic).
-
-<div class="table-scroller" markdown="1">
-
-| Property       | Description                                                                                                                                                                                                                                                                                                                        | Type     | Default      |
-| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------------ |
-| `dotfiles`     | Determines how dotfiles (files or directories that begin with a dot ".") are treated. <br/><br/>See [dotfiles](#dotfiles) below.                                                                                                                                                                                                   | String   | `undefined`  |
-| `etag`         | Enable or disable etag generation <br/><br/>NOTE: `express.static` always sends weak ETags.                                                                                                                                                                                                                                        | Boolean  | `true`       |
-| `extensions`   | Sets file extension fallbacks: If a file is not found, search for files with the specified extensions and serve the first one found. Example: `['html', 'htm']`.                                                                                                                                                                   | Mixed    | `false`      |
-| `fallthrough`  | Let client errors fall-through as unhandled requests, otherwise forward a client error. <br/><br/>See [fallthrough](#fallthrough) below.                                                                                                                                                                                           | Boolean  | `true`       |
-| `immutable`    | Enable or disable the `immutable` directive in the `Cache-Control` response header. If enabled, the `maxAge` option should also be specified to enable caching. The `immutable` directive will prevent supported clients from making conditional requests during the life of the `maxAge` option to check if the file has changed. | Boolean  | `false`      |
-| `index`        | Sends the specified directory index file. Set to `false` to disable directory indexing.                                                                                                                                                                                                                                            | Mixed    | "index.html" |
-| `lastModified` | Set the `Last-Modified` header to the last modified date of the file on the OS.                                                                                                                                                                                                                                                    | Boolean  | `true`       |
-| `maxAge`       | Set the max-age property of the Cache-Control header in milliseconds or a string in [ms format](https://www.npmjs.com/package/ms).                                                                                                                                                                                                 | Number   | 0            |
-| `redirect`     | Redirect to trailing "/" when the pathname is a directory.                                                                                                                                                                                                                                                                         | Boolean  | `true`       |
-| `setHeaders`   | Function for setting HTTP headers to serve with the file. <br/><br/>See [setHeaders](#setheaders) below.                                                                                                                                                                                                                           | Function |              |
-| `acceptRanges` | Enable or disable accepting ranged requests. Disabling this will not send the `Accept-Ranges` header and will ignore the contents of the Range request header.                                                                                                                                                                     | Boolean  | true         |
-| `cacheControl` | Enable or disable setting the `Cache-Control` response header. Disabling this will ignore the immutable and maxAge options.                                                                                                                                                                                                        | Boolean  | true         |
-
-</div>
 
 For more information, see [Serving static files in Express](/starter/static-files).
 and [Using middleware - Built-in middleware](/guide/using-middleware/#built-in-middleware).
@@ -222,9 +272,17 @@ var options = {
 app.use(express.static('public', options));
 ```
 
-### express.text([options])
+### express.text()
 
-<Alert type="info">This middleware is available in Express v4.17.0 onwards.</Alert>
+<Signature returns="Function" since="v4.17.0">
+  <Fragment slot="attributes">
+    <Param name="defaultCharset" type="String" default='"utf-8"'>Specify the default character set for the text content if the charset is not specified in the `Content-Type` header of the request.</Param>
+    <Param name="inflate" type="Boolean" default="true">Enables or disables handling deflated (compressed) bodies; when disabled, deflated bodies are rejected.</Param>
+    <Param name="limit" type="Number | String" default='"100kb"'>Controls the maximum request body size. If this is a number, then the value specifies the number of bytes; if it is a string, the value is passed to the [bytes](https://www.npmjs.com/package/bytes) library for parsing.</Param>
+    <Param name="type" type="String | String[] | Function" default='"text/plain"'>This is used to determine what media type the middleware will parse. This option can be a string, array of strings, or a function. If not a function, `type` option is passed directly to the [type-is](https://www.npmjs.com/package/type-is#readme) library and this can be an extension name (like `txt`), a mime type (like `text/plain`), or a mime type with a wildcard (like `*/*` or `text/*`). If a function, the `type` option is called as `fn(req)` and the request is parsed if it returns a truthy value.</Param>
+    <Param name="verify" type="Function" default="undefined">This option, if supplied, is called as `verify(req, res, buf, encoding)`, where `buf` is a `Buffer` of the raw request body and `encoding` is the encoding of the request. The parsing can be aborted by throwing an error.</Param>
+  </Fragment>
+</Signature>
 
 This is a built-in middleware function in Express. It parses incoming request
 payloads into a string and is based on
@@ -249,23 +307,19 @@ Testing that `req.body` is a string before calling string methods is recommended
 
 </Alert>
 
-The following table describes the properties of the optional `options` object.
+### express.urlencoded()
 
-<div class="table-scroller" markdown="1">
-
-| Property         | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | Type     | Default        |
-| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | -------------- |
-| `defaultCharset` | Specify the default character set for the text content if the charset is not specified in the `Content-Type` header of the request.                                                                                                                                                                                                                                                                                                                                                                                     | String   | `"utf-8"`      |
-| `inflate`        | Enables or disables handling deflated (compressed) bodies; when disabled, deflated bodies are rejected.                                                                                                                                                                                                                                                                                                                                                                                                                 | Boolean  | `true`         |
-| `limit`          | Controls the maximum request body size. If this is a number, then the value specifies the number of bytes; if it is a string, the value is passed to the [bytes](https://www.npmjs.com/package/bytes) library for parsing.                                                                                                                                                                                                                                                                                              | Mixed    | `"100kb"`      |
-| `type`           | This is used to determine what media type the middleware will parse. This option can be a string, array of strings, or a function. If not a function, `type` option is passed directly to the [type-is](https://www.npmjs.com/package/type-is#readme) library and this can be an extension name (like `txt`), a mime type (like `text/plain`), or a mime type with a wildcard (like `*/*` or `text/*`). If a function, the `type` option is called as `fn(req)` and the request is parsed if it returns a truthy value. | Mixed    | `"text/plain"` |
-| `verify`         | This option, if supplied, is called as `verify(req, res, buf, encoding)`, where `buf` is a `Buffer` of the raw request body and `encoding` is the encoding of the request. The parsing can be aborted by throwing an error.                                                                                                                                                                                                                                                                                             | Function | `undefined`    |
-
-</div>
-
-### express.urlencoded([options])
-
-<Alert type="info">This middleware is available in Express v4.16.0 onwards.</Alert>
+<Signature returns="Function" since="v4.16.0">
+  <Fragment slot="attributes">
+    <Param name="extended" type="Boolean" default="true">This option allows to choose between parsing the URL-encoded data with the `querystring` library (when `false`) or the `qs` library (when `true`). The "extended" syntax allows for rich objects and arrays to be encoded into the URL-encoded format, allowing for a JSON-like experience with URL-encoded. For more information, please [see the qs library](https://www.npmjs.com/package/qs#readme).</Param>
+    <Param name="inflate" type="Boolean" default="true">Enables or disables handling deflated (compressed) bodies; when disabled, deflated bodies are rejected.</Param>
+    <Param name="limit" type="Number | String" default='"100kb"'>Controls the maximum request body size. If this is a number, then the value specifies the number of bytes; if it is a string, the value is passed to the [bytes](https://www.npmjs.com/package/bytes) library for parsing.</Param>
+    <Param name="parameterLimit" type="Number" default="1000">This option controls the maximum number of parameters that are allowed in the URL-encoded data. If a request contains more parameters than this value, an error will be raised.</Param>
+    <Param name="type" type="String | String[] | Function" default='"application/x-www-form-urlencoded"'>This is used to determine what media type the middleware will parse. This option can be a string, array of strings, or a function. If not a function, `type` option is passed directly to the [type-is](https://www.npmjs.com/package/type-is#readme) library and this can be an extension name (like `urlencoded`), a mime type (like `application/x-www-form-urlencoded`), or a mime type with a wildcard (like `*/x-www-form-urlencoded`). If a function, the `type` option is called as `fn(req)` and the request is parsed if it returns a truthy value.</Param>
+    <Param name="verify" type="Function" default="undefined">This option, if supplied, is called as `verify(req, res, buf, encoding)`, where `buf` is a `Buffer` of the raw request body and `encoding` is the encoding of the request. The parsing can be aborted by throwing an error.</Param>
+    <Param name="depth" type="Number" default="32" since="v4.20.0">Configure the maximum depth of the `qs` library when `extended` is `true`. This allows you to limit the amount of keys that are parsed and can be useful to prevent certain types of abuse. Defaults to `32`. It is recommended to keep this value as low as possible.</Param>
+  </Fragment>
+</Signature>
 
 This is a built-in middleware function in Express. It parses incoming requests
 with urlencoded payloads and is based on [body-parser](/resources/middleware/body-parser).
@@ -288,28 +342,5 @@ As `req.body`'s shape is based on user-controlled input, all properties and valu
 are untrusted and should be validated before trusting. For example, `req.body.foo.toString()` may
 fail in multiple ways, for example `foo` may not be there or may not be a string, and `toString`
 may not be a function and instead a string or other user-input.
-
-</Alert>
-
-The following table describes the properties of the optional `options` object.
-
-<div class="table-scroller" markdown="1">
-
-| Property         | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | Type     | Default                               |
-| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------------------------------------- |
-| `extended`       | This option allows to choose between parsing the URL-encoded data with the `querystring` library (when `false`) or the `qs` library (when `true`). The "extended" syntax allows for rich objects and arrays to be encoded into the URL-encoded format, allowing for a JSON-like experience with URL-encoded. For more information, please [see the qs library](https://www.npmjs.com/package/qs#readme).                                                                                                                                                      | Boolean  | `true`                                |
-| `inflate`        | Enables or disables handling deflated (compressed) bodies; when disabled, deflated bodies are rejected.                                                                                                                                                                                                                                                                                                                                                                                                                                                       | Boolean  | `true`                                |
-| `limit`          | Controls the maximum request body size. If this is a number, then the value specifies the number of bytes; if it is a string, the value is passed to the [bytes](https://www.npmjs.com/package/bytes) library for parsing.                                                                                                                                                                                                                                                                                                                                    | Mixed    | `"100kb"`                             |
-| `parameterLimit` | This option controls the maximum number of parameters that are allowed in the URL-encoded data. If a request contains more parameters than this value, an error will be raised.                                                                                                                                                                                                                                                                                                                                                                               | Number   | `1000`                                |
-| `type`           | This is used to determine what media type the middleware will parse. This option can be a string, array of strings, or a function. If not a function, `type` option is passed directly to the [type-is](https://www.npmjs.com/package/type-is#readme) library and this can be an extension name (like `urlencoded`), a mime type (like `application/x-www-form-urlencoded`), or a mime type with a wildcard (like `*/x-www-form-urlencoded`). If a function, the `type` option is called as `fn(req)` and the request is parsed if it returns a truthy value. | Mixed    | `"application/x-www-form-urlencoded"` |
-| `verify`         | This option, if supplied, is called as `verify(req, res, buf, encoding)`, where `buf` is a `Buffer` of the raw request body and `encoding` is the encoding of the request. The parsing can be aborted by throwing an error.                                                                                                                                                                                                                                                                                                                                   | Function | `undefined`                           |
-| `depth`          | Configure the maximum depth of the `qs` library when `extended` is `true`. This allows you to limit the amount of keys that are parsed and can be useful to prevent certain types of abuse. Defaults to `32`. It is recommended to keep this value as low as possible.                                                                                                                                                                                                                                                                                        | Number   | `32`                                  |
-
-</div>
-
-<Alert type="alert">
-
-The `depth` option was added in Express v4.20.0. If you are using an earlier version, this option
-will not be available.
 
 </Alert>

--- a/src/content/api/4x/api/request/index.mdx
+++ b/src/content/api/4x/api/request/index.mdx
@@ -4,6 +4,7 @@ description: The req object represents the HTTP request and has properties for t
 ---
 
 import Alert from '@components/primitives/Alert/Alert.astro';
+import Signature from '@components/patterns/Signature/Signature.astro';
 
 The `req` object represents the HTTP request and has properties for the
 request query string, parameters, body, HTTP headers, and so on. In this documentation and by convention,
@@ -43,6 +44,8 @@ or [pez](https://www.npmjs.com/package/pez).
 </Alert>
 
 ### req.app
+
+<Signature type="Application" />
 
 This property holds a reference to the instance of the Express application that is using the middleware.
 

--- a/src/content/api/4x/api/request/index.mdx
+++ b/src/content/api/4x/api/request/index.mdx
@@ -5,6 +5,7 @@ description: The req object represents the HTTP request and has properties for t
 
 import Alert from '@components/primitives/Alert/Alert.astro';
 import Signature from '@components/patterns/Signature/Signature.astro';
+import Param from '@components/patterns/Signature/Param.astro';
 
 The `req` object represents the HTTP request and has properties for the
 request query string, parameters, body, HTTP headers, and so on. In this documentation and by convention,
@@ -68,6 +69,8 @@ module.exports = function (req, res) {
 
 ### req.baseUrl
 
+<Signature type="String" />
+
 The URL path on which a router instance was mounted.
 
 The `req.baseUrl` property is similar to the [mountpath](/api/application/#appmountpath) property of the `app` object,
@@ -98,6 +101,8 @@ When a request is made to `/greet/jp`, `req.baseUrl` is "/greet". When a request
 made to `/hello/jp`, `req.baseUrl` is "/hello".
 
 ### req.body
+
+<Signature type="Object" />
 
 Contains key-value pairs of data submitted in the request body.
 By default, it is `undefined`, and is populated when you use body-parsing middleware such
@@ -130,6 +135,8 @@ app.post('/profile', function (req, res, next) {
 
 ### req.cookies
 
+<Signature type="Object" />
+
 When using [cookie-parser](https://www.npmjs.com/package/cookie-parser) middleware, this property is an object that
 contains cookies sent by the request. If the request contains no cookies, it defaults to `{}`.
 
@@ -145,6 +152,8 @@ For more information, issues, or concerns, see [cookie-parser](https://github.co
 
 ### req.fresh
 
+<Signature type="Boolean" />
+
 When the response is still "fresh" in the client's cache `true` is returned, otherwise `false` is returned to indicate that the client cache is now stale and the full response should be sent.
 
 When a client sends the `Cache-Control: no-cache` request header to indicate an end-to-end reload request, this module will return `false` to make handling these requests transparent.
@@ -158,6 +167,8 @@ console.dir(req.fresh);
 ```
 
 ### req.hostname
+
+<Signature type="String" />
 
 Contains the hostname derived from the `Host` HTTP header.
 
@@ -185,6 +196,8 @@ console.dir(req.hostname);
 
 ### req.ip
 
+<Signature type="String" />
+
 Contains the remote IP address of the request.
 
 When the [`trust proxy` setting](/api/application/#options-for-trust-proxy-setting) does not evaluate to `false`,
@@ -198,6 +211,8 @@ console.dir(req.ip);
 
 ### req.ips
 
+<Signature type="String[]" />
+
 When the [`trust proxy` setting](/api/application/#options-for-trust-proxy-setting) does not evaluate to `false`,
 this property contains an array of IP addresses
 specified in the `X-Forwarded-For` request header. Otherwise, it contains an
@@ -208,10 +223,14 @@ For example, if `X-Forwarded-For` is `client, proxy1, proxy2`, `req.ips` would b
 
 ### req.method
 
+<Signature type="String" />
+
 Contains a string corresponding to the HTTP method of the request:
 `GET`, `POST`, `PUT`, and so on.
 
 ### req.originalUrl
+
+<Signature type="String" />
 
 <Alert type="alert">
 
@@ -245,6 +264,8 @@ app.use('/admin', function (req, res, next) {
 
 ### req.params
 
+<Signature type="Object" />
+
 This property is an object containing properties mapped to the [named route "parameters"](/guide/routing/#route-parameters). For example, if you have the route `/user/:name`, then the "name" property is available as `req.params.name`. This object defaults to `{}`.
 
 ```js
@@ -275,6 +296,8 @@ Express automatically decodes the values in `req.params` (using `decodeURICompon
 
 ### req.path
 
+<Signature type="String" />
+
 Contains the path part of the request URL.
 
 ```js
@@ -292,6 +315,8 @@ When called from a middleware, the mount point is not included in `req.path`. Se
 
 ### req.protocol
 
+<Signature type="String" />
+
 Contains the request protocol string: either `http` or (for TLS requests) `https`.
 
 When the [`trust proxy` setting](/api/application/#options-for-trust-proxy-setting) does not evaluate to `false`,
@@ -304,6 +329,8 @@ console.dir(req.protocol);
 ```
 
 ### req.query
+
+<Signature type="Object" />
 
 This property is an object containing a property for each query string parameter in the route.
 When [query parser](/api/application/#application-settings) is set to disabled, it is an empty object `{}`, otherwise it is the result of the configured query parser.
@@ -332,12 +359,16 @@ Check out the [query parser application setting](/api/application/#application-s
 
 ### req.res
 
+<Signature type="Response" />
+
 This property holds a reference to the [response object](/api/response)
 that relates to this request object.
 
 ### req.route
 
-Contains the currently-matched route, a string. For example:
+<Signature type="Route" />
+
+Contains the currently-matched route (a `Route` object). For example:
 
 ```js
 app.get('/user/:id?', function userIdHandler(req, res) {
@@ -363,6 +394,8 @@ Example output from the previous snippet:
 
 ### req.secure
 
+<Signature type="Boolean" />
+
 A Boolean property that is true if a TLS connection is established. Equivalent to:
 
 ```js
@@ -371,6 +404,8 @@ console.dir(req.protocol === 'https');
 ```
 
 ### req.signedCookies
+
+<Signature type="Object" />
 
 When using [cookie-parser](https://www.npmjs.com/package/cookie-parser) middleware, this property
 contains signed cookies sent by the request, unsigned and ready for use. Signed cookies reside
@@ -390,6 +425,8 @@ For more information, issues, or concerns, see [cookie-parser](https://github.co
 
 ### req.stale
 
+<Signature type="Boolean" />
+
 Indicates whether the request is "stale," and is the opposite of `req.fresh`.
 For more information, see [req.fresh](#reqfresh).
 
@@ -399,6 +436,8 @@ console.dir(req.stale);
 ```
 
 ### req.subdomains
+
+<Signature type="String[]" />
 
 An array of subdomains in the domain name of the request.
 
@@ -414,6 +453,8 @@ using [app.set](/api/application/#appset).
 
 ### req.xhr
 
+<Signature type="Boolean" />
+
 A Boolean property that is `true` if the request's `X-Requested-With` header field is
 "XMLHttpRequest", indicating that the request was issued by a client library such as jQuery.
 
@@ -426,7 +467,16 @@ console.dir(req.xhr);
 
 The `req` object also contains a number of methods that can be used to perform various tasks related to the HTTP request, such as checking the content type, retrieving header values, and more.
 
-### req.accepts(types)
+### req.accepts()
+
+<Signature returns="String | false">
+  <Fragment slot="attributes">
+    <Param name="types" type="String | String[]">
+      The content type(s) to check: a MIME type (such as `application/json`), an extension name
+      (such as `json`), a comma-delimited list, or an array.
+    </Param>
+  </Fragment>
+</Signature>
 
 Checks if the specified content types are acceptable, based on the request's `Accept` HTTP header field.
 The method returns the best match, or if none of the specified content types is acceptable, returns
@@ -463,7 +513,15 @@ req.accepts(['html', 'json']);
 
 For more information, or if you have issues or concerns, see [accepts](https://github.com/expressjs/accepts).
 
-### req.acceptsCharsets(charset [, ...])
+### req.acceptsCharsets()
+
+<Signature returns="String | false">
+  <Fragment slot="attributes">
+    <Param name="charset" type="String | String[]">
+      One or more character sets to test against the request's `Accept-Charset` header.
+    </Param>
+  </Fragment>
+</Signature>
 
 Returns the first accepted charset of the specified character sets,
 based on the request's `Accept-Charset` HTTP header field.
@@ -471,7 +529,15 @@ If none of the specified charsets is accepted, returns `false`.
 
 For more information, or if you have issues or concerns, see [accepts](https://github.com/expressjs/accepts).
 
-### req.acceptsEncodings(encoding [, ...])
+### req.acceptsEncodings()
+
+<Signature returns="String | false">
+  <Fragment slot="attributes">
+    <Param name="encoding" type="String | String[]">
+      One or more encodings to test against the request's `Accept-Encoding` header.
+    </Param>
+  </Fragment>
+</Signature>
 
 Returns the first accepted encoding of the specified encodings,
 based on the request's `Accept-Encoding` HTTP header field.
@@ -479,7 +545,16 @@ If none of the specified encodings is accepted, returns `false`.
 
 For more information, or if you have issues or concerns, see [accepts](https://github.com/expressjs/accepts).
 
-### req.acceptsLanguages([lang, ...])
+### req.acceptsLanguages()
+
+<Signature returns="String | String[] | false">
+  <Fragment slot="attributes">
+    <Param name="lang" type="String | String[]" optional>
+      One or more languages to test against the request's `Accept-Language` header. If omitted, all
+      accepted languages are returned as an array.
+    </Param>
+  </Fragment>
+</Signature>
 
 Returns the first accepted language of the specified languages,
 based on the request's `Accept-Language` HTTP header field.
@@ -495,7 +570,16 @@ Express (4.x) source: [request.js line 179](https://github.com/expressjs/express
 
 Accepts (1.3) source: [index.js line 195](https://github.com/jshttp/accepts/blob/f69c19e459bd501e59fb0b1a40b7471bb578113a/index.js#L195)
 
-### req.get(field)
+### req.get()
+
+<Signature returns="String | undefined">
+  <Fragment slot="attributes">
+    <Param name="field" type="String">
+      The name of the HTTP request header to read (case-insensitive). `Referrer` and `Referer` are
+      interchangeable.
+    </Param>
+  </Fragment>
+</Signature>
 
 Returns the specified HTTP request header field (case-insensitive match).
 The `Referrer` and `Referer` fields are interchangeable.
@@ -513,7 +597,15 @@ req.get('Something');
 
 Aliased as `req.header(field)`.
 
-### req.is(type)
+### req.is()
+
+<Signature returns="String | false | null">
+  <Fragment slot="attributes">
+    <Param name="type" type="String | String[]">
+      The MIME type(s) or extension name(s) to match against the request's `Content-Type` header.
+    </Param>
+  </Fragment>
+</Signature>
 
 Returns the matching content type if the incoming request's "Content-Type" HTTP header field
 matches the MIME type specified by the `type` parameter. If the request has no body, returns `null`.
@@ -556,7 +648,19 @@ req.is('xml', 'yaml');
 
 For more information, or if you have issues or concerns, see [type-is](https://github.com/expressjs/type-is).
 
-### req.param(name [, defaultValue])
+### req.param()
+
+<Signature returns="any">
+  <Fragment slot="attributes">
+    <Param name="name" type="String">
+      The name of the parameter to look up, searched in `req.params`, then `req.body`, then
+      `req.query`.
+    </Param>
+    <Param name="defaultValue" type="any" optional>
+      A value to return when the parameter is not found in any of the request objects.
+    </Param>
+  </Fragment>
+</Signature>
 
 <Alert type="warning">
 
@@ -595,21 +699,28 @@ Body-parsing middleware must be loaded for `req.param()` to work predictably. Re
 
 </Alert>
 
-### req.range(size[, options])
+### req.range()
+
+<Signature returns="Array | Number">
+  <Fragment slot="attributes">
+    <Param name="size" type="Number">
+      The maximum size of the resource.
+    </Param>
+    <Param name="options" type="Object" optional>
+      Options for parsing the `Range` header.
+
+      <Fragment slot="properties">
+        <Param name="combine" type="Boolean" default="false">
+          Specify if overlapping and adjacent ranges should be combined. When `true`, ranges are
+          combined and returned as if they were specified that way in the header.
+        </Param>
+      </Fragment>
+    </Param>
+
+  </Fragment>
+</Signature>
 
 `Range` header parser.
-
-The `size` parameter is the maximum size of the resource.
-
-The `options` parameter is an object that can have the following properties.
-
-<div class="table-scroller" markdown="1">
-
-| Property  | Type    | Description                                                                                                                                                                           |
-| --------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `combine` | Boolean | Specify if overlapping & adjacent ranges should be combined, defaults to `false`. When `true`, ranges will be combined and returned as if they were specified that way in the header. |
-
-</div>
 
 An array of ranges will be returned or negative numbers indicating an error parsing.
 

--- a/src/content/api/4x/api/request/index.mdx
+++ b/src/content/api/4x/api/request/index.mdx
@@ -101,7 +101,7 @@ made to `/hello/jp`, `req.baseUrl` is "/hello".
 
 Contains key-value pairs of data submitted in the request body.
 By default, it is `undefined`, and is populated when you use body-parsing middleware such
-as [`express.json()`](/api/express/#expressjsonoptions) or [`express.urlencoded()`](/api/express/#expressurlencodedoptions).
+as [`express.json()`](/api/express/#expressjson) or [`express.urlencoded()`](/api/express/#expressurlencoded).
 
 <Alert type="warning">
 
@@ -222,7 +222,7 @@ module](https://nodejs.org/api/http.html#http_message_url).
 
 This property is much like `req.url`; however, it retains the original request URL,
 allowing you to rewrite `req.url` freely for internal routing purposes. For example,
-the "mounting" feature of [app.use()](/api/application/#appusepath-callback--callback) will rewrite `req.url` to strip the mount point.
+the "mounting" feature of [app.use()](/api/application/#appuse) will rewrite `req.url` to strip the mount point.
 
 ```js
 // GET /search?q=something
@@ -263,7 +263,7 @@ console.dir(req.params[0]);
 
 Named capturing groups in regular expressions behave like named route parameters. For example the group from `/^\/file\/(?<path>.*)$/` expression is available as `req.params.path`.
 
-If you need to make changes to a key in `req.params`, use the [app.param](/api/application/#appparamname-callback) handler. Changes are applicable only to [parameters](/guide/routing/#route-parameters) already defined in the route path.
+If you need to make changes to a key in `req.params`, use the [app.param](/api/application/#appparam) handler. Changes are applicable only to [parameters](/guide/routing/#route-parameters) already defined in the route path.
 
 Any changes made to the `req.params` object in a middleware or route handler will be reset.
 
@@ -286,7 +286,7 @@ console.dir(req.path);
 <Alert type="info">
 
 When called from a middleware, the mount point is not included in `req.path`. See
-[app.use()](/api/application/#appusepath-callback--callback) for more details.
+[app.use()](/api/application/#appuse) for more details.
 
 </Alert>
 
@@ -410,7 +410,7 @@ console.dir(req.subdomains);
 
 The application property `subdomain offset`, which defaults to 2, is used for determining the
 beginning of the subdomain segments. To change this behavior, change its value
-using [app.set](/api/application/#appsetname-value).
+using [app.set](/api/application/#appset).
 
 ### req.xhr
 

--- a/src/content/api/4x/api/response/index.mdx
+++ b/src/content/api/4x/api/response/index.mdx
@@ -4,6 +4,8 @@ description: The res object represents the HTTP response that an Express app sen
 ---
 
 import Alert from '@components/primitives/Alert/Alert.astro';
+import Signature from '@components/patterns/Signature/Signature.astro';
+import Param from '@components/patterns/Signature/Param.astro';
 
 The `res` object represents the HTTP response that an Express app sends when it gets an HTTP request.
 
@@ -34,11 +36,15 @@ and supports all [built-in fields and methods](https://nodejs.org/api/http.html#
 
 ### res.app
 
+<Signature type="Application" />
+
 This property holds a reference to the instance of the Express application that is using the middleware.
 
 `res.app` is identical to the [req.app](/api/request/#reqapp) property in the request object.
 
 ### res.headersSent
+
+<Signature type="Boolean" />
 
 Boolean property that indicates if the app sent HTTP headers for the response.
 
@@ -52,7 +58,9 @@ app.get('/', function (req, res) {
 
 ### res.locals
 
-Use this property to set variables accessible in templates rendered with [res.render](#resrenderview--locals--callback).
+<Signature type="Object" />
+
+Use this property to set variables accessible in templates rendered with [res.render](#resrender).
 The variables set on `res.locals` are available within a single request-response cycle, and will not
 be shared between requests.
 
@@ -82,12 +90,25 @@ app.use(function (req, res, next) {
 
 ### res.req
 
+<Signature type="Request" />
+
 This property holds a reference to the [request object](/api/request/)
 that relates to this response object.
 
 ## Methods
 
-### res.append(field [, value])
+### res.append()
+
+<Signature returns="Response">
+  <Fragment slot="attributes">
+    <Param name="field" type="String">
+      The name of the HTTP response header to append to.
+    </Param>
+    <Param name="value" type="String | String[]" optional>
+      The value(s) to append to the header.
+    </Param>
+  </Fragment>
+</Signature>
 
 <Alert type="info">`res.append()` is supported by Express v4.11.0+</Alert>
 Appends the specified `value` to the HTTP response header `field`. If the header is not already set,
@@ -105,7 +126,16 @@ res.append('Set-Cookie', 'foo=bar; Path=/; HttpOnly');
 res.append('Warning', '199 Miscellaneous warning');
 ```
 
-### res.attachment([filename])
+### res.attachment()
+
+<Signature returns="Response">
+  <Fragment slot="attributes">
+    <Param name="filename" type="String" optional>
+      The file name used to set the `Content-Disposition` "filename=" parameter and the
+      `Content-Type` (from its extension).
+    </Param>
+  </Fragment>
+</Signature>
 
 Sets the HTTP response `Content-Disposition` header field to "attachment". If a `filename` is given,
 then it sets the Content-Type based on the extension name via `res.type()`,
@@ -120,11 +150,23 @@ res.attachment('path/to/logo.png');
 // Content-Type: image/png
 ```
 
-### res.clearCookie(name [, options])
+### res.clearCookie()
+
+<Signature returns="Response">
+  <Fragment slot="attributes">
+    <Param name="name" type="String">
+      The name of the cookie to clear.
+    </Param>
+    <Param name="options" type="Object" optional>
+      Cookie options, which should match those given to [res.cookie()](#rescookie) (excluding
+      `expires` and `maxAge`).
+    </Param>
+  </Fragment>
+</Signature>
 
 Clears the cookie with the specified `name` by sending a `Set-Cookie` header that sets its expiration date in the past.
 This instructs the client that the cookie has expired and is no longer valid. For more information
-about available `options`, see [res.cookie()](#rescookiename-value--options).
+about available `options`, see [res.cookie()](#rescookie).
 
 <Alert type="warning">
 
@@ -138,7 +180,7 @@ Express v4.20.0.
 <Alert type="alert">
 
 Web browsers and other compliant clients will only clear the cookie if the given `options` is
-identical to those given to [res.cookie()](#rescookiename-value--options), excluding `expires` and `maxAge`.
+identical to those given to [res.cookie()](#rescookie), excluding `expires` and `maxAge`.
 
 </Alert>
 
@@ -147,29 +189,60 @@ res.cookie('name', 'tobi', { path: '/admin' });
 res.clearCookie('name', { path: '/admin' });
 ```
 
-### res.cookie(name, value [, options])
+### res.cookie()
+
+<Signature returns="Response">
+  <Fragment slot="attributes">
+    <Param name="name" type="String">
+      The name of the cookie.
+    </Param>
+    <Param name="value" type="String | Object">
+      The cookie value; an object is serialized as JSON.
+    </Param>
+    <Param name="options" type="Object" optional>
+      Options for the `Set-Cookie` header.
+
+      <Fragment slot="properties">
+        <Param name="domain" type="String">
+          Domain name for the cookie. Defaults to the domain name of the app.
+        </Param>
+        <Param name="encode" type="Function">
+          A synchronous function used for cookie value encoding. Defaults to `encodeURIComponent`.
+        </Param>
+        <Param name="expires" type="Date">
+          Expiry date of the cookie in GMT. If not specified or set to `0`, creates a session cookie.
+        </Param>
+        <Param name="httpOnly" type="Boolean">
+          Flags the cookie to be accessible only by the web server.
+        </Param>
+        <Param name="maxAge" type="Number">
+          Convenient option for setting the expiry time relative to the current time in milliseconds.
+        </Param>
+        <Param name="path" type="String" default='"/"'>
+          Path for the cookie. Defaults to "/".
+        </Param>
+        <Param name="partitioned" type="Boolean">
+          Indicates that the cookie should be stored using partitioned storage. See [CHIPS](https://developer.mozilla.org/en-US/docs/Web/Privacy/Guides/Third-party_cookies/Partitioned_cookies) for more details.
+        </Param>
+        <Param name="priority" type="String">
+          Value of the "Priority" **Set-Cookie** attribute.
+        </Param>
+        <Param name="secure" type="Boolean">
+          Marks the cookie to be used with HTTPS only.
+        </Param>
+        <Param name="signed" type="Boolean">
+          Indicates if the cookie should be signed.
+        </Param>
+        <Param name="sameSite" type="Boolean | String">
+          Value of the "SameSite" **Set-Cookie** attribute.
+        </Param>
+      </Fragment>
+    </Param>
+
+  </Fragment>
+</Signature>
 
 Sets cookie `name` to `value`. The `value` parameter may be a string or object converted to JSON.
-
-The `options` parameter is an object that can have the following properties.
-
-<div class="table-scroller" markdown="1">
-
-| Property      | Type              | Description                                                                                                                                                                                                                                             |
-| ------------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `domain`      | String            | Domain name for the cookie. Defaults to the domain name of the app.                                                                                                                                                                                     |
-| `encode`      | Function          | A synchronous function used for cookie value encoding. Defaults to `encodeURIComponent`.                                                                                                                                                                |
-| `expires`     | Date              | Expiry date of the cookie in GMT. If not specified or set to 0, creates a session cookie.                                                                                                                                                               |
-| `httpOnly`    | Boolean           | Flags the cookie to be accessible only by the web server.                                                                                                                                                                                               |
-| `maxAge`      | Number            | Convenient option for setting the expiry time relative to the current time in milliseconds.                                                                                                                                                             |
-| `path`        | String            | Path for the cookie. Defaults to "/".                                                                                                                                                                                                                   |
-| `partitioned` | Boolean           | Indicates that the cookie should be stored using partitioned storage. See [Cookies Having Independent Partitioned State (CHIPS)](https://developer.mozilla.org/en-US/docs/Web/Privacy/Guides/Third-party_cookies/Partitioned_cookies) for more details. |
-| `priority`    | String            | Value of the "Priority" **Set-Cookie** attribute.                                                                                                                                                                                                       |
-| `secure`      | Boolean           | Marks the cookie to be used with HTTPS only.                                                                                                                                                                                                            |
-| `signed`      | Boolean           | Indicates if the cookie should be signed.                                                                                                                                                                                                               |
-| `sameSite`    | Boolean or String | Value of the "SameSite" **Set-Cookie** attribute. More information at [https://tools.ietf.org/html/draft-ietf-httpbis-cookie-same-site-00#section-4.1.1](https://tools.ietf.org/html/draft-ietf-httpbis-cookie-same-site-00#section-4.1.1).             |
-
-</div>
 
 <Alert type="alert">
 
@@ -240,7 +313,52 @@ res.cookie('name', 'tobi', { signed: true });
 
 Later you may access this value through the [req.signedCookie](/api/request/#reqsignedcookies) object.
 
-### res.download(path [, filename] [, options] [, fn])
+### res.download()
+
+<Signature>
+  <Fragment slot="attributes">
+    <Param name="path" type="String">
+      The path to the file to transfer. If relative, it is resolved against the current working directory or the `root` option.
+    </Param>
+    <Param name="filename" type="String" optional>
+      The file name for the `Content-Disposition` "filename=" parameter; overrides the name derived from `path`.
+    </Param>
+    <Param name="options" type="Object" optional>
+      Options forwarded to [res.sendFile()](#ressendfile).
+
+      <Fragment slot="properties">
+        <Param name="maxAge" type="Number | String" default="0">
+          Sets the max-age property of the `Cache-Control` header in milliseconds, or a string in [ms format](https://www.npmjs.com/package/ms).
+        </Param>
+        <Param name="root" type="String">
+          Root directory for relative file names.
+        </Param>
+        <Param name="lastModified" type="Boolean" default="true">
+          Sets the `Last-Modified` header to the last modified date of the file on the OS. Set `false` to disable it.
+        </Param>
+        <Param name="headers" type="Object">
+          Object containing HTTP headers to serve with the file.
+        </Param>
+        <Param name="dotfiles" type="String" default='"ignore"'>
+          Option for serving dotfiles. Possible values are `"allow"`, `"deny"`, and `"ignore"`.
+        </Param>
+        <Param name="acceptRanges" type="Boolean" default="true">
+          Enable or disable accepting ranged requests.
+        </Param>
+        <Param name="cacheControl" type="Boolean" default="true">
+          Enable or disable setting the `Cache-Control` response header.
+        </Param>
+        <Param name="immutable" type="Boolean" default="false">
+          Enable or disable the `immutable` directive in the `Cache-Control` response header. If enabled, the `maxAge` option should also be specified to enable caching.
+        </Param>
+      </Fragment>
+    </Param>
+    <Param name="fn" type="Function" optional>
+      Callback `fn(err)` invoked when the transfer completes or an error occurs.
+    </Param>
+
+  </Fragment>
+</Signature>
 
 Transfers the file at `path` as an "attachment". Typically, browsers will prompt the user for download.
 By default, the `Content-Disposition` header "filename=" parameter is derived from the `path` argument, but can be overridden with the `filename` parameter.
@@ -257,24 +375,7 @@ When the `root` option is provided, Express will validate that the relative path
 
 </Alert>
 
-The following table provides details on the `options` parameter.
-
 <Alert type="info">The optional `options` argument is supported by Express v4.16.0 onwards.</Alert>
-
-<div class="table-scroller" markdown="1">
-
-| Property       | Description                                                                                                                                                                                                                                                                                                                        | Default  | Availability |
-| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------------ |
-| `maxAge`       | Sets the max-age property of the `Cache-Control` header in milliseconds or a string in [ms format](https://www.npmjs.com/package/ms)                                                                                                                                                                                               | 0        | 4.16+        |
-| `root`         | Root directory for relative filenames.                                                                                                                                                                                                                                                                                             |          | 4.18+        |
-| `lastModified` | Sets the `Last-Modified` header to the last modified date of the file on the OS. Set `false` to disable it.                                                                                                                                                                                                                        | Enabled  | 4.16+        |
-| `headers`      | Object containing HTTP headers to serve with the file. The header `Content-Disposition` will be overridden by the `filename` argument.                                                                                                                                                                                             |          | 4.16+        |
-| `dotfiles`     | Option for serving dotfiles. Possible values are "allow", "deny", "ignore".                                                                                                                                                                                                                                                        | "ignore" | 4.16+        |
-| `acceptRanges` | Enable or disable accepting ranged requests.                                                                                                                                                                                                                                                                                       | `true`   | 4.16+        |
-| `cacheControl` | Enable or disable setting `Cache-Control` response header.                                                                                                                                                                                                                                                                         | `true`   | 4.16+        |
-| `immutable`    | Enable or disable the `immutable` directive in the `Cache-Control` response header. If enabled, the `maxAge` option should also be specified to enable caching. The `immutable` directive will prevent supported clients from making conditional requests during the life of the `maxAge` option to check if the file has changed. | `false`  | 4.16+        |
-
-</div>
 
 The method invokes the callback function `fn(err)` when the transfer is complete
 or when an error occurs. If the callback function is specified and an error occurs,
@@ -296,18 +397,41 @@ res.download('/report-12345.pdf', 'report.pdf', function (err) {
 });
 ```
 
-### res.end([data[, encoding]][, callback])
+### res.end()
+
+<Signature returns="Response">
+  <Fragment slot="attributes">
+    <Param name="data" type="String | Buffer" optional>
+      Data to write before ending the response.
+    </Param>
+    <Param name="encoding" type="String" optional>
+      The encoding for `data` when it is a string.
+    </Param>
+    <Param name="callback" type="Function" optional>
+      Called once the response has finished.
+    </Param>
+  </Fragment>
+</Signature>
 
 Ends the response process. This method actually comes from Node core, specifically the [response.end() method of http.ServerResponse](https://nodejs.org/api/http.html#responseenddata-encoding-callback).
 
-Use to quickly end the response without any data. If you need to respond with data, instead use methods such as [res.send()](#ressendbody) and [res.json()](#resjsonbody).
+Use to quickly end the response without any data. If you need to respond with data, instead use methods such as [res.send()](#ressend) and [res.json()](#resjson).
 
 ```js
 res.end();
 res.status(404).end();
 ```
 
-### res.format(object)
+### res.format()
+
+<Signature returns="Response">
+  <Fragment slot="attributes">
+    <Param name="object" type="Object">
+      An object whose keys are MIME types (or extension names) mapped to handler functions,
+      optionally with a `default` handler.
+    </Param>
+  </Fragment>
+</Signature>
 
 Performs content-negotiation on the `Accept` HTTP header on the request object, when present.
 It uses [req.accepts()](/api/request/#reqaccepts) to select a handler for the request, based on the acceptable
@@ -360,7 +484,15 @@ res.format({
 });
 ```
 
-### res.get(field)
+### res.get()
+
+<Signature returns="String">
+  <Fragment slot="attributes">
+    <Param name="field" type="String">
+      The name of the response header to read (case-insensitive).
+    </Param>
+  </Fragment>
+</Signature>
 
 Returns the HTTP response header specified by `field`.
 The match is case-insensitive.
@@ -370,7 +502,16 @@ res.get('Content-Type');
 // => "text/plain"
 ```
 
-### res.json([body])
+### res.json()
+
+<Signature returns="Response">
+  <Fragment slot="attributes">
+    <Param name="body" type="any" optional>
+      The value to send as JSON. Can be any JSON type: object, array, string, Boolean, number, or
+      null.
+    </Param>
+  </Fragment>
+</Signature>
 
 Sends a JSON response. This method sends a response (with the correct content-type) that is the parameter converted to a
 JSON string using [JSON.stringify()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify).
@@ -384,7 +525,15 @@ res.json({ user: 'tobi' });
 res.status(500).json({ error: 'message' });
 ```
 
-### res.jsonp([body])
+### res.jsonp()
+
+<Signature returns="Response">
+  <Fragment slot="attributes">
+    <Param name="body" type="any" optional>
+      The value to send as a JSONP response. Can be any JSON type.
+    </Param>
+  </Fragment>
+</Signature>
 
 Sends a JSON response with JSONP support. This method is identical to `res.json()`,
 except that it opts-in to JSONP callback support.
@@ -418,7 +567,15 @@ res.status(500).jsonp({ error: 'message' });
 // => foo({ "error": "message" })
 ```
 
-### res.links(links)
+### res.links()
+
+<Signature returns="Response">
+  <Fragment slot="attributes">
+    <Param name="links" type="Record<String, String>">
+      An object whose properties (such as `next` and `last`) populate the `Link` response header.
+    </Param>
+  </Fragment>
+</Signature>
 
 Joins the `links` provided as properties of the parameter to populate the response's
 `Link` HTTP header field.
@@ -439,7 +596,15 @@ Link: <http://api.example.com/users?page=2>; rel="next",
       <http://api.example.com/users?page=5>; rel="last"
 ```
 
-### res.location(path)
+### res.location()
+
+<Signature returns="Response">
+  <Fragment slot="attributes">
+    <Param name="path" type="String">
+      The URL to set in the `Location` header.
+    </Param>
+  </Fragment>
+</Signature>
 
 Sets the response `Location` HTTP header to the specified `path` parameter.
 
@@ -469,7 +634,18 @@ or the referring URL, and the URL specified in the `Location` header; and redire
 
 </Alert>
 
-### res.redirect([status,] path)
+### res.redirect()
+
+<Signature>
+  <Fragment slot="attributes">
+    <Param name="status" type="Number" optional>
+      The HTTP status code to use. Defaults to `302` (Found).
+    </Param>
+    <Param name="path" type="String">
+      The URL to redirect to.
+    </Param>
+  </Fragment>
+</Signature>
 
 Redirects to the URL derived from the specified `path`, with specified `status`, a positive integer
 that corresponds to an [HTTP status code](https://www.rfc-editor.org/rfc/rfc9110#name-status-codes) .
@@ -534,7 +710,21 @@ res.redirect('back');
 See also [Security best practices: Prevent open redirect
 vulnerabilities](/advanced/best-practice-security/#prevent-open-redirects).
 
-### res.render(view [, locals] [, callback])
+### res.render()
+
+<Signature>
+  <Fragment slot="attributes">
+    <Param name="view" type="String">
+      The file path of the view to render (absolute or relative to the `views` setting).
+    </Param>
+    <Param name="locals" type="Object" optional>
+      An object whose properties define local variables for the view.
+    </Param>
+    <Param name="callback" type="Function" optional>
+      Called as `callback(err, html)`. When provided, the rendered HTML is not sent automatically.
+    </Param>
+  </Fragment>
+</Signature>
 
 Renders a `view` and sends the rendered HTML string to the client.
 Optional parameters:
@@ -584,7 +774,15 @@ res.render('user', { name: 'Tobi' }, function (err, html) {
 });
 ```
 
-### res.send([body])
+### res.send()
+
+<Signature returns="Response">
+  <Fragment slot="attributes">
+    <Param name="body" type="String | Buffer | Object | Array | Boolean" optional>
+      The response body. Strings are sent as HTML; objects and arrays as JSON; Buffers as binary.
+    </Param>
+  </Fragment>
+</Signature>
 
 Sends the HTTP response.
 
@@ -624,7 +822,49 @@ res.send({ user: 'tobi' });
 res.send([1, 2, 3]);
 ```
 
-### res.sendFile(path [, options] [, fn])
+### res.sendFile()
+
+<Signature>
+  <Fragment slot="attributes">
+    <Param name="path" type="String">
+      The path to the file to transfer. Must be absolute unless the `root` option is set.
+    </Param>
+    <Param name="options" type="Object" optional>
+      Options for serving the file.
+
+      <Fragment slot="properties">
+        <Param name="maxAge" type="Number | String" default="0">
+          Sets the max-age property of the `Cache-Control` header in milliseconds, or a string in [ms format](https://www.npmjs.com/package/ms).
+        </Param>
+        <Param name="root" type="String">
+          Root directory for relative file names.
+        </Param>
+        <Param name="lastModified" type="Boolean" default="true">
+          Sets the `Last-Modified` header to the last modified date of the file on the OS. Set `false` to disable it.
+        </Param>
+        <Param name="headers" type="Object">
+          Object containing HTTP headers to serve with the file.
+        </Param>
+        <Param name="dotfiles" type="String" default='"ignore"'>
+          Option for serving dotfiles. Possible values are `"allow"`, `"deny"`, and `"ignore"`.
+        </Param>
+        <Param name="acceptRanges" type="Boolean" default="true">
+          Enable or disable accepting ranged requests.
+        </Param>
+        <Param name="cacheControl" type="Boolean" default="true">
+          Enable or disable setting the `Cache-Control` response header.
+        </Param>
+        <Param name="immutable" type="Boolean" default="false">
+          Enable or disable the `immutable` directive in the `Cache-Control` response header. If enabled, the `maxAge` option should also be specified to enable caching.
+        </Param>
+      </Fragment>
+    </Param>
+    <Param name="fn" type="Function" optional>
+      Callback `fn(err)` invoked when the transfer completes or an error occurs.
+    </Param>
+
+  </Fragment>
+</Signature>
 
 <Alert type="info">`res.sendFile()` is supported by Express v4.8.0 onwards.</Alert>
 
@@ -642,23 +882,6 @@ including containing `..`. Express will validate that the relative path provided
 resolve within the given `root` option.
 
 </Alert>
-
-The following table provides details on the `options` parameter.
-
-<div class="table-scroller" markdown="1">
-
-| Property       | Description                                                                                                                                                                                                                                                                                                                        | Default  | Availability |
-| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------------ |
-| `maxAge`       | Sets the max-age property of the `Cache-Control` header in milliseconds or a string in [ms format](https://www.npmjs.com/package/ms)                                                                                                                                                                                               | 0        |              |
-| `root`         | Root directory for relative filenames.                                                                                                                                                                                                                                                                                             |          |              |
-| `lastModified` | Sets the `Last-Modified` header to the last modified date of the file on the OS. Set `false` to disable it.                                                                                                                                                                                                                        | Enabled  | 4.9.0+       |
-| `headers`      | Object containing HTTP headers to serve with the file.                                                                                                                                                                                                                                                                             |          |              |
-| `dotfiles`     | Option for serving dotfiles. Possible values are "allow", "deny", "ignore".                                                                                                                                                                                                                                                        | "ignore" | &nbsp;       |
-| `acceptRanges` | Enable or disable accepting ranged requests.                                                                                                                                                                                                                                                                                       | `true`   | 4.14+        |
-| `cacheControl` | Enable or disable setting `Cache-Control` response header.                                                                                                                                                                                                                                                                         | `true`   | 4.14+        |
-| `immutable`    | Enable or disable the `immutable` directive in the `Cache-Control` response header. If enabled, the `maxAge` option should also be specified to enable caching. The `immutable` directive will prevent supported clients from making conditional requests during the life of the `maxAge` option to check if the file has changed. | `false`  | 4.16+        |
-
-</div>
 
 The method invokes the callback function `fn(err)` when the transfer is complete
 or when an error occurs. If the callback function is specified and an error occurs,
@@ -709,7 +932,15 @@ app.get('/user/:uid/photos/:file', function (req, res) {
 
 For more information, or if you have issues or concerns, see [send](https://github.com/pillarjs/send).
 
-### res.sendStatus(statusCode)
+### res.sendStatus()
+
+<Signature returns="Response">
+  <Fragment slot="attributes">
+    <Param name="statusCode" type="Number">
+      The HTTP status code to set; its registered status message becomes the response body.
+    </Param>
+  </Fragment>
+</Signature>
 
 Sets the response HTTP status code to `statusCode` and sends the registered status message as the text response body. If an unknown status code is specified, the response body will just be the code number.
 
@@ -727,7 +958,18 @@ version being used.
 
 [More about HTTP Status Codes](https://en.wikipedia.org/wiki/List_of_HTTP_status_codes)
 
-### res.set(field [, value])
+### res.set()
+
+<Signature returns="Response">
+  <Fragment slot="attributes">
+    <Param name="field" type="String | Object">
+      The header name, or an object of header name/value pairs to set multiple headers at once.
+    </Param>
+    <Param name="value" type="String | String[]" optional>
+      The header value (when `field` is a string).
+    </Param>
+  </Fragment>
+</Signature>
 
 Sets the response's HTTP header `field` to `value`.
 To set multiple fields at once, pass an object as the parameter.
@@ -744,7 +986,15 @@ res.set({
 
 Aliased as `res.header(field [, value])`.
 
-### res.status(code)
+### res.status()
+
+<Signature returns="Response">
+  <Fragment slot="attributes">
+    <Param name="code" type="Number">
+      The HTTP status code for the response.
+    </Param>
+  </Fragment>
+</Signature>
 
 Sets the HTTP status for the response.
 It is a chainable alias of Node's [response.statusCode](https://nodejs.org/api/http.html#http_response_statuscode).
@@ -755,7 +1005,16 @@ res.status(400).send('Bad Request');
 res.status(404).sendFile('/absolute/path/to/404.png');
 ```
 
-### res.type(type)
+### res.type()
+
+<Signature returns="Response">
+  <Fragment slot="attributes">
+    <Param name="type" type="String">
+      The MIME type, or a file extension that is looked up to a MIME type. If it contains `/`, it is
+      used as-is.
+    </Param>
+  </Fragment>
+</Signature>
 
 Sets the `Content-Type` HTTP header to the MIME type as determined by the specified `type`. If `type` contains the "/" character, then it sets the `Content-Type` to the exact value of `type`, otherwise it is assumed to be a file extension and the MIME type is looked up in a mapping using the `express.static.mime.lookup()` method.
 
@@ -774,7 +1033,15 @@ res.type('png');
 
 Aliased as `res.contentType(type)`.
 
-### res.vary(field)
+### res.vary()
+
+<Signature returns="Response">
+  <Fragment slot="attributes">
+    <Param name="field" type="String">
+      The header field name to add to the `Vary` response header.
+    </Param>
+  </Fragment>
+</Signature>
 
 Adds the field to the `Vary` response header, if it is not there already.
 

--- a/src/content/api/4x/api/response/index.mdx
+++ b/src/content/api/4x/api/response/index.mdx
@@ -310,7 +310,7 @@ res.status(404).end();
 ### res.format(object)
 
 Performs content-negotiation on the `Accept` HTTP header on the request object, when present.
-It uses [req.accepts()](/api/request/#reqacceptstypes) to select a handler for the request, based on the acceptable
+It uses [req.accepts()](/api/request/#reqaccepts) to select a handler for the request, based on the acceptable
 types ordered by their quality values. If the header is not specified, the first callback is invoked.
 When no match is found, the server responds with 406 "Not Acceptable", or invokes the `default` callback.
 

--- a/src/content/api/4x/api/router/index.mdx
+++ b/src/content/api/4x/api/router/index.mdx
@@ -10,9 +10,9 @@ as a "mini-application," capable only of performing middleware and routing
 functions. Every Express application has a built-in app router.
 
 A router behaves like middleware itself, so you can use it as an argument to
-[app.use()](/api/application#appusepath-callback--callback) or as the argument to another router's [use()](#routerusepath-function--function) method.
+[app.use()](/api/application#appuse) or as the argument to another router's [use()](#routerusepath-function--function) method.
 
-The top-level `express` object has a [Router()](/api/express#expressrouteroptions) method that creates a new `router` object.
+The top-level `express` object has a [Router()](/api/express#expressrouter) method that creates a new `router` object.
 
 Once you've created a router object, you can add middleware and HTTP method routes (such as `get`, `put`, `post`,
 and so on) to it just like an application. For example:
@@ -306,8 +306,8 @@ belong to the route to which they were added.
 
 Uses the specified middleware function or functions, with optional mount path `path`, that defaults to "/".
 
-This method is similar to [app.use()](/api/application#appusepath-callback--callback). A simple example and use case is described below.
-See [app.use()](/api/application#appusepath-callback--callback) for more information.
+This method is similar to [app.use()](/api/application#appuse). A simple example and use case is described below.
+See [app.use()](/api/application#appuse) for more information.
 
 Middleware is like a plumbing pipe: requests start at the first middleware function defined
 and work their way "down" the middleware stack processing for each path they match.

--- a/src/content/api/4x/api/router/index.mdx
+++ b/src/content/api/4x/api/router/index.mdx
@@ -4,13 +4,15 @@ description: A router object is an isolated instance of middleware and routes in
 ---
 
 import Alert from '@components/primitives/Alert/Alert.astro';
+import Signature from '@components/patterns/Signature/Signature.astro';
+import Param from '@components/patterns/Signature/Param.astro';
 
 A `router` object is an instance of middleware and routes. You can think of it
 as a "mini-application," capable only of performing middleware and routing
 functions. Every Express application has a built-in app router.
 
 A router behaves like middleware itself, so you can use it as an argument to
-[app.use()](/api/application#appuse) or as the argument to another router's [use()](#routerusepath-function--function) method.
+[app.use()](/api/application#appuse) or as the argument to another router's [use()](#routeruse) method.
 
 The top-level `express` object has a [Router()](/api/express#expressrouter) method that creates a new `router` object.
 
@@ -40,9 +42,42 @@ app.use('/calendar', router);
 
 ## Methods
 
-### Router([options])
+### Router()
 
-### router.all(path, [callback, ...] callback)
+<Signature returns="Router">
+  <Fragment slot="attributes">
+    <Param name="options" type="Object" optional>
+      Options that configure the router's behavior.
+
+      <Fragment slot="properties">
+        <Param name="caseSensitive" type="Boolean" default="false">
+          Enable case sensitivity. Disabled by default, treating `/Foo` and `/foo` as the same.
+        </Param>
+        <Param name="mergeParams" type="Boolean" default="false">
+          Preserve the `req.params` values from the parent router. If the parent and the child have conflicting param names, the child's value takes precedence.
+        </Param>
+        <Param name="strict" type="Boolean" default="false">
+          Enable strict routing. Disabled by default, `/foo` and `/foo/` are treated the same by the router.
+        </Param>
+      </Fragment>
+    </Param>
+
+  </Fragment>
+</Signature>
+
+### router.all()
+
+<Signature returns="Router">
+  <Fragment slot="attributes">
+    <Param name="path" type="String | RegExp | Array">
+      The path for which the route callbacks are invoked.
+    </Param>
+    <Param name="callback" type="Function | Function[]">
+      One or more middleware/handler functions. Each may call `next('route')` to skip the remaining
+      callbacks.
+    </Param>
+  </Fragment>
+</Signature>
 
 This method is just like the `router.METHOD()` methods, except that it matches all HTTP methods (verbs).
 
@@ -74,7 +109,19 @@ the example is much like before, but it only restricts paths prefixed with
 router.all('/api/*', requireAuthentication);
 ```
 
-### router.METHOD(path, [callback, ...] callback)
+### router.METHOD()
+
+<Signature returns="Router">
+  <Fragment slot="attributes">
+    <Param name="path" type="String | RegExp | Array">
+      The path for which the route callbacks are invoked.
+    </Param>
+    <Param name="callback" type="Function | Function[]">
+      One or more middleware/handler functions. Each may call `next('route')` to skip the remaining
+      callbacks.
+    </Param>
+  </Fragment>
+</Signature>
 
 The `router.METHOD()` methods provide the routing functionality in Express,
 where METHOD is one of the HTTP methods, such as GET, PUT, POST, and so on,
@@ -118,7 +165,19 @@ router.get(/^\/commits\/(\w+)(?:\.\.(\w+))?$/, function (req, res) {
 });
 ```
 
-### router.param(name, callback)
+### router.param()
+
+<Signature returns="Router">
+  <Fragment slot="attributes">
+    <Param name="name" type="String">
+      The name of the route parameter to attach the trigger to. Unlike `app.param()`, this does not
+      accept an array.
+    </Param>
+    <Param name="callback" type="Function">
+      The trigger called as `callback(req, res, next, value, name)`.
+    </Param>
+  </Fragment>
+</Signature>
 
 Adds callback triggers to route parameters, where `name` is the name of the parameter and `callback` is the callback function. Although `name` is technically optional, using this method without it is deprecated starting with Express v4.11.0 (see below).
 
@@ -246,7 +305,15 @@ router.param('id', function (candidate) {
 });
 ```
 
-### router.route(path)
+### router.route()
+
+<Signature returns="Route">
+  <Fragment slot="attributes">
+    <Param name="path" type="String">
+      The path of the route to create.
+    </Param>
+  </Fragment>
+</Signature>
 
 Returns an instance of a single route which you can then use to handle HTTP verbs
 with optional middleware. Use `router.route()` to avoid duplicate route naming and
@@ -302,7 +369,18 @@ belong to the route to which they were added.
 
 </Alert>
 
-### router.use([path], [function, ...] function)
+### router.use()
+
+<Signature returns="Router">
+  <Fragment slot="attributes">
+    <Param name="path" type="String | RegExp | Array" optional>
+      The mount path for the middleware. Defaults to `/`.
+    </Param>
+    <Param name="callback" type="Function | Function[]">
+      One or more middleware functions to mount.
+    </Param>
+  </Fragment>
+</Signature>
 
 Uses the specified middleware function or functions, with optional mount path `path`, that defaults to "/".
 

--- a/src/content/api/5x/api/application/index.mdx
+++ b/src/content/api/5x/api/application/index.mdx
@@ -4,6 +4,8 @@ description: Learn about the properties of the Express application object.
 ---
 
 import Alert from '@components/primitives/Alert/Alert.astro';
+import Signature from '@components/patterns/Signature/Signature.astro';
+import Param from '@components/patterns/Signature/Param.astro';
 
 The `app` object conventionally denotes the Express application.
 Create it by calling the top-level `express()` function exported by the Express module:
@@ -21,10 +23,10 @@ app.listen(3000);
 
 The `app` object has methods for
 
-- Routing HTTP requests; see for example, [app.METHOD](#appmethodpath-callback--callback-) and [app.param](#appparamname-callback).
-- Configuring middleware; see [app.route](#approutepath).
-- Rendering HTML views; see [app.render](#apprenderview-locals-callback).
-- Registering a template engine; see [app.engine](#appengineext-callback).
+- Routing HTTP requests; see for example, [app.METHOD](#appmethod) and [app.param](#appparam).
+- Configuring middleware; see [app.route](#approute).
+- Rendering HTML views; see [app.render](#apprender).
+- Registering a template engine; see [app.engine](#appengine).
 
 It also has settings (properties) that affect how the application behaves;
 for more information, see [Application settings](#application-settings).
@@ -38,6 +40,8 @@ The Express application object can be referred from the [request object](/api/re
 ## Properties
 
 ### app.locals
+
+<Signature type="Object" />
 
 The `app.locals` object has properties that are local variables within the application,
 and will be available in templates rendered with [res.render](/api/response/#resrenderview--locals--callback).
@@ -74,6 +78,8 @@ app.locals.email = 'me@myapp.com';
 ```
 
 ### app.mountpath
+
+<Signature type="String | String[]" />
 
 The `app.mountpath` property contains one or more path patterns on which a sub-app was mounted.
 
@@ -123,6 +129,8 @@ app.use(['/adm{*splat}n', '/manager'], admin); // load the 'admin' router on '/a
 
 ### app.router
 
+<Signature type="Router" />
+
 The application's in-built instance of router. This is created lazily, on first access.
 
 ```js
@@ -143,7 +151,16 @@ For more information, see [Router](/api/router/).
 
 ## Events
 
-### app.on('mount', callback(parent))
+### app.on('mount')
+
+<Signature>
+  <Fragment slot="attributes">
+    <Param name="callback" type="Function">
+      The listener called when the `mount` event fires. It receives the parent app as its only
+      argument: `callback(parent)`.
+    </Param>
+  </Fragment>
+</Signature>
 
 The `mount` event is fired on a sub-app, when it is mounted on a parent app. The parent app is passed to the callback function.
 
@@ -176,17 +193,31 @@ app.use('/admin', admin);
 
 ## Methods
 
-### app.all(path, callback [, callback ...])
+### app.all()
 
-This method is like the standard [app.METHOD()](#appmethodpath-callback--callback-) methods,
+<Signature>
+  <Fragment slot="attributes">
+    <Param name="path" type="String | RegExp | Array">
+      The path for which the middleware function is invoked; can be any of: a string representing a
+      path, a path pattern, a regular expression pattern to match paths, or an array of combinations
+      of any of the above. For examples, see [Path examples](#path-examples).
+    </Param>
+    <Param name="callback" type="Function | Function[]">
+      Callback functions; can be: a middleware function, a series of middleware functions (separated
+      by commas), an array of middleware functions, or a combination of all of the above. You can
+      provide multiple callback functions that behave just like middleware, except that these
+      callbacks can invoke `next('route')` to bypass the remaining route callback(s). You can use
+      this mechanism to impose pre-conditions on a route, then pass control to subsequent routes if
+      there is no reason to proceed with the current route. Since [router](/api/router/) and
+      [app](#overview) implement the middleware interface, you can use them as you would any other
+      middleware function. For examples, see [Middleware callback function
+      examples](#middleware-callback-function-examples).
+    </Param>
+  </Fragment>
+</Signature>
+
+This method is like the standard [app.METHOD()](#appmethod) methods,
 except it matches all HTTP verbs.
-
-#### Arguments
-
-| Argument   | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | Default           |
-| ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
-| `path`     | The path for which the middleware function is invoked. It can be any of the following: a string representing a path, a path pattern, a regular expression pattern to match paths, or an array containing any combination of the above. For examples, see [Path examples](#path-examples).                                                                                                                                                                                                                                                                                                                                                                                                                                                          | `'/'` (root path) |
-| `callback` | One or more callback functions. Accepted formats: a single middleware function, multiple middleware functions separated by commas, an array of middleware functions, or a combination of the above. You may provide multiple callbacks that behave like middleware. These can call `next('route')` to skip remaining callbacks for the current route. This is useful for conditional routing logic. If a callback throws an error or returns a rejected promise, `next(err)` is invoked automatically. Since both [router](/api/router/) and [app](#overview) implement the middleware interface, they can also be used as callback middleware. For examples, see [Middleware callback function examples](#middleware-callback-function-examples). | _None_            |
 
 #### Examples
 
@@ -226,17 +257,31 @@ The example is similar to the ones above, but it only restricts paths that start
 app.all('/api/{*splat}', requireAuthentication);
 ```
 
-### app.delete(path, callback [, callback ...])
+### app.delete()
+
+<Signature>
+  <Fragment slot="attributes">
+    <Param name="path" type="String | RegExp | Array">
+      The path for which the middleware function is invoked; can be any of: a string representing a
+      path, a path pattern, a regular expression pattern to match paths, or an array of combinations
+      of any of the above. For examples, see [Path examples](#path-examples).
+    </Param>
+    <Param name="callback" type="Function | Function[]">
+      Callback functions; can be: a middleware function, a series of middleware functions (separated
+      by commas), an array of middleware functions, or a combination of all of the above. You can
+      provide multiple callback functions that behave just like middleware, except that these
+      callbacks can invoke `next('route')` to bypass the remaining route callback(s). You can use
+      this mechanism to impose pre-conditions on a route, then pass control to subsequent routes if
+      there is no reason to proceed with the current route. Since [router](/api/router/) and
+      [app](#overview) implement the middleware interface, you can use them as you would any other
+      middleware function. For examples, see [Middleware callback function
+      examples](#middleware-callback-function-examples).
+    </Param>
+  </Fragment>
+</Signature>
 
 Routes HTTP DELETE requests to the specified path with the specified callback functions.
 For more information, see the [routing guide](/guide/routing/).
-
-#### Arguments
-
-| Argument   | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | Default           |
-| ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
-| `path`     | The path for which the middleware function is invoked. It can be any of the following: a string representing a path, a path pattern, a regular expression pattern to match paths, or an array containing any combination of the above. For examples, see [Path examples](#path-examples).                                                                                                                                                                                                                                                                                                                                                                                                                                                          | `'/'` (root path) |
-| `callback` | One or more callback functions. Accepted formats: a single middleware function, multiple middleware functions separated by commas, an array of middleware functions, or a combination of the above. You may provide multiple callbacks that behave like middleware. These can call `next('route')` to skip remaining callbacks for the current route. This is useful for conditional routing logic. If a callback throws an error or returns a rejected promise, `next(err)` is invoked automatically. Since both [router](/api/router/) and [app](#overview) implement the middleware interface, they can also be used as callback middleware. For examples, see [Middleware callback function examples](#middleware-callback-function-examples). | _None_            |
 
 #### Example
 
@@ -246,7 +291,16 @@ app.delete('/', (req, res) => {
 });
 ```
 
-### app.disable(name)
+### app.disable()
+
+<Signature returns="Application">
+  <Fragment slot="attributes">
+    <Param name="name" type="String">
+      The name of the Boolean setting to disable; one of the properties from the [app settings
+      table](#application-settings).
+    </Param>
+  </Fragment>
+</Signature>
 
 Sets the Boolean setting `name` to `false`, where `name` is one of the properties from the [app settings table](#application-settings).
 Calling `app.set('foo', false)` for a Boolean property is the same as calling `app.disable('foo')`.
@@ -259,7 +313,16 @@ app.get('trust proxy');
 // => false
 ```
 
-### app.disabled(name)
+### app.disabled()
+
+<Signature returns="Boolean">
+  <Fragment slot="attributes">
+    <Param name="name" type="String">
+      The name of the Boolean setting to test; one of the properties from the [app settings
+      table](#application-settings).
+    </Param>
+  </Fragment>
+</Signature>
 
 Returns `true` if the Boolean setting `name` is disabled (`false`), where `name` is one of the properties from
 the [app settings table](#application-settings).
@@ -273,7 +336,16 @@ app.disabled('trust proxy');
 // => false
 ```
 
-### app.enable(name)
+### app.enable()
+
+<Signature returns="Application">
+  <Fragment slot="attributes">
+    <Param name="name" type="String">
+      The name of the Boolean setting to enable; one of the properties from the [app settings
+      table](#application-settings).
+    </Param>
+  </Fragment>
+</Signature>
 
 Sets the Boolean setting `name` to `true`, where `name` is one of the properties from the [app settings table](#application-settings).
 Calling `app.set('foo', true)` for a Boolean property is the same as calling `app.enable('foo')`.
@@ -284,7 +356,16 @@ app.get('trust proxy');
 // => true
 ```
 
-### app.enabled(name)
+### app.enabled()
+
+<Signature returns="Boolean">
+  <Fragment slot="attributes">
+    <Param name="name" type="String">
+      The name of the setting to test; one of the properties from the [app settings
+      table](#application-settings).
+    </Param>
+  </Fragment>
+</Signature>
 
 Returns `true` if the setting `name` is enabled (`true`), where `name` is one of the
 properties from the [app settings table](#application-settings).
@@ -298,7 +379,18 @@ app.enabled('trust proxy');
 // => true
 ```
 
-### app.engine(ext, callback)
+### app.engine()
+
+<Signature returns="Application">
+  <Fragment slot="attributes">
+    <Param name="ext" type="String">
+      The file extension the template engine is registered for (for example, `pug` or `html`).
+    </Param>
+    <Param name="callback" type="Function">
+      The template engine function used to render files with the given extension.
+    </Param>
+  </Fragment>
+</Signature>
 
 Registers the given template engine `callback` as `ext`.
 
@@ -337,6 +429,15 @@ app.engine('html', engines.hogan);
 
 ### app.get(name)
 
+<Signature returns="any">
+  <Fragment slot="attributes">
+    <Param name="name" type="String">
+      The name of the setting to read; one of the strings in the [app settings
+      table](#application-settings).
+    </Param>
+  </Fragment>
+</Signature>
+
 Returns the value of `name` app setting, where `name` is one of the strings in the
 [app settings table](#application-settings). For example:
 
@@ -349,16 +450,30 @@ app.get('title');
 // => "My Site"
 ```
 
-### app.get(path, callback [, callback ...])
+### app.get()
+
+<Signature>
+  <Fragment slot="attributes">
+    <Param name="path" type="String | RegExp | Array">
+      The path for which the middleware function is invoked; can be any of: a string representing a
+      path, a path pattern, a regular expression pattern to match paths, or an array of combinations
+      of any of the above. For examples, see [Path examples](#path-examples).
+    </Param>
+    <Param name="callback" type="Function | Function[]">
+      Callback functions; can be: a middleware function, a series of middleware functions (separated
+      by commas), an array of middleware functions, or a combination of all of the above. You can
+      provide multiple callback functions that behave just like middleware, except that these
+      callbacks can invoke `next('route')` to bypass the remaining route callback(s). You can use
+      this mechanism to impose pre-conditions on a route, then pass control to subsequent routes if
+      there is no reason to proceed with the current route. Since [router](/api/router/) and
+      [app](#overview) implement the middleware interface, you can use them as you would any other
+      middleware function. For examples, see [Middleware callback function
+      examples](#middleware-callback-function-examples).
+    </Param>
+  </Fragment>
+</Signature>
 
 Routes HTTP GET requests to the specified path with the specified callback functions.
-
-#### Arguments
-
-| Argument   | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | Default           |
-| ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
-| `path`     | The path for which the middleware function is invoked. It can be any of the following: a string representing a path, a path pattern, a regular expression pattern to match paths, or an array containing any combination of the above. For examples, see [Path examples](#path-examples).                                                                                                                                                                                                                                                                                                                                                                                                                                                          | `'/'` (root path) |
-| `callback` | One or more callback functions. Accepted formats: a single middleware function, multiple middleware functions separated by commas, an array of middleware functions, or a combination of the above. You may provide multiple callbacks that behave like middleware. These can call `next('route')` to skip remaining callbacks for the current route. This is useful for conditional routing logic. If a callback throws an error or returns a rejected promise, `next(err)` is invoked automatically. Since both [router](/api/router/) and [app](#overview) implement the middleware interface, they can also be used as callback middleware. For examples, see [Middleware callback function examples](#middleware-callback-function-examples). | _None_            |
 
 For more information, see the [routing guide](/guide/routing/).
 
@@ -370,21 +485,31 @@ app.get('/', (req, res) => {
 });
 ```
 
-### app.listen(path, [callback])
+### app.listen()
 
-Starts a UNIX socket and listens for connections on the given path.
-This method is identical to Node's [http.Server.listen()](https://nodejs.org/api/http.html#http_server_listen).
+<Signature returns="http.Server">
+  <Fragment slot="attributes">
+    <Param name="port" type="Number" optional>
+      The TCP port to listen on. If omitted or `0`, the OS assigns an arbitrary unused port.
+    </Param>
+    <Param name="host" type="String" optional>
+      The host on which to accept connections.
+    </Param>
+    <Param name="backlog" type="Number" optional>
+      The maximum length of the queue of pending connections.
+    </Param>
+    <Param name="path" type="String" optional>
+      The path of a UNIX socket to listen on, as an alternative to host and port.
+    </Param>
+    <Param name="callback" type="Function" optional>
+      A function to call once the server is listening.
+    </Param>
+  </Fragment>
+</Signature>
 
-```js
-const express = require('express');
-const app = express();
-app.listen('/tmp/sock');
-```
-
-### app.listen([port[, host[, backlog]]][, callback])
-
-Binds and listens for connections on the specified host and port.
-This method is identical to Node's [http.Server.listen()](https://nodejs.org/api/http.html#http_server_listen).
+Binds and listens for connections on the specified host and port, or starts a
+UNIX socket and listens for connections on the given path. This method is
+identical to Node's [http.Server.listen()](https://nodejs.org/api/http.html#http_server_listen).
 
 If port is omitted or is 0, the operating system will assign an arbitrary unused
 port, which is useful for cases like automated tasks (tests, etc.).
@@ -392,7 +517,9 @@ port, which is useful for cases like automated tasks (tests, etc.).
 ```js
 const express = require('express');
 const app = express();
-app.listen(3000);
+
+app.listen(3000); // bind and listen on a TCP port
+app.listen('/tmp/sock'); // or listen on a UNIX socket
 ```
 
 The `app` returned by `express()` is in fact a JavaScript
@@ -428,18 +555,32 @@ actually supported.
 
 </Alert>
 
-### app.METHOD(path, callback [, callback ...])
+### app.METHOD()
+
+<Signature>
+  <Fragment slot="attributes">
+    <Param name="path" type="String | RegExp | Array">
+      The path for which the middleware function is invoked; can be any of: a string representing a
+      path, a path pattern, a regular expression pattern to match paths, or an array of combinations
+      of any of the above. For examples, see [Path examples](#path-examples).
+    </Param>
+    <Param name="callback" type="Function | Function[]">
+      Callback functions; can be: a middleware function, a series of middleware functions (separated
+      by commas), an array of middleware functions, or a combination of all of the above. You can
+      provide multiple callback functions that behave just like middleware, except that these
+      callbacks can invoke `next('route')` to bypass the remaining route callback(s). You can use
+      this mechanism to impose pre-conditions on a route, then pass control to subsequent routes if
+      there is no reason to proceed with the current route. Since [router](/api/router/) and
+      [app](#overview) implement the middleware interface, you can use them as you would any other
+      middleware function. For examples, see [Middleware callback function
+      examples](#middleware-callback-function-examples).
+    </Param>
+  </Fragment>
+</Signature>
 
 Routes an HTTP request, where METHOD is the HTTP method of the request, such as GET,
 PUT, POST, and so on, in lowercase. Thus, the actual methods are `app.get()`,
 `app.post()`, `app.put()`, and so on. See [Routing methods](#routing-methods) below for the complete list.
-
-#### Arguments
-
-| Argument   | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | Default           |
-| ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
-| `path`     | The path for which the middleware function is invoked. It can be any of the following: a string representing a path, a path pattern, a regular expression pattern to match paths, or an array containing any combination of the above. For examples, see [Path examples](#path-examples).                                                                                                                                                                                                                                                                                                                                                                                                                                                          | `'/'` (root path) |
-| `callback` | One or more callback functions. Accepted formats: a single middleware function, multiple middleware functions separated by commas, an array of middleware functions, or a combination of the above. You may provide multiple callbacks that behave like middleware. These can call `next('route')` to skip remaining callbacks for the current route. This is useful for conditional routing logic. If a callback throws an error or returns a rejected promise, `next(err)` is invoked automatically. Since both [router](/api/router/) and [app](#overview) implement the middleware interface, they can also be used as callback middleware. For examples, see [Middleware callback function examples](#middleware-callback-function-examples). | _None_            |
 
 #### Routing methods
 
@@ -538,11 +679,24 @@ The `app.get()` function is automatically called for the HTTP `HEAD` method in a
 
 The method, `app.all()`, is not derived from any HTTP method and loads middleware at
 the specified path for _all_ HTTP request methods.
-For more information, see [app.all](#appallpath-callback--callback-).
+For more information, see [app.all](#appall).
 
 For more information on routing, see the [routing guide](/guide/routing/).
 
-### app.param(name, callback)
+### app.param()
+
+<Signature>
+  <Fragment slot="attributes">
+    <Param name="name" type="String | String[]">
+      The name of the route parameter, or an array of names.
+    </Param>
+    <Param name="callback" type="Function">
+      The trigger called as `callback(req, res, next, value, name)`: the request object, the
+      response object, the next middleware, the value of the parameter, and the name of the
+      parameter, in that order.
+    </Param>
+  </Fragment>
+</Signature>
 
 Add callback triggers to [route parameters](/guide/routing/#route-parameters), where `name` is the name of the parameter or an array of them, and `callback` is the callback function. The parameters of the callback function are the request object, the response object, the next middleware, the value of the parameter and the name of the parameter, in that order.
 
@@ -623,6 +777,8 @@ and this matches too
 
 ### app.path()
 
+<Signature returns="String" />
+
 Returns the canonical path of the app, a string.
 
 ```js
@@ -641,17 +797,31 @@ console.log(blogAdmin.path()); // '/blog/admin'
 The behavior of this method can become very complicated in complex cases of mounted apps:
 it is usually better to use [req.baseUrl](/api/request/#reqbaseurl) to get the canonical path of the app.
 
-### app.post(path, callback [, callback ...])
+### app.post()
+
+<Signature>
+  <Fragment slot="attributes">
+    <Param name="path" type="String | RegExp | Array">
+      The path for which the middleware function is invoked; can be any of: a string representing a
+      path, a path pattern, a regular expression pattern to match paths, or an array of combinations
+      of any of the above. For examples, see [Path examples](#path-examples).
+    </Param>
+    <Param name="callback" type="Function | Function[]">
+      Callback functions; can be: a middleware function, a series of middleware functions (separated
+      by commas), an array of middleware functions, or a combination of all of the above. You can
+      provide multiple callback functions that behave just like middleware, except that these
+      callbacks can invoke `next('route')` to bypass the remaining route callback(s). You can use
+      this mechanism to impose pre-conditions on a route, then pass control to subsequent routes if
+      there is no reason to proceed with the current route. Since [router](/api/router/) and
+      [app](#overview) implement the middleware interface, you can use them as you would any other
+      middleware function. For examples, see [Middleware callback function
+      examples](#middleware-callback-function-examples).
+    </Param>
+  </Fragment>
+</Signature>
 
 Routes HTTP POST requests to the specified path with the specified callback functions.
 For more information, see the [routing guide](/guide/routing/).
-
-#### Arguments
-
-| Argument   | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | Default           |
-| ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
-| `path`     | The path for which the middleware function is invoked. It can be any of the following: a string representing a path, a path pattern, a regular expression pattern to match paths, or an array containing any combination of the above. For examples, see [Path examples](#path-examples).                                                                                                                                                                                                                                                                                                                                                                                                                                                          | `'/'` (root path) |
-| `callback` | One or more callback functions. Accepted formats: a single middleware function, multiple middleware functions separated by commas, an array of middleware functions, or a combination of the above. You may provide multiple callbacks that behave like middleware. These can call `next('route')` to skip remaining callbacks for the current route. This is useful for conditional routing logic. If a callback throws an error or returns a rejected promise, `next(err)` is invoked automatically. Since both [router](/api/router/) and [app](#overview) implement the middleware interface, they can also be used as callback middleware. For examples, see [Middleware callback function examples](#middleware-callback-function-examples). | _None_            |
 
 #### Example
 
@@ -661,16 +831,30 @@ app.post('/', (req, res) => {
 });
 ```
 
-### app.put(path, callback [, callback ...])
+### app.put()
+
+<Signature>
+  <Fragment slot="attributes">
+    <Param name="path" type="String | RegExp | Array">
+      The path for which the middleware function is invoked; can be any of: a string representing a
+      path, a path pattern, a regular expression pattern to match paths, or an array of combinations
+      of any of the above. For examples, see [Path examples](#path-examples).
+    </Param>
+    <Param name="callback" type="Function | Function[]">
+      Callback functions; can be: a middleware function, a series of middleware functions (separated
+      by commas), an array of middleware functions, or a combination of all of the above. You can
+      provide multiple callback functions that behave just like middleware, except that these
+      callbacks can invoke `next('route')` to bypass the remaining route callback(s). You can use
+      this mechanism to impose pre-conditions on a route, then pass control to subsequent routes if
+      there is no reason to proceed with the current route. Since [router](/api/router/) and
+      [app](#overview) implement the middleware interface, you can use them as you would any other
+      middleware function. For examples, see [Middleware callback function
+      examples](#middleware-callback-function-examples).
+    </Param>
+  </Fragment>
+</Signature>
 
 Routes HTTP PUT requests to the specified path with the specified callback functions.
-
-#### Arguments
-
-| Argument   | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | Default           |
-| ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
-| `path`     | The path for which the middleware function is invoked. It can be any of the following: a string representing a path, a path pattern, a regular expression pattern to match paths, or an array containing any combination of the above. For examples, see [Path examples](#path-examples).                                                                                                                                                                                                                                                                                                                                                                                                                                                          | `'/'` (root path) |
-| `callback` | One or more callback functions. Accepted formats: a single middleware function, multiple middleware functions separated by commas, an array of middleware functions, or a combination of the above. You may provide multiple callbacks that behave like middleware. These can call `next('route')` to skip remaining callbacks for the current route. This is useful for conditional routing logic. If a callback throws an error or returns a rejected promise, `next(err)` is invoked automatically. Since both [router](/api/router/) and [app](#overview) implement the middleware interface, they can also be used as callback middleware. For examples, see [Middleware callback function examples](#middleware-callback-function-examples). | _None_            |
 
 #### Example
 
@@ -680,7 +864,21 @@ app.put('/', (req, res) => {
 });
 ```
 
-### app.render(view, [locals], callback)
+### app.render()
+
+<Signature>
+  <Fragment slot="attributes">
+    <Param name="view" type="String">
+      The name of the view to render.
+    </Param>
+    <Param name="locals" type="Object" optional>
+      An object whose properties define local variables for the view.
+    </Param>
+    <Param name="callback" type="Function">
+      The callback invoked as `callback(err, html)` with the rendered HTML.
+    </Param>
+  </Fragment>
+</Signature>
 
 Returns the rendered HTML of a view via the `callback` function. It accepts an optional parameter
 that is an object containing local variables for the view. It is like [res.render()](/api/response/#resrenderview--locals--callback),
@@ -726,7 +924,15 @@ app.render('email', { name: 'Tobi' }, (err, html) => {
 });
 ```
 
-### app.route(path)
+### app.route()
+
+<Signature returns="Route">
+  <Fragment slot="attributes">
+    <Param name="path" type="String">
+      The path of the route to create.
+    </Param>
+  </Fragment>
+</Signature>
 
 Returns an instance of a single route, which you can then use to handle HTTP verbs with optional middleware.
 Use `app.route()` to avoid duplicate route names (and thus typo errors).
@@ -748,7 +954,19 @@ app
   });
 ```
 
-### app.set(name, value)
+### app.set()
+
+<Signature returns="Application">
+  <Fragment slot="attributes">
+    <Param name="name" type="String">
+      The name of the setting to assign. Certain names configure the server's behavior; see the [app
+      settings table](#application-settings).
+    </Param>
+    <Param name="value" type="any">
+      The value to assign to the setting.
+    </Param>
+  </Fragment>
+</Signature>
 
 Assigns setting `name` to `value`. You may store any value that you want,
 but certain names can be used to configure the behavior of the server. These
@@ -777,23 +995,55 @@ Note that sub-apps will:
 Exceptions: Sub-apps will inherit the value of `trust proxy` even though it has a default value (for backward-compatibility);
 Sub-apps will not inherit the value of `view cache` in production (when `NODE_ENV` is "production").
 
-| Property                 | Type            | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | Default                                                                                             |
-| ------------------------ | --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
-| `case sensitive routing` | Boolean         | Enable case sensitivity. When enabled, "/Foo" and "/foo" are different routes. When disabled, "/Foo" and "/foo" are treated the same. **NOTE**: Sub-apps will inherit the value of this setting.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | N/A (undefined)                                                                                     |
-| `env`                    | String          | Environment mode. Be sure to set to "production" in a production environment; see [Production best practices: performance and reliability](/advanced/best-practice-performance#things-to-do-in-your-environment--setup).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | `process.env.NODE_ENV` (`NODE_ENV` environment variable) or "development" if `NODE_ENV` is not set. |
-| `etag`                   | Varied          | Set the ETag response header. For possible values, see the `etag` options table below. [More about the HTTP ETag header](https://en.wikipedia.org/wiki/HTTP_ETag).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | `weak`                                                                                              |
-| `jsonp callback name`    | String          | Specifies the default JSONP callback name.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | "callback"                                                                                          |
-| `json escape`            | Boolean         | Enable escaping JSON responses from the `res.json`, `res.jsonp`, and `res.send` APIs. This will escape the characters `<`, `>`, and `&` as Unicode escape sequences in JSON. The purpose of this is to assist with [mitigating certain types of persistent XSS attacks](https://blog.mozilla.org/security/2017/07/18/web-service-audits-firefox-accounts/) when clients sniff responses for HTML. **NOTE**: Sub-apps will inherit the value of this setting.                                                                                                                                                                                                                                                                                                                                                                                   | N/A (undefined)                                                                                     |
-| `json replacer`          | Varied          | The ['replacer' argument used by `JSON.stringify`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#the_replacer_parameter). **NOTE**: Sub-apps will inherit the value of this setting.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | N/A (undefined)                                                                                     |
-| `json spaces`            | Varied          | The ['space' argument used by `JSON.stringify`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#the_space_parameter). This is typically set to the number of spaces to use to indent prettified JSON. **NOTE**: Sub-apps will inherit the value of this setting.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | N/A (undefined)                                                                                     |
-| `query parser`           | Varied          | Disable query parsing by setting the value to `false`, or set the query parser to use either "simple" or "extended" or a custom query string parsing function. The simple query parser is based on Node's native query parser, [querystring](https://nodejs.org/api/querystring.html). The extended query parser is based on [qs](https://www.npmjs.com/package/qs). A custom query string parsing function will receive the complete query string, and must return an object of query keys and their values.                                                                                                                                                                                                                                                                                                                                  | "simple"                                                                                            |
-| `strict routing`         | Boolean         | Enable strict routing. When enabled, the router treats "/foo" and "/foo/" as different. Otherwise, the router treats "/foo" and "/foo/" as the same. **NOTE**: Sub-apps will inherit the value of this setting.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | N/A (undefined)                                                                                     |
-| `subdomain offset`       | Number          | The number of dot-separated parts of the host to remove to access subdomain.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | 2                                                                                                   |
-| `trust proxy`            | Varied          | Indicates the app is behind a front-facing proxy, and to use the `X-Forwarded-*` headers to determine the connection and the IP address of the client. NOTE: `X-Forwarded-*` headers are easily spoofed and the detected IP addresses are unreliable. When enabled, Express attempts to determine the IP address of the client connected through the front-facing proxy, or series of proxies. The `req.ips` property, then contains an array of IP addresses the client is connected through. To enable it, use the values described in the trust proxy options table below. The `trust proxy` setting is implemented using the [proxy-addr](https://www.npmjs.com/package/proxy-addr) package. For more information, see its documentation. **NOTE**: Sub-apps _will_ inherit the value of this setting, even though it has a default value. | `false` (disabled)                                                                                  |
-| `views`                  | String or Array | A directory or an array of directories for the application's views. If an array, the views are looked up in the order they occur in the array.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | `process.cwd() + '/views'`                                                                          |
-| `view cache`             | Boolean         | Enables view template compilation caching. **NOTE**: Sub-apps will not inherit the value of this setting in production (when `NODE_ENV` is "production").                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      | `true` in production, otherwise undefined.                                                          |
-| `view engine`            | String          | The default engine extension to use when omitted. **NOTE**: Sub-apps will inherit the value of this setting.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | N/A (undefined)                                                                                     |
-| `x-powered-by`           | Boolean         | Enables the "X-Powered-By: Express" HTTP header.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | `true`                                                                                              |
+<Signature attributesTitle="Settings">
+  <Fragment slot="attributes">
+    <Param name="case sensitive routing" type="Boolean" default="N/A (undefined)">
+      Enable case sensitivity. When enabled, "/Foo" and "/foo" are different routes. When disabled, "/Foo" and "/foo" are treated the same. **NOTE**: Sub-apps will inherit the value of this setting.
+    </Param>
+    <Param name="env" type="String" default='process.env.NODE_ENV (NODE_ENV environment variable) or "development" if NODE_ENV is not set.'>
+      Environment mode. Be sure to set to "production" in a production environment; see [Production best practices: performance and reliability](/advanced/best-practice-performance#things-to-do-in-your-environment--setup).
+    </Param>
+    <Param name="etag" type="Varied" default="weak">
+      Set the ETag response header. For possible values, see the `etag` options table below. [More about the HTTP ETag header](https://en.wikipedia.org/wiki/HTTP_ETag).
+    </Param>
+    <Param name="jsonp callback name" type="String" default='"callback"'>
+      Specifies the default JSONP callback name.
+    </Param>
+    <Param name="json escape" type="Boolean" default="N/A (undefined)">
+      Enable escaping JSON responses from the `res.json`, `res.jsonp`, and `res.send` APIs. This will escape the characters `<`, `>`, and `&` as Unicode escape sequences in JSON. The purpose of this is to assist with [mitigating certain types of persistent XSS attacks](https://blog.mozilla.org/security/2017/07/18/web-service-audits-firefox-accounts/) when clients sniff responses for HTML. **NOTE**: Sub-apps will inherit the value of this setting.
+    </Param>
+    <Param name="json replacer" type="Varied" default="N/A (undefined)">
+      The ['replacer' argument used by `JSON.stringify`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#the_replacer_parameter). **NOTE**: Sub-apps will inherit the value of this setting.
+    </Param>
+    <Param name="json spaces" type="Varied" default="N/A (undefined)">
+      The ['space' argument used by `JSON.stringify`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#the_space_parameter). This is typically set to the number of spaces to use to indent prettified JSON. **NOTE**: Sub-apps will inherit the value of this setting.
+    </Param>
+    <Param name="query parser" type="Varied" default='"simple"'>
+      Disable query parsing by setting the value to `false`, or set the query parser to use either "simple" or "extended" or a custom query string parsing function. The simple query parser is based on Node's native query parser, [querystring](https://nodejs.org/api/querystring.html). The extended query parser is based on [qs](https://www.npmjs.com/package/qs). A custom query string parsing function will receive the complete query string, and must return an object of query keys and their values.
+    </Param>
+    <Param name="strict routing" type="Boolean" default="N/A (undefined)">
+      Enable strict routing. When enabled, the router treats "/foo" and "/foo/" as different. Otherwise, the router treats "/foo" and "/foo/" as the same. **NOTE**: Sub-apps will inherit the value of this setting.
+    </Param>
+    <Param name="subdomain offset" type="Number" default="2">
+      The number of dot-separated parts of the host to remove to access subdomain.
+    </Param>
+    <Param name="trust proxy" type="Varied" default="false (disabled)">
+      Indicates the app is behind a front-facing proxy, and to use the `X-Forwarded-*` headers to determine the connection and the IP address of the client. NOTE: `X-Forwarded-*` headers are easily spoofed and the detected IP addresses are unreliable. When enabled, Express attempts to determine the IP address of the client connected through the front-facing proxy, or series of proxies. The `req.ips` property, then contains an array of IP addresses the client is connected through. To enable it, use the values described in the trust proxy options table below. The `trust proxy` setting is implemented using the [proxy-addr](https://www.npmjs.com/package/proxy-addr) package. For more information, see its documentation. **NOTE**: Sub-apps _will_ inherit the value of this setting, even though it has a default value.
+    </Param>
+    <Param name="views" type="String or Array" default="process.cwd() + '/views'">
+      A directory or an array of directories for the application's views. If an array, the views are looked up in the order they occur in the array.
+    </Param>
+    <Param name="view cache" type="Boolean" default="true in production, otherwise undefined.">
+      Enables view template compilation caching. **NOTE**: Sub-apps will not inherit the value of this setting in production (when `NODE_ENV` is "production").
+    </Param>
+    <Param name="view engine" type="String" default="N/A (undefined)">
+      The default engine extension to use when omitted. **NOTE**: Sub-apps will inherit the value of this setting.
+    </Param>
+    <Param name="x-powered-by" type="Boolean" default="true">
+      Enables the "X-Powered-By: Express" HTTP header.
+    </Param>
+  </Fragment>
+</Signature>
 
 #### Options for `trust proxy` setting
 
@@ -853,11 +1103,17 @@ app.set('trust proxy', (ip) => {
 
 The ETag functionality is implemented using the [etag](https://www.npmjs.com/package/etag) package. For more information, see its documentation.
 
-| Type     | Value                                                                                    |
-| -------- | ---------------------------------------------------------------------------------------- |
-| Boolean  | `true` enables weak ETag. This is the default setting. `false` disables ETag altogether. |
-| String   | If "strong", enables strong ETag. If "weak", enables weak ETag.                          |
-| Function | Custom ETag function implementation. Use this only if you know what you are doing.       |
+<Signature attributesTitle="Values">
+  <Fragment slot="attributes">
+    <Param name="Boolean">
+      `true` enables weak ETag. This is the default setting. `false` disables ETag altogether.
+    </Param>
+    <Param name="String">If "strong", enables strong ETag. If "weak", enables weak ETag.</Param>
+    <Param name="Function">
+      Custom ETag function implementation. Use this only if you know what you are doing.
+    </Param>
+  </Fragment>
+</Signature>
 
 ```js
 app.set('etag', (body, encoding) => {
@@ -865,18 +1121,32 @@ app.set('etag', (body, encoding) => {
 });
 ```
 
-### app.use([path,] callback [, callback...])
+### app.use()
+
+<Signature>
+  <Fragment slot="attributes">
+    <Param name="path" type="String | RegExp | Array" optional>
+      The path for which the middleware function is invoked; can be any of: a string representing a
+      path, a path pattern, a regular expression pattern to match paths, or an array of combinations
+      of any of the above. For examples, see [Path examples](#path-examples).
+    </Param>
+    <Param name="callback" type="Function | Function[]">
+      Callback functions; can be: a middleware function, a series of middleware functions (separated
+      by commas), an array of middleware functions, or a combination of all of the above. You can
+      provide multiple callback functions that behave just like middleware, except that these
+      callbacks can invoke `next('route')` to bypass the remaining route callback(s). You can use
+      this mechanism to impose pre-conditions on a route, then pass control to subsequent routes if
+      there is no reason to proceed with the current route. Since [router](/api/router/) and
+      [app](#overview) implement the middleware interface, you can use them as you would any other
+      middleware function. For examples, see [Middleware callback function
+      examples](#middleware-callback-function-examples).
+    </Param>
+  </Fragment>
+</Signature>
 
 Mounts the specified [middleware](/guide/using-middleware) function or functions
 at the specified path:
 the middleware function is executed when the base of the requested path matches `path`.
-
-#### Arguments
-
-| Argument   | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | Default           |
-| ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
-| `path`     | The path for which the middleware function is invoked. It can be any of the following: a string representing a path, a path pattern, a regular expression pattern to match paths, or an array containing any combination of the above. For examples, see [Path examples](#path-examples).                                                                                                                                                                                                                                                                                                                                                                                                                                                          | `'/'` (root path) |
-| `callback` | One or more callback functions. Accepted formats: a single middleware function, multiple middleware functions separated by commas, an array of middleware functions, or a combination of the above. You may provide multiple callbacks that behave like middleware. These can call `next('route')` to skip remaining callbacks for the current route. This is useful for conditional routing logic. If a callback throws an error or returns a rejected promise, `next(err)` is invoked automatically. Since both [router](/api/router/) and [app](#overview) implement the middleware interface, they can also be used as callback middleware. For examples, see [Middleware callback function examples](#middleware-callback-function-examples). | _None_            |
 
 #### Description
 

--- a/src/content/api/5x/api/application/index.mdx
+++ b/src/content/api/5x/api/application/index.mdx
@@ -209,8 +209,8 @@ app.use('/admin', admin);
       callbacks can invoke `next('route')` to bypass the remaining route callback(s). You can use
       this mechanism to impose pre-conditions on a route, then pass control to subsequent routes if
       there is no reason to proceed with the current route. Since [router](/api/router/) and
-      [app](#overview) implement the middleware interface, you can use them as you would any other
-      middleware function. For examples, see [Middleware callback function
+      [app](/api/application/) implement the middleware interface, you can use them as you would any
+      other middleware function. For examples, see [Middleware callback function
       examples](#middleware-callback-function-examples).
     </Param>
   </Fragment>
@@ -273,8 +273,8 @@ app.all('/api/{*splat}', requireAuthentication);
       callbacks can invoke `next('route')` to bypass the remaining route callback(s). You can use
       this mechanism to impose pre-conditions on a route, then pass control to subsequent routes if
       there is no reason to proceed with the current route. Since [router](/api/router/) and
-      [app](#overview) implement the middleware interface, you can use them as you would any other
-      middleware function. For examples, see [Middleware callback function
+      [app](/api/application/) implement the middleware interface, you can use them as you would any
+      other middleware function. For examples, see [Middleware callback function
       examples](#middleware-callback-function-examples).
     </Param>
   </Fragment>
@@ -466,8 +466,8 @@ app.get('title');
       callbacks can invoke `next('route')` to bypass the remaining route callback(s). You can use
       this mechanism to impose pre-conditions on a route, then pass control to subsequent routes if
       there is no reason to proceed with the current route. Since [router](/api/router/) and
-      [app](#overview) implement the middleware interface, you can use them as you would any other
-      middleware function. For examples, see [Middleware callback function
+      [app](/api/application/) implement the middleware interface, you can use them as you would any
+      other middleware function. For examples, see [Middleware callback function
       examples](#middleware-callback-function-examples).
     </Param>
   </Fragment>
@@ -571,8 +571,8 @@ actually supported.
       callbacks can invoke `next('route')` to bypass the remaining route callback(s). You can use
       this mechanism to impose pre-conditions on a route, then pass control to subsequent routes if
       there is no reason to proceed with the current route. Since [router](/api/router/) and
-      [app](#overview) implement the middleware interface, you can use them as you would any other
-      middleware function. For examples, see [Middleware callback function
+      [app](/api/application/) implement the middleware interface, you can use them as you would any
+      other middleware function. For examples, see [Middleware callback function
       examples](#middleware-callback-function-examples).
     </Param>
   </Fragment>
@@ -813,8 +813,8 @@ it is usually better to use [req.baseUrl](/api/request/#reqbaseurl) to get the c
       callbacks can invoke `next('route')` to bypass the remaining route callback(s). You can use
       this mechanism to impose pre-conditions on a route, then pass control to subsequent routes if
       there is no reason to proceed with the current route. Since [router](/api/router/) and
-      [app](#overview) implement the middleware interface, you can use them as you would any other
-      middleware function. For examples, see [Middleware callback function
+      [app](/api/application/) implement the middleware interface, you can use them as you would any
+      other middleware function. For examples, see [Middleware callback function
       examples](#middleware-callback-function-examples).
     </Param>
   </Fragment>
@@ -847,8 +847,8 @@ app.post('/', (req, res) => {
       callbacks can invoke `next('route')` to bypass the remaining route callback(s). You can use
       this mechanism to impose pre-conditions on a route, then pass control to subsequent routes if
       there is no reason to proceed with the current route. Since [router](/api/router/) and
-      [app](#overview) implement the middleware interface, you can use them as you would any other
-      middleware function. For examples, see [Middleware callback function
+      [app](/api/application/) implement the middleware interface, you can use them as you would any
+      other middleware function. For examples, see [Middleware callback function
       examples](#middleware-callback-function-examples).
     </Param>
   </Fragment>
@@ -1137,8 +1137,8 @@ app.set('etag', (body, encoding) => {
       callbacks can invoke `next('route')` to bypass the remaining route callback(s). You can use
       this mechanism to impose pre-conditions on a route, then pass control to subsequent routes if
       there is no reason to proceed with the current route. Since [router](/api/router/) and
-      [app](#overview) implement the middleware interface, you can use them as you would any other
-      middleware function. For examples, see [Middleware callback function
+      [app](/api/application/) implement the middleware interface, you can use them as you would any
+      other middleware function. For examples, see [Middleware callback function
       examples](#middleware-callback-function-examples).
     </Param>
   </Fragment>

--- a/src/content/api/5x/api/application/index.mdx
+++ b/src/content/api/5x/api/application/index.mdx
@@ -1003,7 +1003,7 @@ Sub-apps will not inherit the value of `view cache` in production (when `NODE_EN
     <Param name="env" type="String" default='process.env.NODE_ENV (NODE_ENV environment variable) or "development" if NODE_ENV is not set.'>
       Environment mode. Be sure to set to "production" in a production environment; see [Production best practices: performance and reliability](/advanced/best-practice-performance#things-to-do-in-your-environment--setup).
     </Param>
-    <Param name="etag" type="Varied" default="weak">
+    <Param name="etag" type="Boolean | String | Function" default="weak">
       Set the ETag response header. For possible values, see the `etag` options table below. [More about the HTTP ETag header](https://en.wikipedia.org/wiki/HTTP_ETag).
     </Param>
     <Param name="jsonp callback name" type="String" default='"callback"'>
@@ -1012,13 +1012,13 @@ Sub-apps will not inherit the value of `view cache` in production (when `NODE_EN
     <Param name="json escape" type="Boolean" default="N/A (undefined)">
       Enable escaping JSON responses from the `res.json`, `res.jsonp`, and `res.send` APIs. This will escape the characters `<`, `>`, and `&` as Unicode escape sequences in JSON. The purpose of this is to assist with [mitigating certain types of persistent XSS attacks](https://blog.mozilla.org/security/2017/07/18/web-service-audits-firefox-accounts/) when clients sniff responses for HTML. **NOTE**: Sub-apps will inherit the value of this setting.
     </Param>
-    <Param name="json replacer" type="Varied" default="N/A (undefined)">
+    <Param name="json replacer" type="Function | Array" default="N/A (undefined)">
       The ['replacer' argument used by `JSON.stringify`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#the_replacer_parameter). **NOTE**: Sub-apps will inherit the value of this setting.
     </Param>
-    <Param name="json spaces" type="Varied" default="N/A (undefined)">
+    <Param name="json spaces" type="Number | String" default="N/A (undefined)">
       The ['space' argument used by `JSON.stringify`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#the_space_parameter). This is typically set to the number of spaces to use to indent prettified JSON. **NOTE**: Sub-apps will inherit the value of this setting.
     </Param>
-    <Param name="query parser" type="Varied" default='"simple"'>
+    <Param name="query parser" type="Boolean | String | Function" default='"simple"'>
       Disable query parsing by setting the value to `false`, or set the query parser to use either "simple" or "extended" or a custom query string parsing function. The simple query parser is based on Node's native query parser, [querystring](https://nodejs.org/api/querystring.html). The extended query parser is based on [qs](https://www.npmjs.com/package/qs). A custom query string parsing function will receive the complete query string, and must return an object of query keys and their values.
     </Param>
     <Param name="strict routing" type="Boolean" default="N/A (undefined)">
@@ -1027,7 +1027,7 @@ Sub-apps will not inherit the value of `view cache` in production (when `NODE_EN
     <Param name="subdomain offset" type="Number" default="2">
       The number of dot-separated parts of the host to remove to access subdomain.
     </Param>
-    <Param name="trust proxy" type="Varied" default="false (disabled)">
+    <Param name="trust proxy" type="Boolean | String | Number | Function | Array" default="false (disabled)">
       Indicates the app is behind a front-facing proxy, and to use the `X-Forwarded-*` headers to determine the connection and the IP address of the client. NOTE: `X-Forwarded-*` headers are easily spoofed and the detected IP addresses are unreliable. When enabled, Express attempts to determine the IP address of the client connected through the front-facing proxy, or series of proxies. The `req.ips` property, then contains an array of IP addresses the client is connected through. To enable it, use the values described in the trust proxy options table below. The `trust proxy` setting is implemented using the [proxy-addr](https://www.npmjs.com/package/proxy-addr) package. For more information, see its documentation. **NOTE**: Sub-apps _will_ inherit the value of this setting, even though it has a default value.
     </Param>
     <Param name="views" type="String or Array" default="process.cwd() + '/views'">

--- a/src/content/api/5x/api/application/index.mdx
+++ b/src/content/api/5x/api/application/index.mdx
@@ -44,7 +44,7 @@ The Express application object can be referred from the [request object](/api/re
 <Signature type="Object" />
 
 The `app.locals` object has properties that are local variables within the application,
-and will be available in templates rendered with [res.render](/api/response/#resrenderview--locals--callback).
+and will be available in templates rendered with [res.render](/api/response/#resrender).
 
 <Alert type="warning">
 
@@ -881,7 +881,7 @@ app.put('/', (req, res) => {
 </Signature>
 
 Returns the rendered HTML of a view via the `callback` function. It accepts an optional parameter
-that is an object containing local variables for the view. It is like [res.render()](/api/response/#resrenderview--locals--callback),
+that is an object containing local variables for the view. It is like [res.render()](/api/response/#resrender),
 except it cannot send the rendered view to the client on its own.
 
 <Alert type="info">

--- a/src/content/api/5x/api/application/index.mdx
+++ b/src/content/api/5x/api/application/index.mdx
@@ -502,7 +502,8 @@ app.get('/', (req, res) => {
       The path of a UNIX socket to listen on, as an alternative to host and port.
     </Param>
     <Param name="callback" type="Function" optional>
-      A function to call once the server is listening.
+      A function called once the server is listening. If the server emits an `error` event (for
+      example `EADDRINUSE`), the error is passed to this callback as its argument.
     </Param>
   </Fragment>
 </Signature>
@@ -520,6 +521,22 @@ const app = express();
 
 app.listen(3000); // bind and listen on a TCP port
 app.listen('/tmp/sock'); // or listen on a UNIX socket
+```
+
+<Alert type="info">
+
+When the server emits an `error` event (such as `EADDRINUSE`), the error is passed to the provided
+`callback`. Handle it inside the callback:
+
+</Alert>
+
+```js
+const server = app.listen(8080, '0.0.0.0', (error) => {
+  if (error) {
+    throw error; // e.g. EADDRINUSE
+  }
+  console.log(`Listening on ${JSON.stringify(server.address())}`);
+});
 ```
 
 The `app` returned by `express()` is in fact a JavaScript

--- a/src/content/api/5x/api/express/index.mdx
+++ b/src/content/api/5x/api/express/index.mdx
@@ -4,6 +4,8 @@ description: Learn about the methods available on the top-level Express object.
 ---
 
 import Alert from '@components/primitives/Alert/Alert.astro';
+import Signature from '@components/patterns/Signature/Signature.astro';
+import Param from '@components/patterns/Signature/Param.astro';
 
 Creates an Express application. The `express()` function is a top-level function exported by the `express` module.
 
@@ -16,7 +18,47 @@ const app = express();
 
 The Express object has the following methods that can be used to create middleware functions, routers and have some built-in middleware:
 
-### express.json([options])
+### express.json()
+
+<Signature returns="Function">
+  <Fragment slot="attributes">
+    <Param name="defaultCharset" type="String" default='"utf-8"'>
+      Specify the default character set for the JSON content if the charset is not specified in the
+      `Content-Type` header of the request.
+    </Param>
+    <Param name="inflate" type="Boolean" default="true">
+      Enables or disables handling deflated (compressed) bodies; when disabled, deflated bodies are
+      rejected.
+    </Param>
+    <Param name="limit" type="Number | String" default='"100kb"'>
+      Controls the maximum request body size. If this is a number, then the value specifies the
+      number of bytes; if it is a string, the value is passed to the
+      [bytes](https://www.npmjs.com/package/bytes) library for parsing.
+    </Param>
+    <Param name="reviver" type="Function" default="null">
+      The `reviver` option is passed directly to `JSON.parse` as the second argument. You can find
+      more information on this argument [in the MDN documentation about
+      JSON.parse](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse#the_reviver_parameter).
+    </Param>
+    <Param name="strict" type="Boolean" default="true">
+      Enables or disables only accepting arrays and objects; when disabled will accept anything
+      `JSON.parse` accepts.
+    </Param>
+    <Param name="type" type="String | String[] | Function" default='"application/json"'>
+      This is used to determine what media type the middleware will parse. This option can be a
+      string, array of strings, or a function. If not a function, `type` option is passed directly
+      to the [type-is](https://www.npmjs.com/package/type-is#readme) library and this can be an
+      extension name (like `json`), a mime type (like `application/json`), or a mime type with a
+      wildcard (like `*/*` or `*/json`). If a function, the `type` option is called as `fn(req)` and
+      the request is parsed if it returns a truthy value.
+    </Param>
+    <Param name="verify" type="Function" default="undefined">
+      This option, if supplied, is called as `verify(req, res, buf, encoding)`, where `buf` is a
+      `Buffer` of the raw request body and `encoding` is the encoding of the request. The parsing
+      can be aborted by throwing an error.
+    </Param>
+  </Fragment>
+</Signature>
 
 This is a built-in middleware function in Express. It parses incoming requests
 with JSON payloads and is based on
@@ -41,22 +83,34 @@ may not be a function and instead a string or other user-input.
 
 </Alert>
 
-The following table describes the properties of the optional `options` object.
+### express.raw()
 
-<div class="table-scroller" markdown="1">
-
-| Property  | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | Type     | Default              |
-| --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------- | -------------------- |
-| `inflate` | Enables or disables handling deflated (compressed) bodies; when disabled, deflated bodies are rejected.                                                                                                                                                                                                                                                                                                                                                                                                                        | Boolean  | `true`               |
-| `limit`   | Controls the maximum request body size. If this is a number, then the value specifies the number of bytes; if it is a string, the value is passed to the [bytes](https://www.npmjs.com/package/bytes) library for parsing.                                                                                                                                                                                                                                                                                                     | Mixed    | `"100kb"`            |
-| `reviver` | The `reviver` option is passed directly to `JSON.parse` as the second argument. You can find more information on this argument [in the MDN documentation about JSON.parse](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse#the_reviver_parameter).                                                                                                                                                                                                                                 | Function | `null`               |
-| `strict`  | Enables or disables only accepting arrays and objects; when disabled will accept anything `JSON.parse` accepts.                                                                                                                                                                                                                                                                                                                                                                                                                | Boolean  | `true`               |
-| `type`    | This is used to determine what media type the middleware will parse. This option can be a string, array of strings, or a function. If not a function, `type` option is passed directly to the [type-is](https://www.npmjs.com/package/type-is#readme) library and this can be an extension name (like `json`), a mime type (like `application/json`), or a mime type with a wildcard (like `*/*` or `*/json`). If a function, the `type` option is called as `fn(req)` and the request is parsed if it returns a truthy value. | Mixed    | `"application/json"` |
-| `verify`  | This option, if supplied, is called as `verify(req, res, buf, encoding)`, where `buf` is a `Buffer` of the raw request body and `encoding` is the encoding of the request. The parsing can be aborted by throwing an error.                                                                                                                                                                                                                                                                                                    | Function | `undefined`          |
-
-</div>
-
-### express.raw([options])
+<Signature returns="Function">
+  <Fragment slot="attributes">
+    <Param name="inflate" type="Boolean" default="true">
+      Enables or disables handling deflated (compressed) bodies; when disabled, deflated bodies are
+      rejected.
+    </Param>
+    <Param name="limit" type="Number | String" default='"100kb"'>
+      Controls the maximum request body size. If this is a number, then the value specifies the
+      number of bytes; if it is a string, the value is passed to the
+      [bytes](https://www.npmjs.com/package/bytes) library for parsing.
+    </Param>
+    <Param name="type" type="String | String[] | Function" default='"application/octet-stream"'>
+      This is used to determine what media type the middleware will parse. This option can be a
+      string, array of strings, or a function. If not a function, `type` option is passed directly
+      to the [type-is](https://www.npmjs.com/package/type-is#readme) library and this can be an
+      extension name (like `bin`), a mime type (like `application/octet-stream`), or a mime type
+      with a wildcard (like `*/*` or `application/*`). If a function, the `type` option is called as
+      `fn(req)` and the request is parsed if it returns a truthy value.
+    </Param>
+    <Param name="verify" type="Function" default="undefined">
+      This option, if supplied, is called as `verify(req, res, buf, encoding)`, where `buf` is a
+      `Buffer` of the raw request body and `encoding` is the encoding of the request. The parsing
+      can be aborted by throwing an error.
+    </Param>
+  </Fragment>
+</Signature>
 
 This is a built-in middleware function in Express. It parses incoming request
 payloads into a `Buffer` and is based on
@@ -81,20 +135,23 @@ Testing that `req.body` is a `Buffer` before calling buffer methods is recommend
 
 </Alert>
 
-The following table describes the properties of the optional `options` object.
+### express.Router()
 
-<div class="table-scroller" markdown="1">
-
-| Property  | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | Type     | Default                      |
-| --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ---------------------------- |
-| `inflate` | Enables or disables handling deflated (compressed) bodies; when disabled, deflated bodies are rejected.                                                                                                                                                                                                                                                                                                                                                                                                                                      | Boolean  | `true`                       |
-| `limit`   | Controls the maximum request body size. If this is a number, then the value specifies the number of bytes; if it is a string, the value is passed to the [bytes](https://www.npmjs.com/package/bytes) library for parsing.                                                                                                                                                                                                                                                                                                                   | Mixed    | `"100kb"`                    |
-| `type`    | This is used to determine what media type the middleware will parse. This option can be a string, array of strings, or a function. If not a function, `type` option is passed directly to the [type-is](https://www.npmjs.com/package/type-is#readme) library and this can be an extension name (like `bin`), a mime type (like `application/octet-stream`), or a mime type with a wildcard (like `*/*` or `application/*`). If a function, the `type` option is called as `fn(req)` and the request is parsed if it returns a truthy value. | Mixed    | `"application/octet-stream"` |
-| `verify`  | This option, if supplied, is called as `verify(req, res, buf, encoding)`, where `buf` is a `Buffer` of the raw request body and `encoding` is the encoding of the request. The parsing can be aborted by throwing an error.                                                                                                                                                                                                                                                                                                                  | Function | `undefined`                  |
-
-</div>
-
-### express.Router([options])
+<Signature returns="Router">
+  <Fragment slot="attributes">
+    <Param name="caseSensitive" type="Boolean" default="false">
+      Enable case sensitivity. Disabled by default, treating `/Foo` and `/foo` as the same.
+    </Param>
+    <Param name="mergeParams" type="Boolean" default="false">
+      Preserve the `req.params` values from the parent router. If the parent and the child have
+      conflicting param names, the child's value take precedence.
+    </Param>
+    <Param name="strict" type="Boolean" default="false">
+      Enable strict routing. Disabled by default, `/foo` and `/foo/` are treated the same by the
+      router.
+    </Param>
+  </Fragment>
+</Signature>
 
 Creates a new [router](/api/router/) object.
 
@@ -102,24 +159,74 @@ Creates a new [router](/api/router/) object.
 const router = express.Router([options]);
 ```
 
-The optional `options` parameter specifies the behavior of the router.
-
-<div class="table-scroller" markdown="1">
-
-| Property        | Description                                                                                                                                           | Default                                                                     | Availability |
-| --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- | ------------ |
-| `caseSensitive` | Enable case sensitivity.                                                                                                                              | Disabled by default, treating "/Foo" and "/foo" as the same.                |              |
-| `mergeParams`   | Preserve the `req.params` values from the parent router. If the parent and the child have conflicting param names, the child's value take precedence. | `false`                                                                     | 4.5.0+       |
-| `strict`        | Enable strict routing.                                                                                                                                | Disabled by default, "/foo" and "/foo/" are treated the same by the router. | &nbsp;       |
-
-</div>
-
 You can add middleware and HTTP method routes (such as `get`, `put`, `post`, and
 so on) to `router` just like an application.
 
 For more information, see [Router](/api/router/).
 
-### express.static(root, [options])
+### express.static()
+
+<Signature returns="Function">
+  <Fragment slot="attributes">
+    <Param name="root" type="String">
+      The root directory from which to serve static assets.
+    </Param>
+    <Param name="options" type="Object" optional>
+      Configures how files are served; it accepts the properties below. See also the [example
+      below](#example-of-expressstatic).
+
+      <Fragment slot="properties">
+        <Param name="dotfiles" type="String" default='"ignore"'>
+          Determines how dotfiles (files or directories that begin with a dot ".") are treated. See
+          [dotfiles](#dotfiles) below.
+        </Param>
+        <Param name="etag" type="Boolean" default="true">
+          Enable or disable etag generation. NOTE: `express.static` always sends weak ETags.
+        </Param>
+        <Param name="extensions" type="String[] | Boolean" default="false">
+          Sets file extension fallbacks: If a file is not found, search for files with the specified
+          extensions and serve the first one found. Example: `['html', 'htm']`.
+        </Param>
+        <Param name="fallthrough" type="Boolean" default="true">
+          Let client errors fall-through as unhandled requests, otherwise forward a client error.
+          See [fallthrough](#fallthrough) below.
+        </Param>
+        <Param name="immutable" type="Boolean" default="false">
+          Enable or disable the `immutable` directive in the `Cache-Control` response header. If
+          enabled, the `maxAge` option should also be specified to enable caching. The `immutable`
+          directive will prevent supported clients from making conditional requests during the life
+          of the `maxAge` option to check if the file has changed.
+        </Param>
+        <Param name="index" type="String | Boolean" default='"index.html"'>
+          Sends the specified directory index file. Set to `false` to disable directory indexing.
+        </Param>
+        <Param name="lastModified" type="Boolean" default="true">
+          Set the `Last-Modified` header to the last modified date of the file on the OS.
+        </Param>
+        <Param name="maxAge" type="Number" default="0">
+          Set the max-age property of the Cache-Control header in milliseconds or a string in [ms
+          format](https://www.npmjs.com/package/ms).
+        </Param>
+        <Param name="redirect" type="Boolean" default="true">
+          Redirect to trailing "/" when the pathname is a directory.
+        </Param>
+        <Param name="setHeaders" type="Function">
+          Function for setting HTTP headers to serve with the file. See [setHeaders](#setheaders)
+          below.
+        </Param>
+        <Param name="acceptRanges" type="Boolean" default="true">
+          Enable or disable accepting ranged requests. Disabling this will not send the
+          `Accept-Ranges` header and will ignore the contents of the Range request header.
+        </Param>
+        <Param name="cacheControl" type="Boolean" default="true">
+          Enable or disable setting the `Cache-Control` response header. Disabling this will ignore
+          the immutable and maxAge options.
+        </Param>
+      </Fragment>
+    </Param>
+
+  </Fragment>
+</Signature>
 
 This is a built-in middleware function in Express.
 It serves static files and is based on [serve-static](/resources/middleware/serve-static).
@@ -136,28 +243,6 @@ The `root` argument specifies the root directory from which to serve static asse
 The function determines the file to serve by combining `req.url` with the provided `root` directory.
 When a file is not found, instead of sending a 404 response, it instead calls `next()`
 to move on to the next middleware, allowing for stacking and fall-backs.
-
-The following table describes the properties of the `options` object.
-See also the [example below](#example-of-expressstatic).
-
-<div class="table-scroller" markdown="1">
-
-| Property       | Description                                                                                                                                                                                                                                                                                                                        | Type     | Default      |
-| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------------ |
-| `dotfiles`     | Determines how dotfiles (files or directories that begin with a dot ".") are treated. <br/><br/>See [dotfiles](#dotfiles) below.                                                                                                                                                                                                   | String   | "ignore"     |
-| `etag`         | Enable or disable etag generation <br/><br/>NOTE: `express.static` always sends weak ETags.                                                                                                                                                                                                                                        | Boolean  | `true`       |
-| `extensions`   | Sets file extension fallbacks: If a file is not found, search for files with the specified extensions and serve the first one found. Example: `['html', 'htm']`.                                                                                                                                                                   | Mixed    | `false`      |
-| `fallthrough`  | Let client errors fall-through as unhandled requests, otherwise forward a client error. <br/><br/>See [fallthrough](#fallthrough) below.                                                                                                                                                                                           | Boolean  | `true`       |
-| `immutable`    | Enable or disable the `immutable` directive in the `Cache-Control` response header. If enabled, the `maxAge` option should also be specified to enable caching. The `immutable` directive will prevent supported clients from making conditional requests during the life of the `maxAge` option to check if the file has changed. | Boolean  | `false`      |
-| `index`        | Sends the specified directory index file. Set to `false` to disable directory indexing.                                                                                                                                                                                                                                            | Mixed    | "index.html" |
-| `lastModified` | Set the `Last-Modified` header to the last modified date of the file on the OS.                                                                                                                                                                                                                                                    | Boolean  | `true`       |
-| `maxAge`       | Set the max-age property of the Cache-Control header in milliseconds or a string in [ms format](https://www.npmjs.com/package/ms).                                                                                                                                                                                                 | Number   | 0            |
-| `redirect`     | Redirect to trailing "/" when the pathname is a directory.                                                                                                                                                                                                                                                                         | Boolean  | `true`       |
-| `setHeaders`   | Function for setting HTTP headers to serve with the file. <br/><br/>See [setHeaders](#setheaders) below.                                                                                                                                                                                                                           | Function |              |
-| `acceptRanges` | Enable or disable accepting ranged requests. Disabling this will not send the Accept-Ranges header and will ignore the contents of the Range request header.                                                                                                                                                                       | Boolean  | true         |
-| `cacheControl` | Enable or disable setting the Cache-Control response header. Disabling this will ignore the immutable and maxAge options.                                                                                                                                                                                                          | Boolean  | true         |
-
-</div>
 
 For more information, see [Serving static files in Express](/starter/static-files).
 and [Using middleware - Built-in middleware](/guide/using-middleware/#built-in-middleware).
@@ -219,7 +304,38 @@ const options = {
 app.use(express.static('public', options));
 ```
 
-### express.text([options])
+### express.text()
+
+<Signature returns="Function">
+  <Fragment slot="attributes">
+    <Param name="defaultCharset" type="String" default='"utf-8"'>
+      Specify the default character set for the text content if the charset is not specified in the
+      `Content-Type` header of the request.
+    </Param>
+    <Param name="inflate" type="Boolean" default="true">
+      Enables or disables handling deflated (compressed) bodies; when disabled, deflated bodies are
+      rejected.
+    </Param>
+    <Param name="limit" type="Number | String" default='"100kb"'>
+      Controls the maximum request body size. If this is a number, then the value specifies the
+      number of bytes; if it is a string, the value is passed to the
+      [bytes](https://www.npmjs.com/package/bytes) library for parsing.
+    </Param>
+    <Param name="type" type="String | String[] | Function" default='"text/plain"'>
+      This is used to determine what media type the middleware will parse. This option can be a
+      string, array of strings, or a function. If not a function, `type` option is passed directly
+      to the [type-is](https://www.npmjs.com/package/type-is#readme) library and this can be an
+      extension name (like `txt`), a mime type (like `text/plain`), or a mime type with a wildcard
+      (like `*/*` or `text/*`). If a function, the `type` option is called as `fn(req)` and the
+      request is parsed if it returns a truthy value.
+    </Param>
+    <Param name="verify" type="Function" default="undefined">
+      This option, if supplied, is called as `verify(req, res, buf, encoding)`, where `buf` is a
+      `Buffer` of the raw request body and `encoding` is the encoding of the request. The parsing
+      can be aborted by throwing an error.
+    </Param>
+  </Fragment>
+</Signature>
 
 This is a built-in middleware function in Express. It parses incoming request
 payloads into a string and is based on
@@ -244,21 +360,65 @@ Testing that `req.body` is a string before calling string methods is recommended
 
 </Alert>
 
-The following table describes the properties of the optional `options` object.
+### express.urlencoded()
 
-<div class="table-scroller" markdown="1">
-
-| Property         | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | Type     | Default        |
-| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | -------------- |
-| `defaultCharset` | Specify the default character set for the text content if the charset is not specified in the `Content-Type` header of the request.                                                                                                                                                                                                                                                                                                                                                                                     | String   | `"utf-8"`      |
-| `inflate`        | Enables or disables handling deflated (compressed) bodies; when disabled, deflated bodies are rejected.                                                                                                                                                                                                                                                                                                                                                                                                                 | Boolean  | `true`         |
-| `limit`          | Controls the maximum request body size. If this is a number, then the value specifies the number of bytes; if it is a string, the value is passed to the [bytes](https://www.npmjs.com/package/bytes) library for parsing.                                                                                                                                                                                                                                                                                              | Mixed    | `"100kb"`      |
-| `type`           | This is used to determine what media type the middleware will parse. This option can be a string, array of strings, or a function. If not a function, `type` option is passed directly to the [type-is](https://www.npmjs.com/package/type-is#readme) library and this can be an extension name (like `txt`), a mime type (like `text/plain`), or a mime type with a wildcard (like `*/*` or `text/*`). If a function, the `type` option is called as `fn(req)` and the request is parsed if it returns a truthy value. | Mixed    | `"text/plain"` |
-| `verify`         | This option, if supplied, is called as `verify(req, res, buf, encoding)`, where `buf` is a `Buffer` of the raw request body and `encoding` is the encoding of the request. The parsing can be aborted by throwing an error.                                                                                                                                                                                                                                                                                             | Function | `undefined`    |
-
-</div>
-
-### express.urlencoded([options])
+<Signature returns="Function">
+  <Fragment slot="attributes">
+    <Param name="extended" type="Boolean" default="false">
+      This option allows to choose between parsing the URL-encoded data with the `querystring`
+      library (when `false`) or the `qs` library (when `true`). The "extended" syntax allows for
+      rich objects and arrays to be encoded into the URL-encoded format, allowing for a JSON-like
+      experience with URL-encoded. For more information, please [see the qs
+      library](https://www.npmjs.com/package/qs#readme).
+    </Param>
+    <Param name="inflate" type="Boolean" default="true">
+      Enables or disables handling deflated (compressed) bodies; when disabled, deflated bodies are
+      rejected.
+    </Param>
+    <Param name="limit" type="Number | String" default='"100kb"'>
+      Controls the maximum request body size. If this is a number, then the value specifies the
+      number of bytes; if it is a string, the value is passed to the
+      [bytes](https://www.npmjs.com/package/bytes) library for parsing.
+    </Param>
+    <Param name="parameterLimit" type="Number" default="1000">
+      This option controls the maximum number of parameters that are allowed in the URL-encoded
+      data. If a request contains more parameters than this value, an error will be raised.
+    </Param>
+    <Param
+      name="type"
+      type="String | String[] | Function"
+      default='"application/x-www-form-urlencoded"'
+    >
+      This is used to determine what media type the middleware will parse. This option can be a
+      string, array of strings, or a function. If not a function, `type` option is passed directly
+      to the [type-is](https://www.npmjs.com/package/type-is#readme) library and this can be an
+      extension name (like `urlencoded`), a mime type (like `application/x-www-form-urlencoded`), or
+      a mime type with a wildcard (like `*/x-www-form-urlencoded`). If a function, the `type` option
+      is called as `fn(req)` and the request is parsed if it returns a truthy value.
+    </Param>
+    <Param name="verify" type="Function" default="undefined">
+      This option, if supplied, is called as `verify(req, res, buf, encoding)`, where `buf` is a
+      `Buffer` of the raw request body and `encoding` is the encoding of the request. The parsing
+      can be aborted by throwing an error.
+    </Param>
+    <Param name="defaultCharset" type="String" default='"utf-8"'>
+      The default charset to parse as, if not specified in content-type. Must be either `utf-8` or
+      `iso-8859-1`.
+    </Param>
+    <Param name="charsetSentinel" type="Boolean" default="false">
+      Whether to let the value of the `utf8` parameter take precedence as the charset selector. It
+      requires the form to contain a parameter named `utf8` with a value of `✓`.
+    </Param>
+    <Param name="interpretNumericEntities" type="Boolean" default="false">
+      Whether to decode numeric entities such as `&#9786;` when parsing an iso-8859-1 form.
+    </Param>
+    <Param name="depth" type="Number" default="32">
+      Configure the maximum depth of the `qs` library when `extended` is `true`. This allows you to
+      limit the amount of keys that are parsed and can be useful to prevent certain types of abuse.
+      It is recommended to keep this value as low as possible.
+    </Param>
+  </Fragment>
+</Signature>
 
 This is a built-in middleware function in Express. It parses incoming requests
 with urlencoded payloads and is based on [body-parser](/resources/middleware/body-parser).
@@ -283,19 +443,3 @@ fail in multiple ways, for example `foo` may not be there or may not be a string
 may not be a function and instead a string or other user-input.
 
 </Alert>
-
-The following table describes the properties of the optional `options` object.
-
-<div class="table-scroller" markdown="1">
-
-| Property         | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | Type     | Default                               |
-| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------------------------------------- |
-| `extended`       | This option allows to choose between parsing the URL-encoded data with the `querystring` library (when `false`) or the `qs` library (when `true`). The "extended" syntax allows for rich objects and arrays to be encoded into the URL-encoded format, allowing for a JSON-like experience with URL-encoded. For more information, please [see the qs library](https://www.npmjs.com/package/qs#readme).                                                                                                                                                      | Boolean  | `false`                               |
-| `inflate`        | Enables or disables handling deflated (compressed) bodies; when disabled, deflated bodies are rejected.                                                                                                                                                                                                                                                                                                                                                                                                                                                       | Boolean  | `true`                                |
-| `limit`          | Controls the maximum request body size. If this is a number, then the value specifies the number of bytes; if it is a string, the value is passed to the [bytes](https://www.npmjs.com/package/bytes) library for parsing.                                                                                                                                                                                                                                                                                                                                    | Mixed    | `"100kb"`                             |
-| `parameterLimit` | This option controls the maximum number of parameters that are allowed in the URL-encoded data. If a request contains more parameters than this value, an error will be raised.                                                                                                                                                                                                                                                                                                                                                                               | Number   | `1000`                                |
-| `type`           | This is used to determine what media type the middleware will parse. This option can be a string, array of strings, or a function. If not a function, `type` option is passed directly to the [type-is](https://www.npmjs.com/package/type-is#readme) library and this can be an extension name (like `urlencoded`), a mime type (like `application/x-www-form-urlencoded`), or a mime type with a wildcard (like `*/x-www-form-urlencoded`). If a function, the `type` option is called as `fn(req)` and the request is parsed if it returns a truthy value. | Mixed    | `"application/x-www-form-urlencoded"` |
-| `verify`         | This option, if supplied, is called as `verify(req, res, buf, encoding)`, where `buf` is a `Buffer` of the raw request body and `encoding` is the encoding of the request. The parsing can be aborted by throwing an error.                                                                                                                                                                                                                                                                                                                                   | Function | `undefined`                           |
-| `depth`          | Configure the maximum depth of the `qs` library when `extended` is `true`. This allows you to limit the amount of keys that are parsed and can be useful to prevent certain types of abuse. Defaults to `32`. It is recommended to keep this value as low as possible.                                                                                                                                                                                                                                                                                        | Number   | `32`                                  |
-
-</div>

--- a/src/content/api/5x/api/express/index.mdx
+++ b/src/content/api/5x/api/express/index.mdx
@@ -22,41 +22,48 @@ The Express object has the following methods that can be used to create middlewa
 
 <Signature returns="Function">
   <Fragment slot="attributes">
-    <Param name="defaultCharset" type="String" default='"utf-8"'>
-      Specify the default character set for the JSON content if the charset is not specified in the
-      `Content-Type` header of the request.
+    <Param name="options" type="Object" optional>
+      Configures how the JSON body is parsed; it accepts the properties below.
+
+      <Fragment slot="properties">
+        <Param name="defaultCharset" type="String" default='"utf-8"'>
+          Specify the default character set for the JSON content if the charset is not specified in
+          the `Content-Type` header of the request.
+        </Param>
+        <Param name="inflate" type="Boolean" default="true">
+          Enables or disables handling deflated (compressed) bodies; when disabled, deflated bodies
+          are rejected.
+        </Param>
+        <Param name="limit" type="Number | String" default='"100kb"'>
+          Controls the maximum request body size. If this is a number, then the value specifies the
+          number of bytes; if it is a string, the value is passed to the
+          [bytes](https://www.npmjs.com/package/bytes) library for parsing.
+        </Param>
+        <Param name="reviver" type="Function" default="null">
+          The `reviver` option is passed directly to `JSON.parse` as the second argument. You can
+          find more information on this argument [in the MDN documentation about
+          JSON.parse](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse#the_reviver_parameter).
+        </Param>
+        <Param name="strict" type="Boolean" default="true">
+          Enables or disables only accepting arrays and objects; when disabled will accept anything
+          `JSON.parse` accepts.
+        </Param>
+        <Param name="type" type="String | String[] | Function" default='"application/json"'>
+          This is used to determine what media type the middleware will parse. This option can be a
+          string, array of strings, or a function. If not a function, `type` option is passed
+          directly to the [type-is](https://www.npmjs.com/package/type-is#readme) library and this
+          can be an extension name (like `json`), a mime type (like `application/json`), or a mime
+          type with a wildcard (like `*/*` or `*/json`). If a function, the `type` option is called
+          as `fn(req)` and the request is parsed if it returns a truthy value.
+        </Param>
+        <Param name="verify" type="Function" default="undefined">
+          This option, if supplied, is called as `verify(req, res, buf, encoding)`, where `buf` is a
+          `Buffer` of the raw request body and `encoding` is the encoding of the request. The
+          parsing can be aborted by throwing an error.
+        </Param>
+      </Fragment>
     </Param>
-    <Param name="inflate" type="Boolean" default="true">
-      Enables or disables handling deflated (compressed) bodies; when disabled, deflated bodies are
-      rejected.
-    </Param>
-    <Param name="limit" type="Number | String" default='"100kb"'>
-      Controls the maximum request body size. If this is a number, then the value specifies the
-      number of bytes; if it is a string, the value is passed to the
-      [bytes](https://www.npmjs.com/package/bytes) library for parsing.
-    </Param>
-    <Param name="reviver" type="Function" default="null">
-      The `reviver` option is passed directly to `JSON.parse` as the second argument. You can find
-      more information on this argument [in the MDN documentation about
-      JSON.parse](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse#the_reviver_parameter).
-    </Param>
-    <Param name="strict" type="Boolean" default="true">
-      Enables or disables only accepting arrays and objects; when disabled will accept anything
-      `JSON.parse` accepts.
-    </Param>
-    <Param name="type" type="String | String[] | Function" default='"application/json"'>
-      This is used to determine what media type the middleware will parse. This option can be a
-      string, array of strings, or a function. If not a function, `type` option is passed directly
-      to the [type-is](https://www.npmjs.com/package/type-is#readme) library and this can be an
-      extension name (like `json`), a mime type (like `application/json`), or a mime type with a
-      wildcard (like `*/*` or `*/json`). If a function, the `type` option is called as `fn(req)` and
-      the request is parsed if it returns a truthy value.
-    </Param>
-    <Param name="verify" type="Function" default="undefined">
-      This option, if supplied, is called as `verify(req, res, buf, encoding)`, where `buf` is a
-      `Buffer` of the raw request body and `encoding` is the encoding of the request. The parsing
-      can be aborted by throwing an error.
-    </Param>
+
   </Fragment>
 </Signature>
 
@@ -87,28 +94,35 @@ may not be a function and instead a string or other user-input.
 
 <Signature returns="Function">
   <Fragment slot="attributes">
-    <Param name="inflate" type="Boolean" default="true">
-      Enables or disables handling deflated (compressed) bodies; when disabled, deflated bodies are
-      rejected.
+    <Param name="options" type="Object" optional>
+      Configures how the request body is parsed; it accepts the properties below.
+
+      <Fragment slot="properties">
+        <Param name="inflate" type="Boolean" default="true">
+          Enables or disables handling deflated (compressed) bodies; when disabled, deflated bodies
+          are rejected.
+        </Param>
+        <Param name="limit" type="Number | String" default='"100kb"'>
+          Controls the maximum request body size. If this is a number, then the value specifies the
+          number of bytes; if it is a string, the value is passed to the
+          [bytes](https://www.npmjs.com/package/bytes) library for parsing.
+        </Param>
+        <Param name="type" type="String | String[] | Function" default='"application/octet-stream"'>
+          This is used to determine what media type the middleware will parse. This option can be a
+          string, array of strings, or a function. If not a function, `type` option is passed
+          directly to the [type-is](https://www.npmjs.com/package/type-is#readme) library and this
+          can be an extension name (like `bin`), a mime type (like `application/octet-stream`), or a
+          mime type with a wildcard (like `*/*` or `application/*`). If a function, the `type`
+          option is called as `fn(req)` and the request is parsed if it returns a truthy value.
+        </Param>
+        <Param name="verify" type="Function" default="undefined">
+          This option, if supplied, is called as `verify(req, res, buf, encoding)`, where `buf` is a
+          `Buffer` of the raw request body and `encoding` is the encoding of the request. The
+          parsing can be aborted by throwing an error.
+        </Param>
+      </Fragment>
     </Param>
-    <Param name="limit" type="Number | String" default='"100kb"'>
-      Controls the maximum request body size. If this is a number, then the value specifies the
-      number of bytes; if it is a string, the value is passed to the
-      [bytes](https://www.npmjs.com/package/bytes) library for parsing.
-    </Param>
-    <Param name="type" type="String | String[] | Function" default='"application/octet-stream"'>
-      This is used to determine what media type the middleware will parse. This option can be a
-      string, array of strings, or a function. If not a function, `type` option is passed directly
-      to the [type-is](https://www.npmjs.com/package/type-is#readme) library and this can be an
-      extension name (like `bin`), a mime type (like `application/octet-stream`), or a mime type
-      with a wildcard (like `*/*` or `application/*`). If a function, the `type` option is called as
-      `fn(req)` and the request is parsed if it returns a truthy value.
-    </Param>
-    <Param name="verify" type="Function" default="undefined">
-      This option, if supplied, is called as `verify(req, res, buf, encoding)`, where `buf` is a
-      `Buffer` of the raw request body and `encoding` is the encoding of the request. The parsing
-      can be aborted by throwing an error.
-    </Param>
+
   </Fragment>
 </Signature>
 
@@ -308,32 +322,39 @@ app.use(express.static('public', options));
 
 <Signature returns="Function">
   <Fragment slot="attributes">
-    <Param name="defaultCharset" type="String" default='"utf-8"'>
-      Specify the default character set for the text content if the charset is not specified in the
-      `Content-Type` header of the request.
+    <Param name="options" type="Object" optional>
+      Configures how the text body is parsed; it accepts the properties below.
+
+      <Fragment slot="properties">
+        <Param name="defaultCharset" type="String" default='"utf-8"'>
+          Specify the default character set for the text content if the charset is not specified in
+          the `Content-Type` header of the request.
+        </Param>
+        <Param name="inflate" type="Boolean" default="true">
+          Enables or disables handling deflated (compressed) bodies; when disabled, deflated bodies
+          are rejected.
+        </Param>
+        <Param name="limit" type="Number | String" default='"100kb"'>
+          Controls the maximum request body size. If this is a number, then the value specifies the
+          number of bytes; if it is a string, the value is passed to the
+          [bytes](https://www.npmjs.com/package/bytes) library for parsing.
+        </Param>
+        <Param name="type" type="String | String[] | Function" default='"text/plain"'>
+          This is used to determine what media type the middleware will parse. This option can be a
+          string, array of strings, or a function. If not a function, `type` option is passed
+          directly to the [type-is](https://www.npmjs.com/package/type-is#readme) library and this
+          can be an extension name (like `txt`), a mime type (like `text/plain`), or a mime type
+          with a wildcard (like `*/*` or `text/*`). If a function, the `type` option is called as
+          `fn(req)` and the request is parsed if it returns a truthy value.
+        </Param>
+        <Param name="verify" type="Function" default="undefined">
+          This option, if supplied, is called as `verify(req, res, buf, encoding)`, where `buf` is a
+          `Buffer` of the raw request body and `encoding` is the encoding of the request. The
+          parsing can be aborted by throwing an error.
+        </Param>
+      </Fragment>
     </Param>
-    <Param name="inflate" type="Boolean" default="true">
-      Enables or disables handling deflated (compressed) bodies; when disabled, deflated bodies are
-      rejected.
-    </Param>
-    <Param name="limit" type="Number | String" default='"100kb"'>
-      Controls the maximum request body size. If this is a number, then the value specifies the
-      number of bytes; if it is a string, the value is passed to the
-      [bytes](https://www.npmjs.com/package/bytes) library for parsing.
-    </Param>
-    <Param name="type" type="String | String[] | Function" default='"text/plain"'>
-      This is used to determine what media type the middleware will parse. This option can be a
-      string, array of strings, or a function. If not a function, `type` option is passed directly
-      to the [type-is](https://www.npmjs.com/package/type-is#readme) library and this can be an
-      extension name (like `txt`), a mime type (like `text/plain`), or a mime type with a wildcard
-      (like `*/*` or `text/*`). If a function, the `type` option is called as `fn(req)` and the
-      request is parsed if it returns a truthy value.
-    </Param>
-    <Param name="verify" type="Function" default="undefined">
-      This option, if supplied, is called as `verify(req, res, buf, encoding)`, where `buf` is a
-      `Buffer` of the raw request body and `encoding` is the encoding of the request. The parsing
-      can be aborted by throwing an error.
-    </Param>
+
   </Fragment>
 </Signature>
 
@@ -364,59 +385,63 @@ Testing that `req.body` is a string before calling string methods is recommended
 
 <Signature returns="Function">
   <Fragment slot="attributes">
-    <Param name="extended" type="Boolean" default="false">
-      This option allows to choose between parsing the URL-encoded data with the `querystring`
-      library (when `false`) or the `qs` library (when `true`). The "extended" syntax allows for
-      rich objects and arrays to be encoded into the URL-encoded format, allowing for a JSON-like
-      experience with URL-encoded. For more information, please [see the qs
-      library](https://www.npmjs.com/package/qs#readme).
+    <Param name="options" type="Object" optional>
+      Configures how the URL-encoded body is parsed; it accepts the properties below.
+
+      <Fragment slot="properties">
+        <Param name="extended" type="Boolean" default="false">
+          This option allows to choose between parsing the URL-encoded data with the `querystring`
+          library (when `false`) or the `qs` library (when `true`). The "extended" syntax allows for
+          rich objects and arrays to be encoded into the URL-encoded format, allowing for a
+          JSON-like experience with URL-encoded. For more information, please [see the qs
+          library](https://www.npmjs.com/package/qs#readme).
+        </Param>
+        <Param name="inflate" type="Boolean" default="true">
+          Enables or disables handling deflated (compressed) bodies; when disabled, deflated bodies
+          are rejected.
+        </Param>
+        <Param name="limit" type="Number | String" default='"100kb"'>
+          Controls the maximum request body size. If this is a number, then the value specifies the
+          number of bytes; if it is a string, the value is passed to the
+          [bytes](https://www.npmjs.com/package/bytes) library for parsing.
+        </Param>
+        <Param name="parameterLimit" type="Number" default="1000">
+          This option controls the maximum number of parameters that are allowed in the URL-encoded
+          data. If a request contains more parameters than this value, an error will be raised.
+        </Param>
+        <Param name="type" type="String | String[] | Function" default='"application/x-www-form-urlencoded"'>
+          This is used to determine what media type the middleware will parse. This option can be a
+          string, array of strings, or a function. If not a function, `type` option is passed
+          directly to the [type-is](https://www.npmjs.com/package/type-is#readme) library and this
+          can be an extension name (like `urlencoded`), a mime type (like
+          `application/x-www-form-urlencoded`), or a mime type with a wildcard (like
+          `*/x-www-form-urlencoded`). If a function, the `type` option is called as `fn(req)` and
+          the request is parsed if it returns a truthy value.
+        </Param>
+        <Param name="verify" type="Function" default="undefined">
+          This option, if supplied, is called as `verify(req, res, buf, encoding)`, where `buf` is a
+          `Buffer` of the raw request body and `encoding` is the encoding of the request. The
+          parsing can be aborted by throwing an error.
+        </Param>
+        <Param name="defaultCharset" type="String" default='"utf-8"'>
+          The default charset to parse as, if not specified in content-type. Must be either `utf-8`
+          or `iso-8859-1`.
+        </Param>
+        <Param name="charsetSentinel" type="Boolean" default="false">
+          Whether to let the value of the `utf8` parameter take precedence as the charset selector.
+          It requires the form to contain a parameter named `utf8` with a value of `✓`.
+        </Param>
+        <Param name="interpretNumericEntities" type="Boolean" default="false">
+          Whether to decode numeric entities such as `&#9786;` when parsing an iso-8859-1 form.
+        </Param>
+        <Param name="depth" type="Number" default="32">
+          Configure the maximum depth of the `qs` library when `extended` is `true`. This allows you
+          to limit the amount of keys that are parsed and can be useful to prevent certain types of
+          abuse. It is recommended to keep this value as low as possible.
+        </Param>
+      </Fragment>
     </Param>
-    <Param name="inflate" type="Boolean" default="true">
-      Enables or disables handling deflated (compressed) bodies; when disabled, deflated bodies are
-      rejected.
-    </Param>
-    <Param name="limit" type="Number | String" default='"100kb"'>
-      Controls the maximum request body size. If this is a number, then the value specifies the
-      number of bytes; if it is a string, the value is passed to the
-      [bytes](https://www.npmjs.com/package/bytes) library for parsing.
-    </Param>
-    <Param name="parameterLimit" type="Number" default="1000">
-      This option controls the maximum number of parameters that are allowed in the URL-encoded
-      data. If a request contains more parameters than this value, an error will be raised.
-    </Param>
-    <Param
-      name="type"
-      type="String | String[] | Function"
-      default='"application/x-www-form-urlencoded"'
-    >
-      This is used to determine what media type the middleware will parse. This option can be a
-      string, array of strings, or a function. If not a function, `type` option is passed directly
-      to the [type-is](https://www.npmjs.com/package/type-is#readme) library and this can be an
-      extension name (like `urlencoded`), a mime type (like `application/x-www-form-urlencoded`), or
-      a mime type with a wildcard (like `*/x-www-form-urlencoded`). If a function, the `type` option
-      is called as `fn(req)` and the request is parsed if it returns a truthy value.
-    </Param>
-    <Param name="verify" type="Function" default="undefined">
-      This option, if supplied, is called as `verify(req, res, buf, encoding)`, where `buf` is a
-      `Buffer` of the raw request body and `encoding` is the encoding of the request. The parsing
-      can be aborted by throwing an error.
-    </Param>
-    <Param name="defaultCharset" type="String" default='"utf-8"'>
-      The default charset to parse as, if not specified in content-type. Must be either `utf-8` or
-      `iso-8859-1`.
-    </Param>
-    <Param name="charsetSentinel" type="Boolean" default="false">
-      Whether to let the value of the `utf8` parameter take precedence as the charset selector. It
-      requires the form to contain a parameter named `utf8` with a value of `✓`.
-    </Param>
-    <Param name="interpretNumericEntities" type="Boolean" default="false">
-      Whether to decode numeric entities such as `&#9786;` when parsing an iso-8859-1 form.
-    </Param>
-    <Param name="depth" type="Number" default="32">
-      Configure the maximum depth of the `qs` library when `extended` is `true`. This allows you to
-      limit the amount of keys that are parsed and can be useful to prevent certain types of abuse.
-      It is recommended to keep this value as low as possible.
-    </Param>
+
   </Fragment>
 </Signature>
 

--- a/src/content/api/5x/api/request/index.mdx
+++ b/src/content/api/5x/api/request/index.mdx
@@ -4,6 +4,8 @@ description: The request object represents the HTTP request and has properties f
 ---
 
 import Alert from '@components/primitives/Alert/Alert.astro';
+import Signature from '@components/patterns/Signature/Signature.astro';
+import Param from '@components/patterns/Signature/Param.astro';
 
 The `req` object represents the HTTP request and has properties for the
 request query string, parameters, body, HTTP headers, and so on. In this documentation and by convention,
@@ -35,6 +37,8 @@ The `req` object contains a number of properties that provide information about 
 
 ### req.app
 
+<Signature type="Application" />
+
 This property holds a reference to the instance of the Express application that is using the middleware.
 
 If you follow the pattern in which you create a module that just exports a middleware function
@@ -55,6 +59,8 @@ module.exports = (req, res) => {
 ```
 
 ### req.baseUrl
+
+<Signature type="String" />
 
 The URL path on which a router instance was mounted.
 
@@ -87,6 +93,8 @@ made to `/hello/jp`, `req.baseUrl` is "/hello".
 
 ### req.body
 
+<Signature type="Object" />
+
 Contains key-value pairs of data submitted in the request body.
 By default, it is `undefined`, and is populated when you use body-parsing middleware such
 as [`express.json()`](/api/express/#expressjson) or [`express.urlencoded()`](/api/express/#expressurlencoded).
@@ -118,6 +126,8 @@ app.post('/profile', (req, res, next) => {
 
 ### req.cookies
 
+<Signature type="Object" />
+
 When using [cookie-parser](https://www.npmjs.com/package/cookie-parser) middleware, this property is an object that
 contains cookies sent by the request. If the request contains no cookies, it defaults to `{}`.
 
@@ -133,6 +143,8 @@ For more information, issues, or concerns, see [cookie-parser](https://github.co
 
 ### req.fresh
 
+<Signature type="Boolean" />
+
 When the response is still "fresh" in the client's cache `true` is returned, otherwise `false` is returned to indicate that the client cache is now stale and the full response should be sent.
 
 When a client sends the `Cache-Control: no-cache` request header to indicate an end-to-end reload request, this module will return `false` to make handling these requests transparent.
@@ -146,6 +158,8 @@ console.dir(req.fresh);
 ```
 
 ### req.host
+
+<Signature type="String" />
 
 Contains the host derived from the `Host` HTTP header.
 
@@ -170,6 +184,8 @@ console.dir(req.host);
 
 ### req.hostname
 
+<Signature type="String" />
+
 Contains the hostname derived from the `Host` HTTP header.
 
 When the [`trust proxy` setting](/api/application/#options-for-trust-proxy-setting)
@@ -189,6 +205,8 @@ console.dir(req.hostname);
 
 ### req.ip
 
+<Signature type="String" />
+
 Contains the remote IP address of the request.
 
 When the [`trust proxy` setting](/api/application/#options-for-trust-proxy-setting) does not evaluate to `false`,
@@ -202,6 +220,8 @@ console.dir(req.ip);
 
 ### req.ips
 
+<Signature type="String[]" />
+
 When the [`trust proxy` setting](/api/application/#options-for-trust-proxy-setting) does not evaluate to `false`,
 this property contains an array of IP addresses
 specified in the `X-Forwarded-For` request header. Otherwise, it contains an
@@ -212,10 +232,14 @@ For example, if `X-Forwarded-For` is `client, proxy1, proxy2`, `req.ips` would b
 
 ### req.method
 
+<Signature type="String" />
+
 Contains a string corresponding to the HTTP method of the request:
 `GET`, `POST`, `PUT`, and so on.
 
 ### req.originalUrl
+
+<Signature type="String" />
 
 <Alert type="alert">
 
@@ -248,6 +272,8 @@ app.use('/admin', (req, res, next) => {
 ```
 
 ### req.params
+
+<Signature type="Object" />
 
 This property is an object containing properties mapped to the [named route "parameters"](/guide/routing/#route-parameters). For example, if you have the route `/user/:name`, then the "name" property is available as `req.params.name`. This object defaults to `Object.create(null)` when using string paths, but remains a standard object with a normal prototype when the path is defined with a regular expression.
 
@@ -293,6 +319,8 @@ Express automatically decodes the values in `req.params` (using `decodeURICompon
 
 ### req.path
 
+<Signature type="String" />
+
 Contains the path part of the request URL.
 
 ```js
@@ -310,6 +338,8 @@ When called from a middleware, the mount point is not included in `req.path`. Se
 
 ### req.protocol
 
+<Signature type="String" />
+
 Contains the request protocol string: either `http` or (for TLS requests) `https`.
 
 When the [`trust proxy` setting](/api/application/#options-for-trust-proxy-setting) does not evaluate to `false`,
@@ -322,6 +352,8 @@ console.dir(req.protocol);
 ```
 
 ### req.query
+
+<Signature type="Object" />
 
 This property is an object containing a property for each query string parameter in the route.
 When [query parser](/api/application/#application-settings) is set to disabled, it is an empty object `{}`, otherwise it is the result of the configured query parser.
@@ -350,12 +382,16 @@ Check out the [query parser application setting](/api/application/#application-s
 
 ### req.res
 
+<Signature type="Response" />
+
 This property holds a reference to the [response object](/api/response)
 that relates to this request object.
 
 ### req.route
 
-Contains the currently-matched route, a string. For example:
+<Signature type="Route" />
+
+Contains the currently-matched route (a `Route` object). For example:
 
 ```js
 app.get('/user/{:id}', (req, res) => {
@@ -387,6 +423,8 @@ Route {
 
 ### req.secure
 
+<Signature type="Boolean" />
+
 A Boolean property that is true if a TLS connection is established. Equivalent to the following:
 
 {/* <!-- eslint-disable no-unused-expressions --> */}
@@ -396,6 +434,8 @@ req.protocol === 'https';
 ```
 
 ### req.signedCookies
+
+<Signature type="Object" />
 
 When using [cookie-parser](https://www.npmjs.com/package/cookie-parser) middleware, this property
 contains signed cookies sent by the request, unsigned and ready for use. Signed cookies reside
@@ -415,6 +455,8 @@ For more information, issues, or concerns, see [cookie-parser](https://github.co
 
 ### req.stale
 
+<Signature type="Boolean" />
+
 Indicates whether the request is "stale," and is the opposite of `req.fresh`.
 For more information, see [req.fresh](#reqfresh).
 
@@ -424,6 +466,8 @@ console.dir(req.stale);
 ```
 
 ### req.subdomains
+
+<Signature type="String[]" />
 
 An array of subdomains in the domain name of the request.
 
@@ -439,6 +483,8 @@ using [app.set](/api/application/#appset).
 
 ### req.xhr
 
+<Signature type="Boolean" />
+
 A Boolean property that is `true` if the request's `X-Requested-With` header field is
 "XMLHttpRequest", indicating that the request was issued by a client library such as jQuery.
 
@@ -451,7 +497,16 @@ console.dir(req.xhr);
 
 The `req` object also contains a number of methods that can be used to perform various tasks related to the HTTP request, such as checking the content type, retrieving header values, and more.
 
-### req.accepts(types)
+### req.accepts()
+
+<Signature returns="String | false">
+  <Fragment slot="attributes">
+    <Param name="types" type="String | String[]">
+      The content type(s) to check: a MIME type (such as `application/json`), an extension name
+      (such as `json`), a comma-delimited list, or an array.
+    </Param>
+  </Fragment>
+</Signature>
 
 Checks if the specified content types are acceptable, based on the request's `Accept` HTTP header field.
 The method returns the best match, or if none of the specified content types is acceptable, returns
@@ -488,7 +543,15 @@ req.accepts(['html', 'json']);
 
 For more information, or if you have issues or concerns, see [accepts](https://github.com/expressjs/accepts).
 
-### req.acceptsCharsets(charset [, ...])
+### req.acceptsCharsets()
+
+<Signature returns="String | false">
+  <Fragment slot="attributes">
+    <Param name="charset" type="String | String[]">
+      One or more character sets to test against the request's `Accept-Charset` header.
+    </Param>
+  </Fragment>
+</Signature>
 
 Returns the first accepted charset of the specified character sets,
 based on the request's `Accept-Charset` HTTP header field.
@@ -496,7 +559,15 @@ If none of the specified charsets is accepted, returns `false`.
 
 For more information, or if you have issues or concerns, see [accepts](https://github.com/expressjs/accepts).
 
-### req.acceptsEncodings(encoding [, ...])
+### req.acceptsEncodings()
+
+<Signature returns="String | false">
+  <Fragment slot="attributes">
+    <Param name="encoding" type="String | String[]">
+      One or more encodings to test against the request's `Accept-Encoding` header.
+    </Param>
+  </Fragment>
+</Signature>
 
 Returns the first accepted encoding of the specified encodings,
 based on the request's `Accept-Encoding` HTTP header field.
@@ -504,7 +575,16 @@ If none of the specified encodings is accepted, returns `false`.
 
 For more information, or if you have issues or concerns, see [accepts](https://github.com/expressjs/accepts).
 
-### req.acceptsLanguages([lang, ...])
+### req.acceptsLanguages()
+
+<Signature returns="String | String[] | false">
+  <Fragment slot="attributes">
+    <Param name="lang" type="String | String[]" optional>
+      One or more languages to test against the request's `Accept-Language` header. If omitted, all
+      accepted languages are returned as an array.
+    </Param>
+  </Fragment>
+</Signature>
 
 Returns the first accepted language of the specified languages,
 based on the request's `Accept-Language` HTTP header field.
@@ -520,7 +600,16 @@ Express (5.x) source: [request.js line 172](https://github.com/expressjs/express
 
 Accepts (2.0) source: [index.js line 195](https://github.com/jshttp/accepts/blob/2.0.0/index.js#L195)
 
-### req.get(field)
+### req.get()
+
+<Signature returns="String | undefined">
+  <Fragment slot="attributes">
+    <Param name="field" type="String">
+      The name of the HTTP request header to read (case-insensitive). `Referrer` and `Referer` are
+      interchangeable.
+    </Param>
+  </Fragment>
+</Signature>
 
 Returns the specified HTTP request header field (case-insensitive match).
 The `Referrer` and `Referer` fields are interchangeable.
@@ -538,7 +627,15 @@ req.get('Something');
 
 Aliased as `req.header(field)`.
 
-### req.is(type)
+### req.is()
+
+<Signature returns="String | false | null">
+  <Fragment slot="attributes">
+    <Param name="type" type="String | String[]">
+      The MIME type(s) or extension name(s) to match against the request's `Content-Type` header.
+    </Param>
+  </Fragment>
+</Signature>
 
 Returns the matching content type if the incoming request's "Content-Type" HTTP header field
 matches the MIME type specified by the `type` parameter. If the request has no body, returns `null`.
@@ -570,21 +667,28 @@ req.is('xml', 'yaml'); // => false
 
 For more information, or if you have issues or concerns, see [type-is](https://github.com/expressjs/type-is).
 
-### req.range(size[, options])
+### req.range()
+
+<Signature returns="Array | Number">
+  <Fragment slot="attributes">
+    <Param name="size" type="Number">
+      The maximum size of the resource.
+    </Param>
+    <Param name="options" type="Object" optional>
+      Options for parsing the `Range` header.
+
+      <Fragment slot="properties">
+        <Param name="combine" type="Boolean" default="false">
+          Specify if overlapping and adjacent ranges should be combined. When `true`, ranges are
+          combined and returned as if they were specified that way in the header.
+        </Param>
+      </Fragment>
+    </Param>
+
+  </Fragment>
+</Signature>
 
 `Range` header parser.
-
-The `size` parameter is the maximum size of the resource.
-
-The `options` parameter is an object that can have the following properties.
-
-<div class="table-scroller" markdown="1">
-
-| Property  | Type    | Description                                                                                                                                                                           |
-| --------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `combine` | Boolean | Specify if overlapping & adjacent ranges should be combined, defaults to `false`. When `true`, ranges will be combined and returned as if they were specified that way in the header. |
-
-</div>
 
 An array of ranges will be returned or negative numbers indicating an error parsing.
 

--- a/src/content/api/5x/api/request/index.mdx
+++ b/src/content/api/5x/api/request/index.mdx
@@ -89,7 +89,7 @@ made to `/hello/jp`, `req.baseUrl` is "/hello".
 
 Contains key-value pairs of data submitted in the request body.
 By default, it is `undefined`, and is populated when you use body-parsing middleware such
-as [`express.json()`](/api/express/#expressjsonoptions) or [`express.urlencoded()`](/api/express/#expressurlencodedoptions).
+as [`express.json()`](/api/express/#expressjson) or [`express.urlencoded()`](/api/express/#expressurlencoded).
 
 <Alert type="warning">
 
@@ -226,7 +226,7 @@ module](https://nodejs.org/api/http.html#http_message_url).
 
 This property is much like `req.url`; however, it retains the original request URL,
 allowing you to rewrite `req.url` freely for internal routing purposes. For example,
-the "mounting" feature of [app.use()](/api/application/#appusepath-callback--callback) will rewrite `req.url` to strip the mount point.
+the "mounting" feature of [app.use()](/api/application/#appuse) will rewrite `req.url` to strip the mount point.
 
 ```js
 // GET /search?q=something
@@ -281,7 +281,7 @@ app.use(/^\/file\/(.*)$/, (req, res) => {
 
 Named capturing groups in regular expressions behave like named route parameters. For example the group from `/^\/file\/(?<path>.*)$/` expression is available as `req.params.path`.
 
-If you need to make changes to a key in `req.params`, use the [app.param](/api/application/#appparamname-callback) handler. Changes are applicable only to [parameters](/guide/routing/#route-parameters) already defined in the route path.
+If you need to make changes to a key in `req.params`, use the [app.param](/api/application/#appparam) handler. Changes are applicable only to [parameters](/guide/routing/#route-parameters) already defined in the route path.
 
 Any changes made to the `req.params` object in a middleware or route handler will be reset.
 
@@ -304,7 +304,7 @@ console.dir(req.path);
 <Alert type="info">
 
 When called from a middleware, the mount point is not included in `req.path`. See
-[app.use()](/api/application/#appusepath-callback--callback) for more details.
+[app.use()](/api/application/#appuse) for more details.
 
 </Alert>
 
@@ -435,7 +435,7 @@ console.dir(req.subdomains);
 
 The application property `subdomain offset`, which defaults to 2, is used for determining the
 beginning of the subdomain segments. To change this behavior, change its value
-using [app.set](/api/application/#appsetname-value).
+using [app.set](/api/application/#appset).
 
 ### req.xhr
 

--- a/src/content/api/5x/api/response/index.mdx
+++ b/src/content/api/5x/api/response/index.mdx
@@ -4,6 +4,8 @@ description: The response object represents the HTTP response that an Express ap
 ---
 
 import Alert from '@components/primitives/Alert/Alert.astro';
+import Signature from '@components/patterns/Signature/Signature.astro';
+import Param from '@components/patterns/Signature/Param.astro';
 
 The `res` object represents the HTTP response that an Express app sends when it gets an HTTP request.
 
@@ -34,11 +36,15 @@ and supports all [built-in fields and methods](https://nodejs.org/api/http.html#
 
 ### res.app
 
+<Signature type="Application" />
+
 This property holds a reference to the instance of the Express application that is using the middleware.
 
 `res.app` is identical to the [req.app](/api/request/#reqapp) property in the request object.
 
 ### res.headersSent
+
+<Signature type="Boolean" />
 
 Boolean property that indicates if the app sent HTTP headers for the response.
 
@@ -52,7 +58,9 @@ app.get('/', (req, res) => {
 
 ### res.locals
 
-Use this property to set variables accessible in templates rendered with [res.render](#resrenderview--locals--callback).
+<Signature type="Object" />
+
+Use this property to set variables accessible in templates rendered with [res.render](#resrender).
 The variables set on `res.locals` are available within a single request-response cycle, and will not
 be shared between requests.
 
@@ -82,12 +90,25 @@ app.use((req, res, next) => {
 
 ### res.req
 
+<Signature type="Request" />
+
 This property holds a reference to the [request object](/api/request/)
 that relates to this response object.
 
 ## Methods
 
-### res.append(field [, value])
+### res.append()
+
+<Signature returns="Response">
+  <Fragment slot="attributes">
+    <Param name="field" type="String">
+      The name of the HTTP response header to append to.
+    </Param>
+    <Param name="value" type="String | String[]" optional>
+      The value(s) to append to the header.
+    </Param>
+  </Fragment>
+</Signature>
 
 Appends the specified `value` to the HTTP response header `field`. If the header is not already set,
 it creates the header with the specified value. The `value` parameter can be a string or an array.
@@ -104,7 +125,16 @@ res.append('Set-Cookie', 'foo=bar; Path=/; HttpOnly');
 res.append('Warning', '199 Miscellaneous warning');
 ```
 
-### res.attachment([filename])
+### res.attachment()
+
+<Signature returns="Response">
+  <Fragment slot="attributes">
+    <Param name="filename" type="String" optional>
+      The file name used to set the `Content-Disposition` "filename=" parameter and the
+      `Content-Type` (from its extension).
+    </Param>
+  </Fragment>
+</Signature>
 
 Sets the HTTP response `Content-Disposition` header field to "attachment". If a `filename` is given,
 then it sets the `Content-Type` based on the extension name via `res.type()`,
@@ -119,18 +149,30 @@ res.attachment('path/to/logo.png');
 // Content-Type: image/png
 ```
 
-### res.clearCookie(name [, options])
+### res.clearCookie()
+
+<Signature returns="Response">
+  <Fragment slot="attributes">
+    <Param name="name" type="String">
+      The name of the cookie to clear.
+    </Param>
+    <Param name="options" type="Object" optional>
+      Cookie options, which should match those given to [res.cookie()](#rescookie) (excluding
+      `expires` and `maxAge`).
+    </Param>
+  </Fragment>
+</Signature>
 
 Clears the cookie with the specified `name` by sending a `Set-Cookie` header that sets its expiration date in the past.
 This instructs the client that the cookie has expired and is no longer valid. For more information
-about available `options`, see [res.cookie()](#rescookiename-value--options).
+about available `options`, see [res.cookie()](#rescookie).
 
 <Alert type="alert">The `expires` and `max-age` options are being ignored completely.</Alert>
 
 <Alert type="alert">
 
 Web browsers and other compliant clients will only clear the cookie if the given `options` is
-identical to those given to [res.cookie()](#rescookiename-value--options)
+identical to those given to [res.cookie()](#rescookie)
 
 </Alert>
 
@@ -139,29 +181,60 @@ res.cookie('name', 'tobi', { path: '/admin' });
 res.clearCookie('name', { path: '/admin' });
 ```
 
-### res.cookie(name, value [, options])
+### res.cookie()
+
+<Signature returns="Response">
+  <Fragment slot="attributes">
+    <Param name="name" type="String">
+      The name of the cookie.
+    </Param>
+    <Param name="value" type="String | Object">
+      The cookie value; an object is serialized as JSON.
+    </Param>
+    <Param name="options" type="Object" optional>
+      Options for the `Set-Cookie` header.
+
+      <Fragment slot="properties">
+        <Param name="domain" type="String">
+          Domain name for the cookie. Defaults to the domain name of the app.
+        </Param>
+        <Param name="encode" type="Function">
+          A synchronous function used for cookie value encoding. Defaults to `encodeURIComponent`.
+        </Param>
+        <Param name="expires" type="Date">
+          Expiry date of the cookie in GMT. If not specified or set to `0`, creates a session cookie.
+        </Param>
+        <Param name="httpOnly" type="Boolean">
+          Flags the cookie to be accessible only by the web server.
+        </Param>
+        <Param name="maxAge" type="Number">
+          Convenient option for setting the expiry time relative to the current time in milliseconds.
+        </Param>
+        <Param name="path" type="String" default='"/"'>
+          Path for the cookie. Defaults to "/".
+        </Param>
+        <Param name="partitioned" type="Boolean">
+          Indicates that the cookie should be stored using partitioned storage. See [CHIPS](https://developer.mozilla.org/en-US/docs/Web/Privacy/Guides/Third-party_cookies/Partitioned_cookies) for more details.
+        </Param>
+        <Param name="priority" type="String">
+          Value of the "Priority" **Set-Cookie** attribute.
+        </Param>
+        <Param name="secure" type="Boolean">
+          Marks the cookie to be used with HTTPS only.
+        </Param>
+        <Param name="signed" type="Boolean">
+          Indicates if the cookie should be signed.
+        </Param>
+        <Param name="sameSite" type="Boolean | String">
+          Value of the "SameSite" **Set-Cookie** attribute.
+        </Param>
+      </Fragment>
+    </Param>
+
+  </Fragment>
+</Signature>
 
 Sets cookie `name` to `value`. The `value` parameter may be a string or object converted to JSON.
-
-The `options` parameter is an object that can have the following properties.
-
-<div class="table-scroller" markdown="1">
-
-| Property      | Type              | Description                                                                                                                                                                                                                                             |
-| ------------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `domain`      | String            | Domain name for the cookie. Defaults to the domain name of the app.                                                                                                                                                                                     |
-| `encode`      | Function          | A synchronous function used for cookie value encoding. Defaults to `encodeURIComponent`.                                                                                                                                                                |
-| `expires`     | Date              | Expiry date of the cookie in GMT. If not specified or set to 0, creates a session cookie.                                                                                                                                                               |
-| `httpOnly`    | Boolean           | Flags the cookie to be accessible only by the web server.                                                                                                                                                                                               |
-| `maxAge`      | Number            | Convenient option for setting the expiry time relative to the current time in milliseconds.                                                                                                                                                             |
-| `path`        | String            | Path for the cookie. Defaults to "/".                                                                                                                                                                                                                   |
-| `partitioned` | Boolean           | Indicates that the cookie should be stored using partitioned storage. See [Cookies Having Independent Partitioned State (CHIPS)](https://developer.mozilla.org/en-US/docs/Web/Privacy/Guides/Third-party_cookies/Partitioned_cookies) for more details. |
-| `priority`    | String            | Value of the "Priority" **Set-Cookie** attribute.                                                                                                                                                                                                       |
-| `secure`      | Boolean           | Marks the cookie to be used with HTTPS only.                                                                                                                                                                                                            |
-| `signed`      | Boolean           | Indicates if the cookie should be signed.                                                                                                                                                                                                               |
-| `sameSite`    | Boolean or String | Value of the "SameSite" **Set-Cookie** attribute. More information at [https://tools.ietf.org/html/draft-ietf-httpbis-cookie-same-site-00#section-4.1.1](https://tools.ietf.org/html/draft-ietf-httpbis-cookie-same-site-00#section-4.1.1).             |
-
-</div>
 
 <Alert type="alert">
 
@@ -232,7 +305,52 @@ res.cookie('name', 'tobi', { signed: true });
 
 Later, you may access this value through the [req.signedCookies](/api/request/#reqsignedcookies) object.
 
-### res.download(path [, filename] [, options] [, fn])
+### res.download()
+
+<Signature>
+  <Fragment slot="attributes">
+    <Param name="path" type="String">
+      The path to the file to transfer. If relative, it is resolved against the current working directory or the `root` option.
+    </Param>
+    <Param name="filename" type="String" optional>
+      The file name for the `Content-Disposition` "filename=" parameter; overrides the name derived from `path`.
+    </Param>
+    <Param name="options" type="Object" optional>
+      Options forwarded to [res.sendFile()](#ressendfile).
+
+      <Fragment slot="properties">
+        <Param name="maxAge" type="Number | String" default="0">
+          Sets the max-age property of the `Cache-Control` header in milliseconds, or a string in [ms format](https://www.npmjs.com/package/ms).
+        </Param>
+        <Param name="root" type="String">
+          Root directory for relative file names.
+        </Param>
+        <Param name="lastModified" type="Boolean" default="true">
+          Sets the `Last-Modified` header to the last modified date of the file on the OS. Set `false` to disable it.
+        </Param>
+        <Param name="headers" type="Object">
+          Object containing HTTP headers to serve with the file.
+        </Param>
+        <Param name="dotfiles" type="String" default='"ignore"'>
+          Option for serving dotfiles. Possible values are `"allow"`, `"deny"`, and `"ignore"`.
+        </Param>
+        <Param name="acceptRanges" type="Boolean" default="true">
+          Enable or disable accepting ranged requests.
+        </Param>
+        <Param name="cacheControl" type="Boolean" default="true">
+          Enable or disable setting the `Cache-Control` response header.
+        </Param>
+        <Param name="immutable" type="Boolean" default="false">
+          Enable or disable the `immutable` directive in the `Cache-Control` response header. If enabled, the `maxAge` option should also be specified to enable caching.
+        </Param>
+      </Fragment>
+    </Param>
+    <Param name="fn" type="Function" optional>
+      Callback `fn(err)` invoked when the transfer completes or an error occurs.
+    </Param>
+
+  </Fragment>
+</Signature>
 
 Transfers the file at `path` as an "attachment". Typically, browsers will prompt the user for download.
 By default, the `Content-Disposition` header "filename=" parameter is derived from the `path` argument, but can be overridden with the `filename` parameter.
@@ -248,23 +366,6 @@ When the `root` option is provided, Express will validate that the relative path
 `path` will resolve within the given `root` option.
 
 </Alert>
-
-The following table provides details on the `options` parameter.
-
-<div class="table-scroller" markdown="1">
-
-| Property       | Description                                                                                                                                                                                                                                                                                                                        | Default  | Availability |
-| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------------ |
-| `maxAge`       | Sets the max-age property of the `Cache-Control` header in milliseconds or a string in [ms format](https://www.npmjs.com/package/ms)                                                                                                                                                                                               | 0        | 4.16+        |
-| `root`         | Root directory for relative filenames.                                                                                                                                                                                                                                                                                             |          | 4.18+        |
-| `lastModified` | Sets the `Last-Modified` header to the last modified date of the file on the OS. Set `false` to disable it.                                                                                                                                                                                                                        | Enabled  | 4.16+        |
-| `headers`      | Object containing HTTP headers to serve with the file. The header `Content-Disposition` will be overridden by the `filename` argument.                                                                                                                                                                                             |          | 4.16+        |
-| `dotfiles`     | Option for serving dotfiles. Possible values are "allow", "deny", "ignore".                                                                                                                                                                                                                                                        | "ignore" | 4.16+        |
-| `acceptRanges` | Enable or disable accepting ranged requests.                                                                                                                                                                                                                                                                                       | `true`   | 4.16+        |
-| `cacheControl` | Enable or disable setting `Cache-Control` response header.                                                                                                                                                                                                                                                                         | `true`   | 4.16+        |
-| `immutable`    | Enable or disable the `immutable` directive in the `Cache-Control` response header. If enabled, the `maxAge` option should also be specified to enable caching. The `immutable` directive will prevent supported clients from making conditional requests during the life of the `maxAge` option to check if the file has changed. | `false`  | 4.16+        |
-
-</div>
 
 The method invokes the callback function `fn(err)` when the transfer is complete
 or when an error occurs. If the callback function is specified and an error occurs,
@@ -286,18 +387,41 @@ res.download('/report-12345.pdf', 'report.pdf', (err) => {
 });
 ```
 
-### res.end([data[, encoding]][, callback])
+### res.end()
+
+<Signature returns="Response">
+  <Fragment slot="attributes">
+    <Param name="data" type="String | Buffer" optional>
+      Data to write before ending the response.
+    </Param>
+    <Param name="encoding" type="String" optional>
+      The encoding for `data` when it is a string.
+    </Param>
+    <Param name="callback" type="Function" optional>
+      Called once the response has finished.
+    </Param>
+  </Fragment>
+</Signature>
 
 Ends the response process. This method actually comes from Node core, specifically the [response.end() method of http.ServerResponse](https://nodejs.org/api/http.html#responseenddata-encoding-callback).
 
-Use to quickly end the response without any data. If you need to respond with data, instead use methods such as [res.send()](#ressendbody) and [res.json()](#resjsonbody).
+Use to quickly end the response without any data. If you need to respond with data, instead use methods such as [res.send()](#ressend) and [res.json()](#resjson).
 
 ```js
 res.end();
 res.status(404).end();
 ```
 
-### res.format(object)
+### res.format()
+
+<Signature returns="Response">
+  <Fragment slot="attributes">
+    <Param name="object" type="Object">
+      An object whose keys are MIME types (or extension names) mapped to handler functions,
+      optionally with a `default` handler.
+    </Param>
+  </Fragment>
+</Signature>
 
 Performs content-negotiation on the `Accept` HTTP header on the request object, when present.
 It uses [req.accepts()](/api/request/#reqaccepts) to select a handler for the request, based on the acceptable
@@ -350,7 +474,15 @@ res.format({
 });
 ```
 
-### res.get(field)
+### res.get()
+
+<Signature returns="String">
+  <Fragment slot="attributes">
+    <Param name="field" type="String">
+      The name of the response header to read (case-insensitive).
+    </Param>
+  </Fragment>
+</Signature>
 
 Returns the HTTP response header specified by `field`.
 The match is case-insensitive.
@@ -360,7 +492,16 @@ res.get('Content-Type');
 // => "text/plain"
 ```
 
-### res.json([body])
+### res.json()
+
+<Signature returns="Response">
+  <Fragment slot="attributes">
+    <Param name="body" type="any" optional>
+      The value to send as JSON. Can be any JSON type: object, array, string, Boolean, number, or
+      null.
+    </Param>
+  </Fragment>
+</Signature>
 
 Sends a JSON response. This method sends a response (with the correct content-type) that is the parameter converted to a
 JSON string using [JSON.stringify()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify).
@@ -374,7 +515,15 @@ res.json({ user: 'tobi' });
 res.status(500).json({ error: 'message' });
 ```
 
-### res.jsonp([body])
+### res.jsonp()
+
+<Signature returns="Response">
+  <Fragment slot="attributes">
+    <Param name="body" type="any" optional>
+      The value to send as a JSONP response. Can be any JSON type.
+    </Param>
+  </Fragment>
+</Signature>
 
 Sends a JSON response with JSONP support. This method is identical to `res.json()`,
 except that it opts-in to JSONP callback support.
@@ -408,7 +557,17 @@ res.status(500).jsonp({ error: 'message' });
 // => foo({ "error": "message" })
 ```
 
-### res.links(links)
+### res.links()
+
+<Signature returns="Response">
+  <Fragment slot="attributes">
+    <Param name="links" type="Record<String, String | String[]>">
+      An object whose properties (such as `next` and `last`) populate the `Link` response header.
+      Each value can be a single URL string, or an array of URL strings to emit multiple links for
+      the same relation.
+    </Param>
+  </Fragment>
+</Signature>
 
 Joins the `links` provided as properties of the parameter to populate the response's
 `Link` HTTP header field.
@@ -429,7 +588,15 @@ Link: <http://api.example.com/users?page=2>; rel="next",
       <http://api.example.com/users?page=5>; rel="last"
 ```
 
-### res.location(path)
+### res.location()
+
+<Signature returns="Response">
+  <Fragment slot="attributes">
+    <Param name="path" type="String">
+      The URL to set in the `Location` header.
+    </Param>
+  </Fragment>
+</Signature>
 
 Sets the response `Location` HTTP header to the specified `path` parameter.
 
@@ -447,7 +614,18 @@ or the referring URL, and the URL specified in the `Location` header; and redire
 
 </Alert>
 
-### res.redirect([status,] path)
+### res.redirect()
+
+<Signature>
+  <Fragment slot="attributes">
+    <Param name="status" type="Number" optional>
+      The HTTP status code to use. Defaults to `302` (Found).
+    </Param>
+    <Param name="path" type="String">
+      The URL to redirect to.
+    </Param>
+  </Fragment>
+</Signature>
 
 Redirects to the URL derived from the specified `path`, with specified `status`, a positive integer
 that corresponds to an [HTTP status code](https://www.rfc-editor.org/rfc/rfc9110#name-status-codes).
@@ -499,7 +677,21 @@ res.redirect('..');
 See also [Security best practices: Prevent open redirect
 vulnerabilities](/advanced/best-practice-security/#prevent-open-redirects).
 
-### res.render(view [, locals] [, callback])
+### res.render()
+
+<Signature>
+  <Fragment slot="attributes">
+    <Param name="view" type="String">
+      The file path of the view to render (absolute or relative to the `views` setting).
+    </Param>
+    <Param name="locals" type="Object" optional>
+      An object whose properties define local variables for the view.
+    </Param>
+    <Param name="callback" type="Function" optional>
+      Called as `callback(err, html)`. When provided, the rendered HTML is not sent automatically.
+    </Param>
+  </Fragment>
+</Signature>
 
 Renders a `view` and sends the rendered HTML string to the client.
 Optional parameters:
@@ -549,7 +741,15 @@ res.render('user', { name: 'Tobi' }, (err, html) => {
 });
 ```
 
-### res.send([body])
+### res.send()
+
+<Signature returns="Response">
+  <Fragment slot="attributes">
+    <Param name="body" type="String | Buffer | Object | Array | Boolean" optional>
+      The response body. Strings are sent as HTML; objects and arrays as JSON; Buffers as binary.
+    </Param>
+  </Fragment>
+</Signature>
 
 Sends the HTTP response.
 
@@ -589,7 +789,49 @@ res.send({ user: 'tobi' });
 res.send([1, 2, 3]);
 ```
 
-### res.sendFile(path [, options] [, fn])
+### res.sendFile()
+
+<Signature>
+  <Fragment slot="attributes">
+    <Param name="path" type="String">
+      The path to the file to transfer. Must be absolute unless the `root` option is set.
+    </Param>
+    <Param name="options" type="Object" optional>
+      Options for serving the file.
+
+      <Fragment slot="properties">
+        <Param name="maxAge" type="Number | String" default="0">
+          Sets the max-age property of the `Cache-Control` header in milliseconds, or a string in [ms format](https://www.npmjs.com/package/ms).
+        </Param>
+        <Param name="root" type="String">
+          Root directory for relative file names.
+        </Param>
+        <Param name="lastModified" type="Boolean" default="true">
+          Sets the `Last-Modified` header to the last modified date of the file on the OS. Set `false` to disable it.
+        </Param>
+        <Param name="headers" type="Object">
+          Object containing HTTP headers to serve with the file.
+        </Param>
+        <Param name="dotfiles" type="String" default='"ignore"'>
+          Option for serving dotfiles. Possible values are `"allow"`, `"deny"`, and `"ignore"`.
+        </Param>
+        <Param name="acceptRanges" type="Boolean" default="true">
+          Enable or disable accepting ranged requests.
+        </Param>
+        <Param name="cacheControl" type="Boolean" default="true">
+          Enable or disable setting the `Cache-Control` response header.
+        </Param>
+        <Param name="immutable" type="Boolean" default="false">
+          Enable or disable the `immutable` directive in the `Cache-Control` response header. If enabled, the `maxAge` option should also be specified to enable caching.
+        </Param>
+      </Fragment>
+    </Param>
+    <Param name="fn" type="Function" optional>
+      Callback `fn(err)` invoked when the transfer completes or an error occurs.
+    </Param>
+
+  </Fragment>
+</Signature>
 
 Transfers the file at the given `path`. Sets the `Content-Type` response HTTP header field
 based on the filename's extension. Unless the `root` option is set in
@@ -605,23 +847,6 @@ including containing `..`. Express will validate that the relative path provided
 resolve within the given `root` option.
 
 </Alert>
-
-The following table provides details on the `options` parameter.
-
-<div class="table-scroller" markdown="1">
-
-| Property       | Description                                                                                                                                                                                                                                                                                                                        | Default  | Availability |
-| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------------ |
-| `maxAge`       | Sets the max-age property of the `Cache-Control` header in milliseconds or a string in [ms format](https://www.npmjs.com/package/ms)                                                                                                                                                                                               | 0        |              |
-| `root`         | Root directory for relative filenames.                                                                                                                                                                                                                                                                                             |          |              |
-| `lastModified` | Sets the `Last-Modified` header to the last modified date of the file on the OS. Set `false` to disable it.                                                                                                                                                                                                                        | Enabled  | 4.9.0+       |
-| `headers`      | Object containing HTTP headers to serve with the file.                                                                                                                                                                                                                                                                             |          |              |
-| `dotfiles`     | Option for serving dotfiles. Possible values are "allow", "deny", "ignore".                                                                                                                                                                                                                                                        | "ignore" | &nbsp;       |
-| `acceptRanges` | Enable or disable accepting ranged requests.                                                                                                                                                                                                                                                                                       | `true`   | 4.14+        |
-| `cacheControl` | Enable or disable setting `Cache-Control` response header.                                                                                                                                                                                                                                                                         | `true`   | 4.14+        |
-| `immutable`    | Enable or disable the `immutable` directive in the `Cache-Control` response header. If enabled, the `maxAge` option should also be specified to enable caching. The `immutable` directive will prevent supported clients from making conditional requests during the life of the `maxAge` option to check if the file has changed. | `false`  | 4.16+        |
-
-</div>
 
 The method invokes the callback function `fn(err)` when the transfer is complete
 or when an error occurs. If the callback function is specified and an error occurs,
@@ -672,7 +897,15 @@ app.get('/user/:uid/photos/:file', (req, res) => {
 
 For more information, or if you have issues or concerns, see [send](https://github.com/pillarjs/send).
 
-### res.sendStatus(statusCode)
+### res.sendStatus()
+
+<Signature returns="Response">
+  <Fragment slot="attributes">
+    <Param name="statusCode" type="Number">
+      The HTTP status code to set; its registered status message becomes the response body.
+    </Param>
+  </Fragment>
+</Signature>
 
 Sets the response HTTP status code to `statusCode` and sends the registered status message as the text response body. If an unknown status code is specified, the response body will just be the code number.
 
@@ -690,7 +923,18 @@ version being used.
 
 [More about HTTP Status Codes](https://en.wikipedia.org/wiki/List_of_HTTP_status_codes)
 
-### res.set(field [, value])
+### res.set()
+
+<Signature returns="Response">
+  <Fragment slot="attributes">
+    <Param name="field" type="String | Object">
+      The header name, or an object of header name/value pairs to set multiple headers at once.
+    </Param>
+    <Param name="value" type="String | String[]" optional>
+      The header value (when `field` is a string).
+    </Param>
+  </Fragment>
+</Signature>
 
 Sets the response's HTTP header `field` to `value`.
 To set multiple fields at once, pass an object as the parameter.
@@ -707,7 +951,15 @@ res.set({
 
 Aliased as `res.header(field [, value])`.
 
-### res.status(code)
+### res.status()
+
+<Signature returns="Response">
+  <Fragment slot="attributes">
+    <Param name="code" type="Number">
+      The HTTP status code for the response.
+    </Param>
+  </Fragment>
+</Signature>
 
 Sets the HTTP status for the response.
 It is a chainable alias of Node's [response.statusCode](https://nodejs.org/api/http.html#http_response_statuscode).
@@ -718,7 +970,16 @@ res.status(400).send('Bad Request');
 res.status(404).sendFile('/absolute/path/to/404.png');
 ```
 
-### res.type(type)
+### res.type()
+
+<Signature returns="Response">
+  <Fragment slot="attributes">
+    <Param name="type" type="String">
+      The MIME type, or a file extension that is looked up to a MIME type. If it contains `/`, it is
+      used as-is.
+    </Param>
+  </Fragment>
+</Signature>
 
 Sets the `Content-Type` HTTP header to the MIME type as determined by the specified `type`. If `type` contains the "/" character, then it sets the `Content-Type` to the exact value of `type`, otherwise it is assumed to be a file extension and the MIME type is looked up using the `contentType()` method of the `mime-types` package.
 
@@ -732,7 +993,15 @@ res.type('png'); // => image/png:
 
 Aliased as `res.contentType(type)`.
 
-### res.vary(field)
+### res.vary()
+
+<Signature returns="Response">
+  <Fragment slot="attributes">
+    <Param name="field" type="String">
+      The header field name to add to the `Vary` response header.
+    </Param>
+  </Fragment>
+</Signature>
 
 Adds the field to the `Vary` response header, if it is not there already.
 

--- a/src/content/api/5x/api/response/index.mdx
+++ b/src/content/api/5x/api/response/index.mdx
@@ -300,7 +300,7 @@ res.status(404).end();
 ### res.format(object)
 
 Performs content-negotiation on the `Accept` HTTP header on the request object, when present.
-It uses [req.accepts()](/api/request/#reqacceptstypes) to select a handler for the request, based on the acceptable
+It uses [req.accepts()](/api/request/#reqaccepts) to select a handler for the request, based on the acceptable
 types ordered by their quality values. If the header is not specified, the first callback is invoked.
 When no match is found, the server responds with 406 "Not Acceptable", or invokes the `default` callback.
 

--- a/src/content/api/5x/api/router/index.mdx
+++ b/src/content/api/5x/api/router/index.mdx
@@ -4,13 +4,15 @@ description: A router object is an isolated instance of middleware and routes in
 ---
 
 import Alert from '@components/primitives/Alert/Alert.astro';
+import Signature from '@components/patterns/Signature/Signature.astro';
+import Param from '@components/patterns/Signature/Param.astro';
 
 A `router` object is an instance of middleware and routes. You can think of it
 as a "mini-application," capable only of performing middleware and routing
 functions. Every Express application has a built-in app router.
 
 A router behaves like middleware itself, so you can use it as an argument to
-[app.use()](/api/application/#appuse) or as the argument to another router's [use()](#routerusepath-function--function) method.
+[app.use()](/api/application/#appuse) or as the argument to another router's [use()](#routeruse) method.
 
 The top-level `express` object has a [Router()](/api/express/#expressrouter) method that creates a new `router` object.
 
@@ -40,9 +42,42 @@ app.use('/calendar', router);
 
 ## Methods
 
-### Router([options])
+### Router()
 
-### router.all(path, [callback, ...] callback)
+<Signature returns="Router">
+  <Fragment slot="attributes">
+    <Param name="options" type="Object" optional>
+      Options that configure the router's behavior.
+
+      <Fragment slot="properties">
+        <Param name="caseSensitive" type="Boolean" default="false">
+          Enable case sensitivity. Disabled by default, treating `/Foo` and `/foo` as the same.
+        </Param>
+        <Param name="mergeParams" type="Boolean" default="false">
+          Preserve the `req.params` values from the parent router. If the parent and the child have conflicting param names, the child's value takes precedence.
+        </Param>
+        <Param name="strict" type="Boolean" default="false">
+          Enable strict routing. Disabled by default, `/foo` and `/foo/` are treated the same by the router.
+        </Param>
+      </Fragment>
+    </Param>
+
+  </Fragment>
+</Signature>
+
+### router.all()
+
+<Signature returns="Router">
+  <Fragment slot="attributes">
+    <Param name="path" type="String | RegExp | Array">
+      The path for which the route callbacks are invoked.
+    </Param>
+    <Param name="callback" type="Function | Function[]">
+      One or more middleware/handler functions. Each may call `next('route')` to skip the remaining
+      callbacks.
+    </Param>
+  </Fragment>
+</Signature>
 
 This method is just like the `router.METHOD()` methods, except that it matches all HTTP methods (verbs).
 
@@ -74,7 +109,19 @@ the example is much like before, but it only restricts paths prefixed with
 router.all('/api/{*splat}', requireAuthentication);
 ```
 
-### router.METHOD(path, [callback, ...] callback)
+### router.METHOD()
+
+<Signature returns="Router">
+  <Fragment slot="attributes">
+    <Param name="path" type="String | RegExp | Array">
+      The path for which the route callbacks are invoked.
+    </Param>
+    <Param name="callback" type="Function | Function[]">
+      One or more middleware/handler functions. Each may call `next('route')` to skip the remaining
+      callbacks.
+    </Param>
+  </Fragment>
+</Signature>
 
 The `router.METHOD()` methods provide the routing functionality in Express,
 where METHOD is one of the HTTP methods, such as GET, PUT, POST, and so on,
@@ -142,7 +189,19 @@ app.get('/foo', (req, res) => {
 });
 ```
 
-### router.param(name, callback)
+### router.param()
+
+<Signature returns="Router">
+  <Fragment slot="attributes">
+    <Param name="name" type="String">
+      The name of the route parameter to attach the trigger to. Unlike `app.param()`, this does not
+      accept an array.
+    </Param>
+    <Param name="callback" type="Function">
+      The trigger called as `callback(req, res, next, value, name)`.
+    </Param>
+  </Fragment>
+</Signature>
 
 Adds callback triggers to route parameters, where `name` is the name of the parameter and `callback` is the callback function. The `name` parameter is required.
 
@@ -207,7 +266,15 @@ although this matches
 and this matches too
 ```
 
-### router.route(path)
+### router.route()
+
+<Signature returns="Route">
+  <Fragment slot="attributes">
+    <Param name="path" type="String">
+      The path of the route to create.
+    </Param>
+  </Fragment>
+</Signature>
 
 Returns an instance of a single route which you can then use to handle HTTP verbs
 with optional middleware. Use `router.route()` to avoid duplicate route naming and
@@ -263,7 +330,18 @@ belong to the route to which they were added.
 
 </Alert>
 
-### router.use([path], [function, ...] function)
+### router.use()
+
+<Signature returns="Router">
+  <Fragment slot="attributes">
+    <Param name="path" type="String | RegExp | Array" optional>
+      The mount path for the middleware. Defaults to `/`.
+    </Param>
+    <Param name="callback" type="Function | Function[]">
+      One or more middleware functions to mount.
+    </Param>
+  </Fragment>
+</Signature>
 
 Uses the specified middleware function or functions, with optional mount path `path`, that defaults to "/".
 

--- a/src/content/api/5x/api/router/index.mdx
+++ b/src/content/api/5x/api/router/index.mdx
@@ -10,9 +10,9 @@ as a "mini-application," capable only of performing middleware and routing
 functions. Every Express application has a built-in app router.
 
 A router behaves like middleware itself, so you can use it as an argument to
-[app.use()](/api/application/#appusepath-callback--callback) or as the argument to another router's [use()](#routerusepath-function--function) method.
+[app.use()](/api/application/#appuse) or as the argument to another router's [use()](#routerusepath-function--function) method.
 
-The top-level `express` object has a [Router()](/api/express/#expressrouteroptions) method that creates a new `router` object.
+The top-level `express` object has a [Router()](/api/express/#expressrouter) method that creates a new `router` object.
 
 Once you've created a router object, you can add middleware and HTTP method routes (such as `get`, `put`, `post`,
 and so on) to it just like an application. For example:
@@ -267,8 +267,8 @@ belong to the route to which they were added.
 
 Uses the specified middleware function or functions, with optional mount path `path`, that defaults to "/".
 
-This method is similar to [app.use()](/api/application/#appusepath-callback--callback). A simple example and use case is described below.
-See [app.use()](/api/application/#appusepath-callback--callback) for more information.
+This method is similar to [app.use()](/api/application/#appuse). A simple example and use case is described below.
+See [app.use()](/api/application/#appuse) for more information.
 
 Middleware is like a plumbing pipe: requests start at the first middleware function defined
 and work their way "down" the middleware stack processing for each path they match.

--- a/src/content/docs/en/4x/guide/routing.mdx
+++ b/src/content/docs/en/4x/guide/routing.mdx
@@ -314,15 +314,15 @@ The methods on the response object (`res`) in the following table can send a res
 
 | Method                                                                 | Description                                                                           |
 | ---------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
-| [res.download()](/api/response#resdownloadpath--filename--options--fn) | Prompt a file to be downloaded.                                                       |
-| [res.end()](/api/response#resenddata-encoding-callback)                | End the response process.                                                             |
-| [res.json()](/api/response#resjsonbody)                                | Send a JSON response.                                                                 |
-| [res.jsonp()](/api/response#resjsonpbody)                              | Send a JSON response with JSONP support.                                              |
-| [res.redirect()](/api/response#resredirectstatus-path)                 | Redirect a request.                                                                   |
-| [res.render()](/api/response#resrenderview--locals--callback)          | Render a view template.                                                               |
-| [res.send()](/api/response#ressendbody)                                | Send a response of various types.                                                     |
-| [res.sendFile()](/api/response#ressendfilepath--options--fn)           | Send a file as an octet stream.                                                       |
-| [res.sendStatus()](/api/response#ressendstatusstatuscode)              | Set the response status code and send its string representation as the response body. |
+| [res.download()](/api/response#resdownload) | Prompt a file to be downloaded.                                                       |
+| [res.end()](/api/response#resend)                | End the response process.                                                             |
+| [res.json()](/api/response#resjson)                                | Send a JSON response.                                                                 |
+| [res.jsonp()](/api/response#resjsonp)                              | Send a JSON response with JSONP support.                                              |
+| [res.redirect()](/api/response#resredirect)                 | Redirect a request.                                                                   |
+| [res.render()](/api/response#resrender)          | Render a view template.                                                               |
+| [res.send()](/api/response#ressend)                                | Send a response of various types.                                                     |
+| [res.sendFile()](/api/response#ressendfile)           | Send a file as an octet stream.                                                       |
+| [res.sendStatus()](/api/response#ressendstatus)              | Set the response status code and send its string representation as the response body. |
 
 ## app.route()
 

--- a/src/content/docs/en/4x/guide/routing.mdx
+++ b/src/content/docs/en/4x/guide/routing.mdx
@@ -312,17 +312,17 @@ app.get(
 
 The methods on the response object (`res`) in the following table can send a response to the client, and terminate the request-response cycle. If none of these methods are called from a route handler, the client request will be left hanging.
 
-| Method                                                                 | Description                                                                           |
-| ---------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
-| [res.download()](/api/response#resdownload) | Prompt a file to be downloaded.                                                       |
-| [res.end()](/api/response#resend)                | End the response process.                                                             |
-| [res.json()](/api/response#resjson)                                | Send a JSON response.                                                                 |
-| [res.jsonp()](/api/response#resjsonp)                              | Send a JSON response with JSONP support.                                              |
-| [res.redirect()](/api/response#resredirect)                 | Redirect a request.                                                                   |
-| [res.render()](/api/response#resrender)          | Render a view template.                                                               |
-| [res.send()](/api/response#ressend)                                | Send a response of various types.                                                     |
-| [res.sendFile()](/api/response#ressendfile)           | Send a file as an octet stream.                                                       |
-| [res.sendStatus()](/api/response#ressendstatus)              | Set the response status code and send its string representation as the response body. |
+| Method                                          | Description                                                                           |
+| ----------------------------------------------- | ------------------------------------------------------------------------------------- |
+| [res.download()](/api/response#resdownload)     | Prompt a file to be downloaded.                                                       |
+| [res.end()](/api/response#resend)               | End the response process.                                                             |
+| [res.json()](/api/response#resjson)             | Send a JSON response.                                                                 |
+| [res.jsonp()](/api/response#resjsonp)           | Send a JSON response with JSONP support.                                              |
+| [res.redirect()](/api/response#resredirect)     | Redirect a request.                                                                   |
+| [res.render()](/api/response#resrender)         | Render a view template.                                                               |
+| [res.send()](/api/response#ressend)             | Send a response of various types.                                                     |
+| [res.sendFile()](/api/response#ressendfile)     | Send a file as an octet stream.                                                       |
+| [res.sendStatus()](/api/response#ressendstatus) | Set the response status code and send its string representation as the response body. |
 
 ## app.route()
 

--- a/src/content/docs/en/4x/guide/routing.mdx
+++ b/src/content/docs/en/4x/guide/routing.mdx
@@ -10,7 +10,7 @@ For an introduction to routing, see [Basic routing](/starter/basic-routing).
 
 You define routing using methods of the Express `app` object that correspond to HTTP methods;
 for example, `app.get()` to handle GET requests and `app.post` to handle POST requests. For a full list,
-see [app.METHOD](/api/application#appmethodpath-callback--callback-). You can also use [app.all()](/api/application#appallpath-callback--callback-) to handle all HTTP methods and [app.use()](/api/application#appusepath-callback--callback) to
+see [app.METHOD](/api/application#appmethod). You can also use [app.all()](/api/application#appall) to handle all HTTP methods and [app.use()](/api/application#appuse) to
 specify middleware as the callback function (See [Using middleware](/guide/using-middleware) for details).
 
 These routing methods specify a callback function (sometimes called "handler functions") called when the application receives a request to the specified route (endpoint) and HTTP method. In other words, the application "listens" for requests that match the specified route(s) and method(s), and when it detects a match, it calls the specified callback function.
@@ -50,7 +50,7 @@ app.post('/', (req, res) => {
 ```
 
 Express supports methods that correspond to all HTTP request methods: `get`, `post`, and so on.
-For a full list, see [app.METHOD](/api/application#appmethodpath-callback--callback-).
+For a full list, see [app.METHOD](/api/application#appmethod).
 
 There is a special routing method, `app.all()`, used to load middleware functions at a path for _all_ HTTP request methods. For example, the following handler is executed for requests to the route `"/secret"` whether using `GET`, `POST`, `PUT`, `DELETE`, or any other HTTP request method supported in the [http module](https://nodejs.org/api/http.html#http_http_methods).
 
@@ -388,7 +388,7 @@ app.use('/birds', birds);
 
 The app will now be able to handle requests to `/birds` and `/birds/about`, as well as call the `timeLog` middleware function that is specific to the route.
 
-But if the parent route `/birds` has path parameters, it will not be accessible by default from the sub-routes. To make it accessible, you will need to pass the `mergeParams` option to the Router constructor [reference](/api/application#appusepath-callback--callback).
+But if the parent route `/birds` has path parameters, it will not be accessible by default from the sub-routes. To make it accessible, you will need to pass the `mergeParams` option to the Router constructor [reference](/api/application#appuse).
 
 ```js
 const router = express.Router({ mergeParams: true });

--- a/src/content/docs/en/4x/guide/using-middleware.mdx
+++ b/src/content/docs/en/4x/guide/using-middleware.mdx
@@ -272,9 +272,9 @@ functions that were previously included with Express are now in separate modules
 
 Express has the following built-in middleware functions:
 
-- [express.static](/api/express/#expressstaticroot-options) serves static assets such as HTML files, images, and so on.
-- [express.json](/api/express/#expressjsonoptions) parses incoming requests with JSON payloads. **NOTE: Available with Express 4.16.0+**
-- [express.urlencoded](/api/express/#expressurlencodedoptions) parses incoming requests with URL-encoded payloads. **NOTE: Available with Express 4.16.0+**
+- [express.static](/api/express/#expressstatic) serves static assets such as HTML files, images, and so on.
+- [express.json](/api/express/#expressjson) parses incoming requests with JSON payloads. **NOTE: Available with Express 4.16.0+**
+- [express.urlencoded](/api/express/#expressurlencoded) parses incoming requests with URL-encoded payloads. **NOTE: Available with Express 4.16.0+**
 
 ## Third-party middleware
 

--- a/src/content/docs/en/4x/guide/using-template-engines.mdx
+++ b/src/content/docs/en/4x/guide/using-template-engines.mdx
@@ -12,7 +12,7 @@ This approach makes it easier to design an HTML page.
 
 The [Express application generator](/starter/generator) uses [Pug](https://pugjs.org/api/getting-started.html) as its default, but it also supports [Handlebars](https://www.npmjs.com/package/handlebars), and [EJS](https://www.npmjs.com/package/ejs), among others.
 
-To render template files, set the following [application setting properties](/api/application/#appsetname-value), in the default `app.js` created by the generator:
+To render template files, set the following [application setting properties](/api/application/#appset), in the default `app.js` created by the generator:
 
 - `views`, the directory where the template files are located. Eg: `app.set('views', './views')`.
   This defaults to the `views` directory in the application root directory.

--- a/src/content/docs/en/4x/starter/static-files.mdx
+++ b/src/content/docs/en/4x/starter/static-files.mdx
@@ -14,7 +14,7 @@ express.static(root, [options]);
 ```
 
 The `root` argument specifies the root directory from which to serve static assets.
-For more information on the `options` argument, see [express.static](/api/express/#expressstaticroot-options).
+For more information on the `options` argument, see [express.static](/api/express/#expressstatic).
 
 For example, use the following code to serve images, CSS files, and JavaScript files in a directory named `public`:
 
@@ -56,7 +56,7 @@ serving static assets.
 
 </Alert>
 
-To create a virtual path prefix (where the path does not actually exist in the file system) for files that are served by the `express.static` function, [specify a mount path](/api/application/#appusepath-callback--callback) for the static directory, as shown below:
+To create a virtual path prefix (where the path does not actually exist in the file system) for files that are served by the `express.static` function, [specify a mount path](/api/application/#appuse) for the static directory, as shown below:
 
 ```js
 app.use('/static', express.static('public'));

--- a/src/content/docs/en/5x/guide/routing.mdx
+++ b/src/content/docs/en/5x/guide/routing.mdx
@@ -294,15 +294,15 @@ The methods on the response object (`res`) in the following table can send a res
 
 | Method                                                                 | Description                                                                           |
 | ---------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
-| [res.download()](/api/response#resdownloadpath--filename--options--fn) | Prompt a file to be downloaded.                                                       |
-| [res.end()](/api/response#resenddata-encoding-callback)                | End the response process.                                                             |
-| [res.json()](/api/response#resjsonbody)                                | Send a JSON response.                                                                 |
-| [res.jsonp()](/api/response#resjsonpbody)                              | Send a JSON response with JSONP support.                                              |
-| [res.redirect()](/api/response#resredirectstatus-path)                 | Redirect a request.                                                                   |
-| [res.render()](/api/response#resrenderview--locals--callback)          | Render a view template.                                                               |
-| [res.send()](/api/response#ressendbody)                                | Send a response of various types.                                                     |
-| [res.sendFile()](/api/response#ressendfilepath--options--fn)           | Send a file as an octet stream.                                                       |
-| [res.sendStatus()](/api/response#ressendstatusstatuscode)              | Set the response status code and send its string representation as the response body. |
+| [res.download()](/api/response#resdownload) | Prompt a file to be downloaded.                                                       |
+| [res.end()](/api/response#resend)                | End the response process.                                                             |
+| [res.json()](/api/response#resjson)                                | Send a JSON response.                                                                 |
+| [res.jsonp()](/api/response#resjsonp)                              | Send a JSON response with JSONP support.                                              |
+| [res.redirect()](/api/response#resredirect)                 | Redirect a request.                                                                   |
+| [res.render()](/api/response#resrender)          | Render a view template.                                                               |
+| [res.send()](/api/response#ressend)                                | Send a response of various types.                                                     |
+| [res.sendFile()](/api/response#ressendfile)           | Send a file as an octet stream.                                                       |
+| [res.sendStatus()](/api/response#ressendstatus)              | Set the response status code and send its string representation as the response body. |
 
 ## app.route()
 

--- a/src/content/docs/en/5x/guide/routing.mdx
+++ b/src/content/docs/en/5x/guide/routing.mdx
@@ -10,7 +10,7 @@ For an introduction to routing, see [Basic routing](/starter/basic-routing).
 
 You define routing using methods of the Express `app` object that correspond to HTTP methods;
 for example, `app.get()` to handle GET requests and `app.post` to handle POST requests. For a full list,
-see [app.METHOD](/api/application#appmethodpath-callback--callback-). You can also use [app.all()](/api/application#appallpath-callback--callback-) to handle all HTTP methods and [app.use()](/api/application#appusepath-callback--callback) to
+see [app.METHOD](/api/application#appmethod). You can also use [app.all()](/api/application#appall) to handle all HTTP methods and [app.use()](/api/application#appuse) to
 specify middleware as the callback function (See [Using middleware](/guide/using-middleware) for details).
 
 These routing methods specify a callback function (sometimes called "handler functions") called when the application receives a request to the specified route (endpoint) and HTTP method. In other words, the application "listens" for requests that match the specified route(s) and method(s), and when it detects a match, it calls the specified callback function.
@@ -50,7 +50,7 @@ app.post('/', (req, res) => {
 ```
 
 Express supports methods that correspond to all HTTP request methods: `get`, `post`, and so on.
-For a full list, see [app.METHOD](/api/application#appmethodpath-callback--callback-).
+For a full list, see [app.METHOD](/api/application#appmethod).
 
 There is a special routing method, `app.all()`, used to load middleware functions at a path for _all_ HTTP request methods. For example, the following handler is executed for requests to the route `"/secret"` whether using `GET`, `POST`, `PUT`, `DELETE`, or any other HTTP request method supported in the [http module](https://nodejs.org/api/http.html#http_http_methods).
 
@@ -368,7 +368,7 @@ app.use('/birds', birds);
 
 The app will now be able to handle requests to `/birds` and `/birds/about`, as well as call the `timeLog` middleware function that is specific to the route.
 
-But if the parent route `/birds` has path parameters, it will not be accessible by default from the sub-routes. To make it accessible, you will need to pass the `mergeParams` option to the Router constructor [reference](/api/application#appusepath-callback--callback).
+But if the parent route `/birds` has path parameters, it will not be accessible by default from the sub-routes. To make it accessible, you will need to pass the `mergeParams` option to the Router constructor [reference](/api/application#appuse).
 
 ```js
 const router = express.Router({ mergeParams: true });

--- a/src/content/docs/en/5x/guide/routing.mdx
+++ b/src/content/docs/en/5x/guide/routing.mdx
@@ -292,17 +292,17 @@ app.get(
 
 The methods on the response object (`res`) in the following table can send a response to the client, and terminate the request-response cycle. If none of these methods are called from a route handler, the client request will be left hanging.
 
-| Method                                                                 | Description                                                                           |
-| ---------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
-| [res.download()](/api/response#resdownload) | Prompt a file to be downloaded.                                                       |
-| [res.end()](/api/response#resend)                | End the response process.                                                             |
-| [res.json()](/api/response#resjson)                                | Send a JSON response.                                                                 |
-| [res.jsonp()](/api/response#resjsonp)                              | Send a JSON response with JSONP support.                                              |
-| [res.redirect()](/api/response#resredirect)                 | Redirect a request.                                                                   |
-| [res.render()](/api/response#resrender)          | Render a view template.                                                               |
-| [res.send()](/api/response#ressend)                                | Send a response of various types.                                                     |
-| [res.sendFile()](/api/response#ressendfile)           | Send a file as an octet stream.                                                       |
-| [res.sendStatus()](/api/response#ressendstatus)              | Set the response status code and send its string representation as the response body. |
+| Method                                          | Description                                                                           |
+| ----------------------------------------------- | ------------------------------------------------------------------------------------- |
+| [res.download()](/api/response#resdownload)     | Prompt a file to be downloaded.                                                       |
+| [res.end()](/api/response#resend)               | End the response process.                                                             |
+| [res.json()](/api/response#resjson)             | Send a JSON response.                                                                 |
+| [res.jsonp()](/api/response#resjsonp)           | Send a JSON response with JSONP support.                                              |
+| [res.redirect()](/api/response#resredirect)     | Redirect a request.                                                                   |
+| [res.render()](/api/response#resrender)         | Render a view template.                                                               |
+| [res.send()](/api/response#ressend)             | Send a response of various types.                                                     |
+| [res.sendFile()](/api/response#ressendfile)     | Send a file as an octet stream.                                                       |
+| [res.sendStatus()](/api/response#ressendstatus) | Set the response status code and send its string representation as the response body. |
 
 ## app.route()
 

--- a/src/content/docs/en/5x/guide/using-middleware.mdx
+++ b/src/content/docs/en/5x/guide/using-middleware.mdx
@@ -272,9 +272,9 @@ functions that were previously included with Express are now in separate modules
 
 Express has the following built-in middleware functions:
 
-- [express.static](/api/express/#expressstaticroot-options) serves static assets such as HTML files, images, and so on.
-- [express.json](/api/express/#expressjsonoptions) parses incoming requests with JSON payloads. **NOTE: Available with Express 4.16.0+**
-- [express.urlencoded](/api/express/#expressurlencodedoptions) parses incoming requests with URL-encoded payloads. **NOTE: Available with Express 4.16.0+**
+- [express.static](/api/express/#expressstatic) serves static assets such as HTML files, images, and so on.
+- [express.json](/api/express/#expressjson) parses incoming requests with JSON payloads. **NOTE: Available with Express 4.16.0+**
+- [express.urlencoded](/api/express/#expressurlencoded) parses incoming requests with URL-encoded payloads. **NOTE: Available with Express 4.16.0+**
 
 ## Third-party middleware
 

--- a/src/content/docs/en/5x/guide/using-template-engines.mdx
+++ b/src/content/docs/en/5x/guide/using-template-engines.mdx
@@ -12,7 +12,7 @@ This approach makes it easier to design an HTML page.
 
 The [Express application generator](/starter/generator) uses [Pug](https://pugjs.org/api/getting-started.html) as its default, but it also supports [Handlebars](https://www.npmjs.com/package/handlebars), and [EJS](https://www.npmjs.com/package/ejs), among others.
 
-To render template files, set the following [application setting properties](/api/application/#appsetname-value), in the default `app.js` created by the generator:
+To render template files, set the following [application setting properties](/api/application/#appset), in the default `app.js` created by the generator:
 
 - `views`, the directory where the template files are located. Eg: `app.set('views', './views')`.
   This defaults to the `views` directory in the application root directory.

--- a/src/content/docs/en/5x/starter/static-files.mdx
+++ b/src/content/docs/en/5x/starter/static-files.mdx
@@ -14,7 +14,7 @@ express.static(root, [options]);
 ```
 
 The `root` argument specifies the root directory from which to serve static assets.
-For more information on the `options` argument, see [express.static](/api/express/#expressstaticroot-options).
+For more information on the `options` argument, see [express.static](/api/express/#expressstatic).
 
 For example, use the following code to serve images, CSS files, and JavaScript files in a directory named `public`:
 
@@ -56,7 +56,7 @@ serving static assets.
 
 </Alert>
 
-To create a virtual path prefix (where the path does not actually exist in the file system) for files that are served by the `express.static` function, [specify a mount path](/api/application/#appusepath-callback--callback) for the static directory, as shown below:
+To create a virtual path prefix (where the path does not actually exist in the file system) for files that are served by the `express.static` function, [specify a mount path](/api/application/#appuse) for the static directory, as shown below:
 
 ```js
 app.use('/static', express.static('public'));

--- a/src/content/pages/en/guide/migrating-5.mdx
+++ b/src/content/pages/en/guide/migrating-5.mdx
@@ -94,7 +94,7 @@ Or you can update your code manually:
 
 A leading colon character (:) in the name for the `app.param(name, fn)` function is a remnant of Express 3, and for the sake of backwards compatibility, Express 4 supported it with a deprecation notice. Express 5 will silently ignore it and use the name parameter without prefixing it with a colon.
 
-This should not affect your code if you follow the Express 4 documentation of [app.param](/4x/api/application/#appparamname-callback), as it makes no mention of the leading colon.
+This should not affect your code if you follow the Express 4 documentation of [app.param](/4x/api/application/#appparam), as it makes no mention of the leading colon.
 
 ### req.param(name)
 

--- a/src/content/pages/en/guide/migrating-5.mdx
+++ b/src/content/pages/en/guide/migrating-5.mdx
@@ -423,6 +423,25 @@ Serve specific dot-directories explicitly using the `dotfiles: "allow"` option. 
  app.use(express.static('public'));
 ```
 
+### router.param() with an array of names
+
+`router.param(name, fn)` no longer accepts an array for `name`. In Express 4 an array was accepted silently; in Express 5, passing anything other than a string throws `TypeError: argument name must be a string`. (Note that `app.param()` still accepts an array of names.)
+
+#### How to update
+
+Register each parameter name with its own `router.param()` call:
+
+```diff
+-router.param(['id', 'page'], (req, res, next, value) => {
+-  // ...
+-});
++const loadParam = (req, res, next, value) => {
++  // ...
++};
++router.param('id', loadParam);
++router.param('page', loadParam);
+```
+
 ### app.listen
 
 In Express 5, the `app.listen` method will invoke the user-provided callback function (if provided) when the server receives an error event. In Express 4, such errors would be thrown. This change shifts error-handling responsibility to the callback function in Express 5. If there is an error, it will be passed to the callback as an argument.


### PR DESCRIPTION
Express v3 wasn’t modified because we really shouldn’t spend time polishing something that is no longer used. Otherwise, I fixed the documentation and other parts here that were somewhat outdated.