### PR TITLE
fixes: issue #2416 triager guide link broken

### DIFF
--- a/src/content/pages/de/resources/contributing.mdx
+++ b/src/content/pages/de/resources/contributing.mdx
@@ -76,7 +76,7 @@ compromise among committers be the default resolution mechanism.
 ### Triager werden
 
 Jeder kann Triader werden! Lesen Sie mehr über den Prozess, ein Triager zu sein, in
-[dem triage process document](https://github.com/expressjs/discussions/blob/HEAD/contributing/triager-guide.md).
+[dem triage process document](https://github.com/expressjs/discussions/blob/HEAD/docs/contributing/triager-guide.md).
 
 Derzeit kann jedes bestehende [Organisationsmitglied](https://github.com/orgs/expressjs/people)
 einen neuen Triager nominieren. Wenn du daran interessiert bist, ein Triager zu werden, unser bester Ratschlag ist,

--- a/src/content/pages/en/resources/contributing.mdx
+++ b/src/content/pages/en/resources/contributing.mdx
@@ -76,7 +76,7 @@ compromise among committers be the default resolution mechanism.
 ### Becoming a Triager
 
 Anyone can become a triager! Read more about the process of being a triager in
-[the triage process document](https://github.com/expressjs/discussions/blob/HEAD/contributing/triager-guide.md).
+[the triage process document](https://github.com/expressjs/discussions/blob/HEAD/docs/contributing/triager-guide.md).
 
 Currently, any existing [organization member](https://github.com/orgs/expressjs/people) can nominate
 a new triager. If you are interested in becoming a triager, our best advice is to actively participate

--- a/src/content/pages/es/resources/contributing.mdx
+++ b/src/content/pages/es/resources/contributing.mdx
@@ -76,7 +76,7 @@ compromise among committers be the default resolution mechanism.
 ### Convertirse en un Triagente
 
 ¡Cualquiera puede convertirse en triager! Lea más sobre el proceso de ser un triager en
-[el documento del proceso de la prueba](https://github.com/expressjs/discussions/blob/HEAD/contributing/triager-guide.md).
+[el documento del proceso de la prueba](https://github.com/expressjs/discussions/blob/HEAD/docs/contributing/triager-guide.md).
 
 Actualmente, cualquier [miembro de la organización] existente (https://github.com/orgs/expressjs/people) puede nominar
 un nuevo triager. Si estás interesado en convertirte en triager, nuestro mejor consejo es participar activamente

--- a/src/content/pages/fr/resources/contributing.mdx
+++ b/src/content/pages/fr/resources/contributing.mdx
@@ -76,7 +76,7 @@ compromise among committers be the default resolution mechanism.
 ### Devenir un Triager
 
 « N'importe qui peut devenir un triager! » En savoir plus sur le processus de triagerie en
-[document sur le processus de triage](https://github.com/expressjs/discussions/blob/HEAD/contributing/triager-guide.md).
+[document sur le processus de triage](https://github.com/expressjs/discussions/blob/HEAD/docs/contributing/triager-guide.md).
 
 Actuellement, tout [membre de l'organisme](https://github.com/orgs/expressjs/people) existant peut nommer
 un nouveau triager. Si vous souhaitez devenir un triager, notre meilleur conseil est de participer activement

--- a/src/content/pages/it/resources/contributing.mdx
+++ b/src/content/pages/it/resources/contributing.mdx
@@ -76,7 +76,7 @@ tra gli impegni costituiscano il meccanismo di risoluzione di default.
 ### Diventare un Triager
 
 Chiunque può diventare un triangolo! Per saperne di più sul processo di essere un triager in
-[il documento di processo di triage](https://github.com/expressjs/discussions/blob/HEAD/contributing/triager-guide.md).
+[il documento di processo di triage](https://github.com/expressjs/discussions/blob/HEAD/docs/contributing/triager-guide.md).
 
 Attualmente, qualsiasi [membro dell'organizzazione](https://github.com/orgs/expressjs/people) può nominare
 un nuovo triager. Se siete interessati a diventare un triager, il nostro miglior consiglio è quello di partecipare attivamente a

--- a/src/content/pages/ja/resources/contributing.mdx
+++ b/src/content/pages/ja/resources/contributing.mdx
@@ -75,7 +75,7 @@ be landed by any committer.
 ### Triager になる
 
 誰でもトリアージになれます！
-[triage process document](https://github.com/expressjs/discussions/blob/HEAD/contributing/triager-guide.md)でトリガーになるプロセスの詳細をお読みください。
+[triage process document](https://github.com/expressjs/discussions/blob/HEAD/docs/contributing/triager-guide.md)でトリガーになるプロセスの詳細をお読みください。
 
 Currently, any existing [organization member](https://github.com/orgs/expressjs/people) can nominate
 a new triager. トリアガーになることに興味があるなら 私たちの最善のアドバイスは、トリアージやプルリクエストを支援することによって、コミュニティで

--- a/src/content/pages/ko/resources/contributing.mdx
+++ b/src/content/pages/ko/resources/contributing.mdx
@@ -76,7 +76,7 @@ compromise among committers be the default resolution mechanism.
 ### Becoming a Triager
 
 Anyone can become a triager! Read more about the process of being a triager in
-[the triage process document](https://github.com/expressjs/discussions/blob/HEAD/contributing/triager-guide.md).
+[the triage process document](https://github.com/expressjs/discussions/blob/HEAD/docs/contributing/triager-guide.md).
 
 Currently, any existing [organization member](https://github.com/orgs/expressjs/people) can nominate
 a new triager. If you are interested in becoming a triager, our best advice is to actively participate

--- a/src/content/pages/pt-br/resources/contributing.mdx
+++ b/src/content/pages/pt-br/resources/contributing.mdx
@@ -76,7 +76,7 @@ entre os committers sejam o mecanismo de resolução padrão.
 ### Tornando-se um Triager
 
 Qualquer um pode se tornar um triagante! Leia mais sobre o processo de ser um triager em
-[o documento do processo de triagem](https://github.com/expressjs/discussions/blob/HEAD/contributing/triager-guide.md).
+[o documento do processo de triagem](https://github.com/expressjs/discussions/blob/HEAD/docs/contributing/triager-guide.md).
 
 Atualmente, qualquer [membro da organização](https://github.com/orgs/expressjs/people) existente pode nomear
 um novo triagador. Se você está interessado em se tornar um triagro, nosso melhor conselho é participar ativamente

--- a/src/content/pages/zh-cn/resources/contributing.mdx
+++ b/src/content/pages/zh-cn/resources/contributing.mdx
@@ -76,7 +76,7 @@ compromise among committers be the default resolution mechanism.
 ### Becoming a Triager
 
 Anyone can become a triager! Read more about the process of being a triager in
-[the triage process document](https://github.com/expressjs/discussions/blob/HEAD/contributing/triager-guide.md).
+[the triage process document](https://github.com/expressjs/discussions/blob/HEAD/docs/contributing/triager-guide.md).
 
 Currently, any existing [organization member](https://github.com/orgs/expressjs/people) can nominate
 a new triager. If you are interested in becoming a triager, our best advice is to actively participate

--- a/src/content/pages/zh-tw/resources/contributing.mdx
+++ b/src/content/pages/zh-tw/resources/contributing.mdx
@@ -76,7 +76,7 @@ compromise among committers be the default resolution mechanism.
 ### Becoming a Triager
 
 Anyone can become a triager! Read more about the process of being a triager in
-[the triage process document](https://github.com/expressjs/discussions/blob/HEAD/contributing/triager-guide.md).
+[the triage process document](https://github.com/expressjs/discussions/blob/HEAD/docs/contributing/triager-guide.md).
 
 Currently, any existing [organization member](https://github.com/orgs/expressjs/people) can nominate
 a new triager. If you are interested in becoming a triager, our best advice is to actively participate


### PR DESCRIPTION
### What was fixed

- Updated the link in the **“Becoming a Triager”** section of the contributing page.
- The old link pointed to:
- `https://github.com/expressjs/discussions/blob/HEAD/contributing/triager-guide.md`
- The new link now points to the correct location:
- `https://github.com/expressjs/discussions/blob/HEAD/docs/contributing/triager-guide.md`

### Why it was done

- The previous link opened a 404 page on GitHub.
- The correct URL is under `docs/contributing/triager-guide.md`, not `contributing/triager-guide.md`.

### Where it was changed

- Fixed all translations of the `resources/contributing.mdx` page:
- `en`
- `de`
- `es`
- `fr`
- `it`
- `ja`
- `ko`
- `pt-br`
- `zh-cn`
- `zh-tw`

### Result

- The “the triage process document” button/link should now go to the correct GitHub document without producing a 404.