### PR TITLE
feat: add deprecation handling for parameters and methods in API documentation

### DIFF
--- a/src/components/patterns/Signature/Param.astro
+++ b/src/components/patterns/Signature/Param.astro
@@ -40,9 +40,11 @@ interface Props {
   optional?: boolean;
   /** Version the parameter was added in, e.g. `"v4.20.0"`. */
   since?: string;
+  /** Version the parameter was deprecated in, e.g. `"v4.11.0"`. */
+  deprecated?: string;
 }
 
-const { name, type, default: defaultValue, optional = false, since } = Astro.props;
+const { name, type, default: defaultValue, optional = false, since, deprecated } = Astro.props;
 
 const hasProperties = Astro.slots.has('properties');
 
@@ -57,7 +59,7 @@ const displayType = optional && type ? `${type} | undefined` : type;
 
   <div class="param__body">
     {
-      (displayType || defaultValue !== undefined || since) && (
+      (displayType || defaultValue !== undefined || since || deprecated) && (
         <div class="param__meta">
           {displayType && (
             <span class="param__meta-item">
@@ -75,6 +77,12 @@ const displayType = optional && type ? `${type} | undefined` : type;
             <span class="param__meta-item">
               <span class="param__label">Added in:</span>
               <code class="param__value">{since}</code>
+            </span>
+          )}
+          {deprecated && (
+            <span class="param__meta-item param__meta-item--deprecated">
+              <span class="param__label">Deprecated in:</span>
+              <code class="param__value">{deprecated}</code>
             </span>
           )}
         </div>

--- a/src/components/patterns/Signature/Signature.astro
+++ b/src/components/patterns/Signature/Signature.astro
@@ -17,6 +17,8 @@
  * </Signature>
  *
  * <Signature type="Boolean" since="v4.5.0" />
+ *
+ * <Signature returns="Response" since="v4.2.0" deprecated="v4.11.0" />
  */
 import './Signature.css';
 
@@ -27,16 +29,18 @@ interface Props {
   type?: string;
   /** Version the member was added in, e.g. `"v4.16.0"`. */
   since?: string;
+  /** Version the member was deprecated in, e.g. `"v4.11.0"`. */
+  deprecated?: string;
   /** Heading text for the arguments section. */
   attributesTitle?: string;
 }
 
-const { returns, type, since, attributesTitle = 'Arguments' } = Astro.props;
+const { returns, type, since, deprecated, attributesTitle = 'Arguments' } = Astro.props;
 
 const hasReturnsSlot = Astro.slots.has('returns');
 const hasReturns = hasReturnsSlot || Boolean(returns);
 const hasAttributes = Astro.slots.has('attributes');
-const hasFooter = Boolean(type) || hasReturns || Boolean(since);
+const hasFooter = Boolean(type) || hasReturns || Boolean(since) || Boolean(deprecated);
 ---
 
 <section class="signature">
@@ -73,6 +77,12 @@ const hasFooter = Boolean(type) || hasReturns || Boolean(since);
           <p class="signature__line">
             <span class="signature__line-label">Added in:</span>
             <code class="type-tag">{since}</code>
+          </p>
+        )}
+        {deprecated && (
+          <p class="signature__line signature__line--deprecated">
+            <span class="signature__line-label">Deprecated in:</span>
+            <code class="type-tag type-tag--deprecated">{deprecated}</code>
           </p>
         )}
       </div>

--- a/src/components/patterns/Signature/Signature.css
+++ b/src/components/patterns/Signature/Signature.css
@@ -58,6 +58,16 @@
     font-weight: var(--font-weight-medium);
   }
 
+  .type-tag--deprecated {
+    border-color: var(--color-border-error);
+    background-color: var(--color-bg-error);
+    color: var(--color-text-error);
+  }
+
+  .signature__line--deprecated .signature__line-label {
+    color: var(--color-text-error);
+  }
+
   .signature__params {
     display: grid;
     grid-template-columns: minmax(8rem, 14rem) minmax(0, 1fr);
@@ -146,6 +156,11 @@
   .param__value {
     font-family: var(--font-family-mono);
     color: var(--color-text-primary);
+  }
+
+  .param__meta-item--deprecated .param__label,
+  .param__meta-item--deprecated .param__value {
+    color: var(--color-text-error);
   }
 
   .param__desc {

--- a/src/content/api/4x/api/application/index.mdx
+++ b/src/content/api/4x/api/application/index.mdx
@@ -6,6 +6,7 @@ description: Learn about the properties of the Express application object.
 import Alert from '@components/primitives/Alert/Alert.astro';
 import Signature from '@components/patterns/Signature/Signature.astro';
 import Param from '@components/patterns/Signature/Param.astro';
+import PackageManagerCommand from '@components/patterns/PackageManagerCommand/PackageManagerCommand.astro';
 
 The `app` object conventionally denotes the Express application.
 Create it by calling the top-level `express()` function exported by the Express module:
@@ -292,6 +293,29 @@ app.delete('/', function (req, res) {
   res.send('DELETE request to homepage');
 });
 ```
+
+### app.del()
+
+<Signature deprecated="v4.2.0">
+  <Fragment slot="attributes">
+    <Param name="path" type="String | RegExp | Array">
+      The path for which the middleware function is invoked; same as [app.delete()](#appdelete).
+    </Param>
+    <Param name="callback" type="Function | Function[]">
+      Callback functions; same as [app.delete()](#appdelete).
+    </Param>
+  </Fragment>
+</Signature>
+
+<Alert type="alert">
+
+`app.del()` is the alias of [`app.delete()`](#appdelete), originally introduced because `delete` was a reserved word in older JavaScript engines. It has emitted a deprecation warning since Express v4.2.0. Use `app.delete()` instead.
+
+You can update your code automatically with the following codemod:
+
+<PackageManagerCommand command="npx codemod@latest @expressjs/route-del-to-delete" />
+
+</Alert>
 
 ### app.disable()
 
@@ -817,7 +841,7 @@ although this matches
 and this matches too
 ```
 
-<Alert type="warning">
+<Alert type="alert">
 
 The following section describes `app.param(callback)`, which is deprecated as of v4.11.0.
 

--- a/src/content/api/4x/api/request/index.mdx
+++ b/src/content/api/4x/api/request/index.mdx
@@ -6,6 +6,7 @@ description: The req object represents the HTTP request and has properties for t
 import Alert from '@components/primitives/Alert/Alert.astro';
 import Signature from '@components/patterns/Signature/Signature.astro';
 import Param from '@components/patterns/Signature/Param.astro';
+import PackageManagerCommand from '@components/patterns/PackageManagerCommand/PackageManagerCommand.astro';
 
 The `req` object represents the HTTP request and has properties for the
 request query string, parameters, body, HTTP headers, and so on. In this documentation and by convention,
@@ -217,6 +218,22 @@ more than once.
 ```js
 // Host: "example.com:3000"
 console.dir(req.hostname);
+// => 'example.com'
+```
+
+### req.host
+
+<Signature type="String" deprecated="v4.5.0" />
+
+<Alert type="alert">
+
+`req.host` is a deprecated alias of [`req.hostname`](#reqhostname) and returns the same value — the hostname with the port number stripped off. It has emitted a deprecation warning since Express v4.5.0. Use `req.hostname` instead.
+
+</Alert>
+
+```js
+// Host: "example.com:3000"
+console.dir(req.host);
 // => 'example.com'
 ```
 
@@ -601,6 +618,26 @@ req.acceptsCharsets('us-ascii');
 
 For more information, or if you have issues or concerns, see [accepts](https://github.com/expressjs/accepts).
 
+### req.acceptsCharset()
+
+<Signature returns="String | false" deprecated="v4.5.0">
+  <Fragment slot="attributes">
+    <Param name="charset" type="String | String[]">
+      One or more character sets to test against the request's `Accept-Charset` header.
+    </Param>
+  </Fragment>
+</Signature>
+
+<Alert type="alert">
+
+`req.acceptsCharset()` is the singular alias of [`req.acceptsCharsets()`](#reqacceptscharsets) and behaves identically. It has emitted a deprecation warning since Express v4.5.0. Use `req.acceptsCharsets()` instead.
+
+You can update your code automatically with the following codemod:
+
+<PackageManagerCommand command="npx codemod@latest @expressjs/pluralize-method-names" />
+
+</Alert>
+
 ### req.acceptsEncodings()
 
 <Signature returns="String | false">
@@ -625,6 +662,26 @@ req.acceptsEncodings('br');
 ```
 
 For more information, or if you have issues or concerns, see [accepts](https://github.com/expressjs/accepts).
+
+### req.acceptsEncoding()
+
+<Signature returns="String | false" deprecated="v4.5.0">
+  <Fragment slot="attributes">
+    <Param name="encoding" type="String | String[]">
+      One or more encodings to test against the request's `Accept-Encoding` header.
+    </Param>
+  </Fragment>
+</Signature>
+
+<Alert type="alert">
+
+`req.acceptsEncoding()` is the singular alias of [`req.acceptsEncodings()`](#reqacceptsencodings) and behaves identically. It has emitted a deprecation warning since Express v4.5.0. Use `req.acceptsEncodings()` instead.
+
+You can update your code automatically with the following codemod:
+
+<PackageManagerCommand command="npx codemod@latest @expressjs/pluralize-method-names" />
+
+</Alert>
 
 ### req.acceptsLanguages()
 
@@ -655,6 +712,27 @@ req.acceptsLanguages();
 ```
 
 For more information, or if you have issues or concerns, see [accepts](https://github.com/expressjs/accepts).
+
+### req.acceptsLanguage()
+
+<Signature returns="String | String[] | false" deprecated="v4.5.0">
+  <Fragment slot="attributes">
+    <Param name="lang" type="String | String[]" optional>
+      One or more languages to test against the request's `Accept-Language` header. If omitted, all
+      accepted languages are returned as an array.
+    </Param>
+  </Fragment>
+</Signature>
+
+<Alert type="alert">
+
+`req.acceptsLanguage()` is the singular alias of [`req.acceptsLanguages()`](#reqacceptslanguages) and behaves identically. It has emitted a deprecation warning since Express v4.5.0. Use `req.acceptsLanguages()` instead.
+
+You can update your code automatically with the following codemod:
+
+<PackageManagerCommand command="npx codemod@latest @expressjs/pluralize-method-names" />
+
+</Alert>
 
 Express (4.x) source: [request.js line 179](https://github.com/expressjs/express/blob/4.x/lib/request.js#L179)
 
@@ -752,7 +830,7 @@ For more information, or if you have issues or concerns, see [type-is](https://g
   </Fragment>
 </Signature>
 
-<Alert type="warning">
+<Alert type="alert">
 
 Deprecated. Use either `req.params`, `req.body` or `req.query`, as applicable.
 

--- a/src/content/api/4x/api/response/index.mdx
+++ b/src/content/api/4x/api/response/index.mdx
@@ -6,6 +6,7 @@ description: The res object represents the HTTP response that an Express app sen
 import Alert from '@components/primitives/Alert/Alert.astro';
 import Signature from '@components/patterns/Signature/Signature.astro';
 import Param from '@components/patterns/Signature/Param.astro';
+import PackageManagerCommand from '@components/patterns/PackageManagerCommand/PackageManagerCommand.astro';
 
 The `res` object represents the HTTP response that an Express app sends when it gets an HTTP request.
 
@@ -116,7 +117,7 @@ app.get('/', function (req, res) {
 
 ### res.append()
 
-<Signature returns="Response">
+<Signature returns="Response" since="v4.11.0">
   <Fragment slot="attributes">
     <Param name="field" type="String">
       The name of the HTTP response header to append to.
@@ -127,7 +128,6 @@ app.get('/', function (req, res) {
   </Fragment>
 </Signature>
 
-<Alert type="info">`res.append()` is supported by Express v4.11.0+</Alert>
 Appends the specified `value` to the HTTP response header `field`. If the header is not already set,
 it creates the header with the specified value. The `value` parameter can be a string or an array.
 
@@ -185,7 +185,7 @@ Clears the cookie with the specified `name` by sending a `Set-Cookie` header tha
 This instructs the client that the cookie has expired and is no longer valid. For more information
 about available `options`, see [res.cookie()](#rescookie).
 
-<Alert type="warning">
+<Alert type="alert">
 
 If the `maxAge` or `expires` options are set, the cookie may not be cleared depending on the time
 values provided, as Express does not ignore these options. It is therefore recommended to omit
@@ -340,7 +340,7 @@ Later you may access this value through the [req.signedCookie](/api/request/#req
     <Param name="filename" type="String" optional>
       The file name for the `Content-Disposition` "filename=" parameter; overrides the name derived from `path`.
     </Param>
-    <Param name="options" type="Object" optional>
+    <Param name="options" type="Object" optional since="v4.16.0">
       Options forwarded to [res.sendFile()](#ressendfile).
 
       <Fragment slot="properties">
@@ -391,8 +391,6 @@ When the `root` option is provided, Express will validate that the relative path
 `path` will resolve within the given `root` option.
 
 </Alert>
-
-<Alert type="info">The optional `options` argument is supported by Express v4.16.0 onwards.</Alert>
 
 The method invokes the callback function `fn(err)` when the transfer is complete
 or when an error occurs. If the callback function is specified and an error occurs,
@@ -527,6 +525,10 @@ res.get('Content-Type');
       The value to send as JSON. Can be any JSON type: object, array, string, Boolean, number, or
       null.
     </Param>
+    <Param name="status" type="Number" optional deprecated="v4.2.0">
+      The HTTP status code, accepted as a positional argument by the old `res.json(obj, status)` and
+      `res.json(status, obj)` signatures. Use [res.status()](#resstatus) instead.
+    </Param>
   </Fragment>
 </Signature>
 
@@ -542,12 +544,26 @@ res.json({ user: 'tobi' });
 res.status(500).json({ error: 'message' });
 ```
 
+<Alert type="alert">
+
+The signature `res.json(obj, status)` has been deprecated since Express v4.2.0 (and the reversed `res.json(status, obj)` since v4.7.0). Set the status separately and chain the call instead: `res.status(status).json(obj)`.
+
+You can update your code automatically with the following codemod:
+
+<PackageManagerCommand command="npx codemod@latest @expressjs/status-send-order" />
+
+</Alert>
+
 ### res.jsonp()
 
 <Signature returns="Response">
   <Fragment slot="attributes">
     <Param name="body" type="any" optional>
       The value to send as a JSONP response. Can be any JSON type.
+    </Param>
+    <Param name="status" type="Number" optional deprecated="v4.2.0">
+      The HTTP status code, accepted as a positional argument by the old `res.jsonp(obj, status)`
+      and `res.jsonp(status, obj)` signatures. Use [res.status()](#resstatus) instead.
     </Param>
   </Fragment>
 </Signature>
@@ -583,6 +599,16 @@ app.set('jsonp callback name', 'cb');
 res.status(500).jsonp({ error: 'message' });
 // => foo({ "error": "message" })
 ```
+
+<Alert type="alert">
+
+The signature `res.jsonp(obj, status)` has been deprecated since Express v4.2.0 (and the reversed `res.jsonp(status, obj)` since v4.7.0). Set the status separately and chain the call instead: `res.status(status).jsonp(obj)`.
+
+You can update your code automatically with the following codemod:
+
+<PackageManagerCommand command="npx codemod@latest @expressjs/status-send-order" />
+
+</Alert>
 
 ### res.links()
 
@@ -631,7 +657,7 @@ res.location('http://example.com');
 res.location('back');
 ```
 
-<Alert type="info">
+<Alert type="alert">
 
 `'back'` was deprecated in 4.21.0, use `req.get('Referrer') || '/'` as an argument instead.
 
@@ -674,6 +700,16 @@ res.redirect('http://example.com');
 res.redirect(301, 'http://example.com');
 res.redirect('../login');
 ```
+
+<Alert type="alert">
+
+The reversed signature `res.redirect(path, status)` (status as the second argument) has been deprecated since Express v4.6.0. Use `res.redirect(status, path)` instead.
+
+You can update your code automatically with the following codemod:
+
+<PackageManagerCommand command="npx codemod@latest @expressjs/redirect-arg-order" />
+
+</Alert>
 
 Redirects can be a fully-qualified URL for redirecting to a different site:
 
@@ -718,7 +754,7 @@ defaulting to `/` when the referer is missing.
 res.redirect('back');
 ```
 
-<Alert type="info">
+<Alert type="alert">
 
 `back` redirect was deprecated in 4.21.0, use `req.get('Referrer') || '/'` as an argument instead.
 
@@ -798,6 +834,11 @@ res.render('user', { name: 'Tobi' }, function (err, html) {
     <Param name="body" type="String | Buffer | Object | Array | Boolean" optional>
       The response body. Strings are sent as HTML; objects and arrays as JSON; Buffers as binary.
     </Param>
+    <Param name="status" type="Number" optional deprecated="v4.5.0">
+      The HTTP status code, accepted as a positional argument by the old `res.send(body, status)`,
+      `res.send(status, body)`, and `res.send(status)` signatures. Use [res.status()](#resstatus) or
+      [res.sendStatus()](#ressendstatus) instead.
+    </Param>
   </Fragment>
 </Signature>
 
@@ -839,9 +880,19 @@ res.send({ user: 'tobi' });
 res.send([1, 2, 3]);
 ```
 
+<Alert type="alert">
+
+The signatures `res.send(body, status)` and `res.send(status)` have been deprecated since Express v4.5.0 (the reversed `res.send(status, body)` since v4.7.0). To set the status, chain the call: `res.status(status).send(body)`. To send only a status code, use [`res.sendStatus()`](#ressendstatus). If you need to send a number as the body, convert it to a string first (for example, `res.send(String(123))`) so it is not interpreted as a status code.
+
+You can update your code automatically with the following codemod:
+
+<PackageManagerCommand command="npx codemod@latest @expressjs/status-send-order" />
+
+</Alert>
+
 ### res.sendFile()
 
-<Signature>
+<Signature since="v4.8.0">
   <Fragment slot="attributes">
     <Param name="path" type="String">
       The path to the file to transfer. Must be absolute unless the `root` option is set.
@@ -882,8 +933,6 @@ res.send([1, 2, 3]);
 
   </Fragment>
 </Signature>
-
-<Alert type="info">`res.sendFile()` is supported by Express v4.8.0 onwards.</Alert>
 
 Transfers the file at the given `path`. Sets the `Content-Type` response HTTP header field
 based on the filename's extension. Unless the `root` option is set in
@@ -948,6 +997,36 @@ app.get('/user/:uid/photos/:file', function (req, res) {
 ```
 
 For more information, or if you have issues or concerns, see [send](https://github.com/pillarjs/send).
+
+### res.sendfile()
+
+<Signature deprecated="v4.8.0">
+  <Fragment slot="attributes">
+    <Param name="path" type="String">
+      The path to the file to transfer.
+    </Param>
+    <Param name="options" type="Object" optional>
+      Options for serving the file. In addition to the options accepted by
+      [`res.sendFile()`](#ressendfile), the legacy `hidden` and `from` options are supported (use
+      `dotfiles` and `root` instead).
+    </Param>
+    <Param name="fn" type="Function" optional>
+      Callback `fn(err)` invoked when the transfer completes or an error occurs.
+    </Param>
+  </Fragment>
+</Signature>
+
+<Alert type="alert">
+
+`res.sendfile()` (lower-cased) is the legacy version of [`res.sendFile()`](#ressendfile) and behaves identically. The camel-cased `res.sendFile()` was introduced in Express v4.8.0, and `res.sendfile()` has emitted a deprecation warning since that release. Use `res.sendFile()` instead.
+
+You can update your code automatically with the following codemod:
+
+<PackageManagerCommand command="npx codemod@latest @expressjs/camelcase-sendfile" />
+
+</Alert>
+
+Transfers the file at the given `path`. This is the legacy, lower-cased version of [`res.sendFile()`](#ressendfile) and behaves the same way. Prefer `res.sendFile()` in new code.
 
 ### res.sendStatus()
 

--- a/src/content/api/4x/api/router/index.mdx
+++ b/src/content/api/4x/api/router/index.mdx
@@ -269,7 +269,7 @@ although this matches
 and this matches too
 ```
 
-<Alert type="warning">
+<Alert type="alert">
 
 The following section describes `router.param(callback)`, which is deprecated as of v4.11.0.
 


### PR DESCRIPTION
ref: https://github.com/expressjs/expressjs.com/discussions/2012