### PR TITLE
fix: resolve relative links in get-contributing.sh sync script (#2416)

### DIFF
--- a/.github/scripts/get-contributing.sh
+++ b/.github/scripts/get-contributing.sh
@@ -79,9 +79,14 @@ while IFS= read -r line; do
     echo "fetching $repo/$path..." >&2
     RAW=$(curl -s "https://raw.githubusercontent.com/${repo}/HEAD/${path}")
 
-    # Convert relative links to absolute GitHub URLs
+    # Convert relative links to absolute GitHub URLs, resolved from the source file's directory
     BASEURL="https://github.com/${repo}/blob/HEAD"
-    RAW=$(echo "$RAW" | sed -E "s|\]\(([^)#/][^):]*)\)|](${BASEURL}/\1)|g")
+    if [[ "$path" == */* ]]; then
+      linkprefix="${path%/*}/"
+    else
+      linkprefix=""
+    fi
+    RAW=$(echo "$RAW" | sed -E "s|\]\(([^)#/][^):]*)\)|](${BASEURL}/${linkprefix}\1)|g")
 
     TRANSFORMED=$(transform_content "$RAW" "$level")
     echo "$TRANSFORMED"

--- a/src/content/pages/en/resources/contributing.mdx
+++ b/src/content/pages/en/resources/contributing.mdx
@@ -17,20 +17,20 @@ The Express technical committee consists of active project members, and guides d
 
 The goal of this document is to create a contribution process that:
 
-* Encourages new contributions.
-* Encourages contributors to remain involved.
-* Avoids unnecessary processes and bureaucracy whenever possible.
-* Creates a transparent decision making process that makes it clear how
-contributors can be involved in decision making.
+- Encourages new contributions.
+- Encourages contributors to remain involved.
+- Avoids unnecessary processes and bureaucracy whenever possible.
+- Creates a transparent decision making process that makes it clear how
+  contributors can be involved in decision making.
 
 ### Vocabulary
 
-* A **Contributor** is any individual creating or commenting on an issue or pull request.
-* A **Committer** is a subset of contributors who have been given write access to the repository.
-* A **Project Captain** is the lead maintainer of a repository.
-* A **TC (Technical Committee)** is a group of committers representing the required technical
-expertise to resolve rare disputes.
-* A **Triager** is a subset of contributors who have been given triage access to the repository.
+- A **Contributor** is any individual creating or commenting on an issue or pull request.
+- A **Committer** is a subset of contributors who have been given write access to the repository.
+- A **Project Captain** is the lead maintainer of a repository.
+- A **TC (Technical Committee)** is a group of committers representing the required technical
+  expertise to resolve rare disputes.
+- A **Triager** is a subset of contributors who have been given triage access to the repository.
 
 ### Logging Issues
 
@@ -155,12 +155,12 @@ to the captain role. To do so, they should submit a PR to this document, updatin
 **Active Project Captains** section (while maintaining the sort order) with the project
 name, the nominee's GitHub handle, and their npm username (if different).
 
-* Repos can have as many captains as make sense for the scope of work.
-* A TC member or an existing repo captain **on the same project** can nominate a new captain.
+- Repos can have as many captains as make sense for the scope of work.
+- A TC member or an existing repo captain **on the same project** can nominate a new captain.
   Repo captains from other projects should not nominate captains for a different project.
 
 The PR will require at least 2 approvals from TC members and 2 weeks hold time to allow
-for comment and/or dissent.  When the PR is merged, a TC member will add them to the
+for comment and/or dissent. When the PR is merged, a TC member will add them to the
 proper GitHub/npm groups.
 
 #### Active Projects and Captains
@@ -183,13 +183,13 @@ Anyone may request a temporary leave from active participation due to personal o
 
 #### Inactivity Process
 
-* If someone is deemed inactive, the individual may be transitioned to an emeritus role that reflects their past contributions. A best effort will be made to inform them that this has occurred. They may request to be reinstated when they are ready to be active again.
-* The emeritus status helps preserve a clear record of contributors who have meaningfully shaped the project over time.
+- If someone is deemed inactive, the individual may be transitioned to an emeritus role that reflects their past contributions. A best effort will be made to inform them that this has occurred. They may request to be reinstated when they are ready to be active again.
+- The emeritus status helps preserve a clear record of contributors who have meaningfully shaped the project over time.
 
 #### Accountability
 
-* The Technical Committee (TC) and the respective captains of each package/team are responsible for assessing activity levels and enacting this policy fairly and transparently, in coordination with other relevant teams.
-* In case of disagreement, the situation can be discussed and resolved by consensus within the TC or appropriate team.
+- The Technical Committee (TC) and the respective captains of each package/team are responsible for assessing activity levels and enacting this policy fairly and transparently, in coordination with other relevant teams.
+- In case of disagreement, the situation can be discussed and resolved by consensus within the TC or appropriate team.
 
 ### Developer's Certificate of Origin 1.1
 
@@ -231,9 +231,9 @@ For issues in other Express managed repos (everything in `expressjs`, `pillarjs`
 
 ### PRs and Code contributions
 
-* Tests must pass.
-* Follow the [JavaScript Standard Style](https://standardjs.com/) and `npm run lint`.
-* If you fix a bug, add a test.
+- Tests must pass.
+- Follow the [JavaScript Standard Style](https://standardjs.com/) and `npm run lint`.
+- If you fix a bug, add a test.
 
 ### Branches
 
@@ -267,10 +267,10 @@ being trigger happy with posting a question issue.
 
 Things that will help get your question issue looked at:
 
-* Full and runnable JS code.
-* Clear description of the problem or unexpected behavior.
-* Clear description of the expected result.
-* Steps you have taken to debug it yourself.
+- Full and runnable JS code.
+- Clear description of the problem or unexpected behavior.
+- Clear description of the expected result.
+- Steps you have taken to debug it yourself.
 
 If you post a question and do not outline the above items or make it easy for
 us to understand and reproduce your issue, it will be closed.
@@ -281,7 +281,7 @@ by the maintainers
 of an issue. If you
 are unsure and open an issue, we may move it to discussions if we triage them and decide they do
 not need high
-visibility or maintainer input. 
+visibility or maintainer input.
 
 ## Security Policies and Procedures
 
@@ -290,12 +290,12 @@ visibility or maintainer input.
 This document outlines security procedures and general policies for the Express
 project.
 
-  * [Reporting a Bug or Security Vulnerability](#reporting-a-bug-or-security-vulnerability)
-  * [Disclosure Policy](#disclosure-policy)
-  * [Comments on this Policy](#comments-on-this-policy)
-  * [The Express Threat Model](#the-express-threat-model)
+- [Reporting a Bug or Security Vulnerability](#reporting-a-bug-or-security-vulnerability)
+- [Disclosure Policy](#disclosure-policy)
+- [Comments on this Policy](#comments-on-this-policy)
+- [The Express Threat Model](#the-express-threat-model)
 
-### Reporting a Bug or Security Vulnerability  
+### Reporting a Bug or Security Vulnerability
 
 <Alert type="info">
 
@@ -303,15 +303,15 @@ Before reporting a vulnerability, please review the [Express Threat Model](#the-
 
 </Alert>
 
-The Express team and community take all security vulnerabilities seriously. 
-Thank you for improving the security of Express and related projects. 
-We appreciate your efforts in responsible disclosure and will make every effort 
-to acknowledge your contributions.  
+The Express team and community take all security vulnerabilities seriously.
+Thank you for improving the security of Express and related projects.
+We appreciate your efforts in responsible disclosure and will make every effort
+to acknowledge your contributions.
 
-A [Security triage team member](https://github.com/expressjs/security-wg#security-triage-team-expressjssecurity-triage) 
-or [the repo captain](https://github.com/expressjs/discussions/blob/master/docs/contributing/captains_and_committers.md) 
-will acknowledge your report as soon as possible. 
-These timelines may extend when our triage 
+A [Security triage team member](https://github.com/expressjs/security-wg#security-triage-team-expressjssecurity-triage)
+or [the repo captain](https://github.com/expressjs/discussions/blob/master/docs/contributing/captains_and_committers.md)
+will acknowledge your report as soon as possible.
+These timelines may extend when our triage
 volunteers are away on holiday, particularly at the end of the year.
 
 After the initial reply to your report, the security team will
@@ -324,34 +324,34 @@ You can find more information about our process in [this guide](https://github.c
 
 </Alert>
 
+#### Reporting Security Bugs via GitHub Security Advisory (Preferred)
 
-#### Reporting Security Bugs via GitHub Security Advisory (Preferred)  
-
-The preferred way to report security vulnerabilities is through 
-[GitHub Security Advisories](https://github.com/advisories). 
-This allows us to collaborate on a fix while maintaining the 
-confidentiality of the report.  
+The preferred way to report security vulnerabilities is through
+[GitHub Security Advisories](https://github.com/advisories).
+This allows us to collaborate on a fix while maintaining the
+confidentiality of the report.
 
 To report a vulnerability
-([docs](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability)):  
-1. Visit the **Security** tab of the affected repository on GitHub.  
-2. Click **Report a vulnerability** and follow the provided steps.  
+([docs](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability)):
 
-This process applies to any repositories within the Express ecosystem. 
-If you are unsure whether a repository falls under this policy, 
-feel free to reach out via email.  
+1. Visit the **Security** tab of the affected repository on GitHub.
+2. Click **Report a vulnerability** and follow the provided steps.
 
-#### Reporting via Email  
+This process applies to any repositories within the Express ecosystem.
+If you are unsure whether a repository falls under this policy,
+feel free to reach out via email.
 
-If you prefer, you can also report security issues by emailing `express-security@lists.openjsf.org`.  
+#### Reporting via Email
 
-To ensure a timely response, please include all relevant details directly in the email body rather than linking to external sources or attaching files.  
+If you prefer, you can also report security issues by emailing `express-security@lists.openjsf.org`.
 
-The lead maintainer will acknowledge your email within 48 hours and provide an initial response outlining the next steps. The security team will keep you updated on the progress and may request additional details.  
+To ensure a timely response, please include all relevant details directly in the email body rather than linking to external sources or attaching files.
 
-#### Third-Party Modules  
+The lead maintainer will acknowledge your email within 48 hours and provide an initial response outlining the next steps. The security team will keep you updated on the progress and may request additional details.
 
-If the security issue pertains to a third-party module that is not directly maintained within the Express ecosystem, please report it to the maintainers of that module.  
+#### Third-Party Modules
+
+If the security issue pertains to a third-party module that is not directly maintained within the Express ecosystem, please report it to the maintainers of that module.
 
 ### Disclosure Policy
 
@@ -359,10 +359,10 @@ When the security team receives a security bug report, they will assign it to a
 primary handler. This person will coordinate the fix and release process,
 involving the following steps:
 
-  * Confirm the problem and determine the affected versions.
-  * Audit code to find any potential similar problems.
-  * Prepare fixes for all releases still under maintenance. These fixes will be
-    released as fast as possible to npm.
+- Confirm the problem and determine the affected versions.
+- Audit code to find any potential similar problems.
+- Prepare fixes for all releases still under maintenance. These fixes will be
+  released as fast as possible to npm.
 
 ### Comments on this Policy
 
@@ -376,4 +376,3 @@ The Express threat model defines the boundaries of what the framework considers 
 Many commonly reported concerns fall outside Express's security scope and are the responsibility of the application developer. Such as prototype pollution from unsanitized user input, misconfigured static file serving, or issues in third-party dependencies.
 
 For complete details, see the [Express Threat Model](https://github.com/expressjs/security-wg/blob/main/docs/ThreatModel.md).
-

--- a/src/content/pages/en/resources/contributing.mdx
+++ b/src/content/pages/en/resources/contributing.mdx
@@ -17,20 +17,20 @@ The Express technical committee consists of active project members, and guides d
 
 The goal of this document is to create a contribution process that:
 
-- Encourages new contributions.
-- Encourages contributors to remain involved.
-- Avoids unnecessary processes and bureaucracy whenever possible.
-- Creates a transparent decision making process that makes it clear how
-  contributors can be involved in decision making.
+* Encourages new contributions.
+* Encourages contributors to remain involved.
+* Avoids unnecessary processes and bureaucracy whenever possible.
+* Creates a transparent decision making process that makes it clear how
+contributors can be involved in decision making.
 
 ### Vocabulary
 
-- A **Contributor** is any individual creating or commenting on an issue or pull request.
-- A **Committer** is a subset of contributors who have been given write access to the repository.
-- A **Project Captain** is the lead maintainer of a repository.
-- A **TC (Technical Committee)** is a group of committers representing the required technical
-  expertise to resolve rare disputes.
-- A **Triager** is a subset of contributors who have been given triage access to the repository.
+* A **Contributor** is any individual creating or commenting on an issue or pull request.
+* A **Committer** is a subset of contributors who have been given write access to the repository.
+* A **Project Captain** is the lead maintainer of a repository.
+* A **TC (Technical Committee)** is a group of committers representing the required technical
+expertise to resolve rare disputes.
+* A **Triager** is a subset of contributors who have been given triage access to the repository.
 
 ### Logging Issues
 
@@ -76,7 +76,7 @@ compromise among committers be the default resolution mechanism.
 ### Becoming a Triager
 
 Anyone can become a triager! Read more about the process of being a triager in
-[the triage process document](https://github.com/expressjs/discussions/blob/HEAD/contributing/triager-guide.md).
+[the triage process document](https://github.com/expressjs/discussions/blob/HEAD/docs/contributing/triager-guide.md).
 
 Currently, any existing [organization member](https://github.com/orgs/expressjs/people) can nominate
 a new triager. If you are interested in becoming a triager, our best advice is to actively participate
@@ -155,12 +155,12 @@ to the captain role. To do so, they should submit a PR to this document, updatin
 **Active Project Captains** section (while maintaining the sort order) with the project
 name, the nominee's GitHub handle, and their npm username (if different).
 
-- Repos can have as many captains as make sense for the scope of work.
-- A TC member or an existing repo captain **on the same project** can nominate a new captain.
+* Repos can have as many captains as make sense for the scope of work.
+* A TC member or an existing repo captain **on the same project** can nominate a new captain.
   Repo captains from other projects should not nominate captains for a different project.
 
 The PR will require at least 2 approvals from TC members and 2 weeks hold time to allow
-for comment and/or dissent. When the PR is merged, a TC member will add them to the
+for comment and/or dissent.  When the PR is merged, a TC member will add them to the
 proper GitHub/npm groups.
 
 #### Active Projects and Captains
@@ -183,13 +183,13 @@ Anyone may request a temporary leave from active participation due to personal o
 
 #### Inactivity Process
 
-- If someone is deemed inactive, the individual may be transitioned to an emeritus role that reflects their past contributions. A best effort will be made to inform them that this has occurred. They may request to be reinstated when they are ready to be active again.
-- The emeritus status helps preserve a clear record of contributors who have meaningfully shaped the project over time.
+* If someone is deemed inactive, the individual may be transitioned to an emeritus role that reflects their past contributions. A best effort will be made to inform them that this has occurred. They may request to be reinstated when they are ready to be active again.
+* The emeritus status helps preserve a clear record of contributors who have meaningfully shaped the project over time.
 
 #### Accountability
 
-- The Technical Committee (TC) and the respective captains of each package/team are responsible for assessing activity levels and enacting this policy fairly and transparently, in coordination with other relevant teams.
-- In case of disagreement, the situation can be discussed and resolved by consensus within the TC or appropriate team.
+* The Technical Committee (TC) and the respective captains of each package/team are responsible for assessing activity levels and enacting this policy fairly and transparently, in coordination with other relevant teams.
+* In case of disagreement, the situation can be discussed and resolved by consensus within the TC or appropriate team.
 
 ### Developer's Certificate of Origin 1.1
 
@@ -231,9 +231,9 @@ For issues in other Express managed repos (everything in `expressjs`, `pillarjs`
 
 ### PRs and Code contributions
 
-- Tests must pass.
-- Follow the [JavaScript Standard Style](https://standardjs.com/) and `npm run lint`.
-- If you fix a bug, add a test.
+* Tests must pass.
+* Follow the [JavaScript Standard Style](https://standardjs.com/) and `npm run lint`.
+* If you fix a bug, add a test.
 
 ### Branches
 
@@ -267,10 +267,10 @@ being trigger happy with posting a question issue.
 
 Things that will help get your question issue looked at:
 
-- Full and runnable JS code.
-- Clear description of the problem or unexpected behavior.
-- Clear description of the expected result.
-- Steps you have taken to debug it yourself.
+* Full and runnable JS code.
+* Clear description of the problem or unexpected behavior.
+* Clear description of the expected result.
+* Steps you have taken to debug it yourself.
 
 If you post a question and do not outline the above items or make it easy for
 us to understand and reproduce your issue, it will be closed.
@@ -281,7 +281,7 @@ by the maintainers
 of an issue. If you
 are unsure and open an issue, we may move it to discussions if we triage them and decide they do
 not need high
-visibility or maintainer input.
+visibility or maintainer input. 
 
 ## Security Policies and Procedures
 
@@ -290,12 +290,12 @@ visibility or maintainer input.
 This document outlines security procedures and general policies for the Express
 project.
 
-- [Reporting a Bug or Security Vulnerability](#reporting-a-bug-or-security-vulnerability)
-- [Disclosure Policy](#disclosure-policy)
-- [Comments on this Policy](#comments-on-this-policy)
-- [The Express Threat Model](#the-express-threat-model)
+  * [Reporting a Bug or Security Vulnerability](#reporting-a-bug-or-security-vulnerability)
+  * [Disclosure Policy](#disclosure-policy)
+  * [Comments on this Policy](#comments-on-this-policy)
+  * [The Express Threat Model](#the-express-threat-model)
 
-### Reporting a Bug or Security Vulnerability
+### Reporting a Bug or Security Vulnerability  
 
 <Alert type="info">
 
@@ -303,15 +303,15 @@ Before reporting a vulnerability, please review the [Express Threat Model](#the-
 
 </Alert>
 
-The Express team and community take all security vulnerabilities seriously.
-Thank you for improving the security of Express and related projects.
-We appreciate your efforts in responsible disclosure and will make every effort
-to acknowledge your contributions.
+The Express team and community take all security vulnerabilities seriously. 
+Thank you for improving the security of Express and related projects. 
+We appreciate your efforts in responsible disclosure and will make every effort 
+to acknowledge your contributions.  
 
-A [Security triage team member](https://github.com/expressjs/security-wg#security-triage-team-expressjssecurity-triage)
-or [the repo captain](https://github.com/expressjs/discussions/blob/master/docs/contributing/captains_and_committers.md)
-will acknowledge your report as soon as possible.
-These timelines may extend when our triage
+A [Security triage team member](https://github.com/expressjs/security-wg#security-triage-team-expressjssecurity-triage) 
+or [the repo captain](https://github.com/expressjs/discussions/blob/master/docs/contributing/captains_and_committers.md) 
+will acknowledge your report as soon as possible. 
+These timelines may extend when our triage 
 volunteers are away on holiday, particularly at the end of the year.
 
 After the initial reply to your report, the security team will
@@ -324,34 +324,34 @@ You can find more information about our process in [this guide](https://github.c
 
 </Alert>
 
-#### Reporting Security Bugs via GitHub Security Advisory (Preferred)
 
-The preferred way to report security vulnerabilities is through
-[GitHub Security Advisories](https://github.com/advisories).
-This allows us to collaborate on a fix while maintaining the
-confidentiality of the report.
+#### Reporting Security Bugs via GitHub Security Advisory (Preferred)  
+
+The preferred way to report security vulnerabilities is through 
+[GitHub Security Advisories](https://github.com/advisories). 
+This allows us to collaborate on a fix while maintaining the 
+confidentiality of the report.  
 
 To report a vulnerability
-([docs](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability)):
+([docs](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability)):  
+1. Visit the **Security** tab of the affected repository on GitHub.  
+2. Click **Report a vulnerability** and follow the provided steps.  
 
-1. Visit the **Security** tab of the affected repository on GitHub.
-2. Click **Report a vulnerability** and follow the provided steps.
+This process applies to any repositories within the Express ecosystem. 
+If you are unsure whether a repository falls under this policy, 
+feel free to reach out via email.  
 
-This process applies to any repositories within the Express ecosystem.
-If you are unsure whether a repository falls under this policy,
-feel free to reach out via email.
+#### Reporting via Email  
 
-#### Reporting via Email
+If you prefer, you can also report security issues by emailing `express-security@lists.openjsf.org`.  
 
-If you prefer, you can also report security issues by emailing `express-security@lists.openjsf.org`.
+To ensure a timely response, please include all relevant details directly in the email body rather than linking to external sources or attaching files.  
 
-To ensure a timely response, please include all relevant details directly in the email body rather than linking to external sources or attaching files.
+The lead maintainer will acknowledge your email within 48 hours and provide an initial response outlining the next steps. The security team will keep you updated on the progress and may request additional details.  
 
-The lead maintainer will acknowledge your email within 48 hours and provide an initial response outlining the next steps. The security team will keep you updated on the progress and may request additional details.
+#### Third-Party Modules  
 
-#### Third-Party Modules
-
-If the security issue pertains to a third-party module that is not directly maintained within the Express ecosystem, please report it to the maintainers of that module.
+If the security issue pertains to a third-party module that is not directly maintained within the Express ecosystem, please report it to the maintainers of that module.  
 
 ### Disclosure Policy
 
@@ -359,10 +359,10 @@ When the security team receives a security bug report, they will assign it to a
 primary handler. This person will coordinate the fix and release process,
 involving the following steps:
 
-- Confirm the problem and determine the affected versions.
-- Audit code to find any potential similar problems.
-- Prepare fixes for all releases still under maintenance. These fixes will be
-  released as fast as possible to npm.
+  * Confirm the problem and determine the affected versions.
+  * Audit code to find any potential similar problems.
+  * Prepare fixes for all releases still under maintenance. These fixes will be
+    released as fast as possible to npm.
 
 ### Comments on this Policy
 
@@ -376,3 +376,4 @@ The Express threat model defines the boundaries of what the framework considers 
 Many commonly reported concerns fall outside Express's security scope and are the responsibility of the application developer. Such as prototype pollution from unsanitized user input, misconfigured static file serving, or issues in third-party dependencies.
 
 For complete details, see the [Express Threat Model](https://github.com/expressjs/security-wg/blob/main/docs/ThreatModel.md).
+


### PR DESCRIPTION
Fixes #2416

On the [contributing page](https://expressjs.com/en/resources/contributing/#becoming-a-triager), the "triage process document" link returns a 404 on GitHub.

The link text comes from [`docs/GOVERNANCE.md`](https://github.com/expressjs/discussions/blob/HEAD/docs/GOVERNANCE.md) in `expressjs/discussions`, where it's written as a relative path: `contributing/triager-guide.md`. That works on GitHub because the file lives under `docs/`, so the real target is [`docs/contributing/triager-guide.md`](https://github.com/expressjs/discussions/blob/HEAD/docs/contributing/triager-guide.md).

When [`.github/scripts/get-contributing.sh`](https://github.com/expressjs/expressjs.com/blob/main/.github/scripts/get-contributing.sh) syncs that content into the website, it turns relative links into full GitHub URLs. However, it was treating them as if they started from the repo root, dropping the `docs/` part of the path.

My proposed fix is to resolve relative links from the directory of the source file being fetched, then regenerate [`src/content/pages/en/resources/contributing.mdx`](https://github.com/expressjs/expressjs.com/blob/main/src/content/pages/en/resources/contributing.mdx). Other locale files aren't touched in this PR since they come from Crowdin, not `get-contributing.sh`. 

### Verification

Ran `get-contributing.sh` from `.github/scripts/`:

<img width="544" height="157" alt="bash-screenshot" src="https://github.com/user-attachments/assets/bd828a7e-1e9c-4fa5-b656-3513661a74a6" />

Before/after link at `/en/resources/contributing/#becoming-a-triager`:

<img width="898" height="183" alt="after-bash-scshot" src="https://github.com/user-attachments/assets/9919a080-234c-446e-8d3e-d151f540f8cb" />

Destination on GitHub:

<img width="1917" height="1031" alt="image" src="https://github.com/user-attachments/assets/86039418-a8af-421d-915b-75d800da0d80" />
