### PR TITLE
llms: no incluide i18n guides

### DIFF
--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -9,9 +9,14 @@ export const GET: APIRoute = async ({ site }) => {
   // Extract API versions from the collection (e.g. "5x", "4x", "3x")
   const apiVersions = [...new Set(api.map((d) => d.id.split('/')[0]))].sort().reverse();
 
-  // Extract docs versions (e.g. "5x", "4x")
+  // Extract docs versions (e.g. "5x", "4x") from the English docs only, so that
+  // translated locales (de, fr, zh-tw, ...) are not mistaken for versions.
   const docs = await getCollection('docs');
-  const docsVersions = [...new Set(docs.map((d) => d.id.replace('en/', '').split('/')[0]))]
+  const docsVersions = [
+    ...new Set(
+      docs.filter((d) => d.id.startsWith('en/')).map((d) => d.id.replace('en/', '').split('/')[0])
+    ),
+  ]
     .sort()
     .reverse();
 

--- a/src/pages/llms/guides-[version].txt.ts
+++ b/src/pages/llms/guides-[version].txt.ts
@@ -4,7 +4,11 @@ import { getRawMarkdown, buildSection, textResponse } from '@/utils/llms';
 
 export async function getStaticPaths() {
   const docs = await getCollection('docs');
-  const versions = [...new Set(docs.map((d) => d.id.replace('en/', '').split('/')[0]))];
+  const versions = [
+    ...new Set(
+      docs.filter((d) => d.id.startsWith('en/')).map((d) => d.id.replace('en/', '').split('/')[0])
+    ),
+  ];
   return versions.map((version) => ({ params: { version } }));
 }
 


### PR DESCRIPTION
We were accidentally generating `llms.txt` files for the i18n guides.

<img width="1350" height="595" alt="imagen" src="https://github.com/user-attachments/assets/29db7d15-18fe-4e1f-86d3-fbe29c32241a" />


<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
