### PR TITLE
fix(seo): declare canonical URLs for unversioned and untranslated page copies

### DIFF
--- a/src/layouts/DocLayout.astro
+++ b/src/layouts/DocLayout.astro
@@ -21,6 +21,7 @@ interface Props {
   isTranslation?: boolean;
   prev?: AdjacentPage | null;
   next?: AdjacentPage | null;
+  canonicalPathname?: string;
 }
 
 const {
@@ -31,6 +32,7 @@ const {
   isTranslation = false,
   prev,
   next,
+  canonicalPathname,
 } = Astro.props;
 
 const lang = getLangFromUrl(Astro.url);
@@ -39,7 +41,7 @@ const t = useTranslations(lang);
 const breadcrumbs = buildBreadcrumbs(Astro.url.pathname, t);
 ---
 
-<Layout title={title} description={description}>
+<Layout title={title} description={description} canonicalPathname={canonicalPathname}>
   <Container>
     <PageTopbar breadcrumbs={breadcrumbs}>
       {

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -11,6 +11,8 @@ interface Props {
   description?: string;
   authors?: { name: string; github?: string }[];
   image?: string;
+  /** Canonical pathname override, for pages served as a copy of another URL. */
+  canonicalPathname?: string;
 }
 
 const {
@@ -18,13 +20,12 @@ const {
   description = 'Fast, unopinionated, minimalist web framework for Node.js',
   authors,
   image,
+  canonicalPathname,
 } = Astro.props;
 
 const pageTitle = title
   ? `${title} · Express.js`
   : 'Express.js · Node.js web application framework';
-
-const canonicalUrl = new URL(Astro.url.pathname, Astro.site || Astro.url.origin);
 
 const pathname = Astro.url.pathname.replace(/\/$/, '');
 const segments = pathname.split('/').filter(Boolean);
@@ -33,6 +34,14 @@ const restSegments = segments.slice(1);
 const isApi =
   restSegments[0] === 'api' || (restSegments[1] === 'api' && /^\dx$/.test(restSegments[0] ?? ''));
 const isBlogOrApi = restSegments[0] === 'blog' || isApi;
+
+// Blog and API content is not translated, so their canonical is the English
+// page and they emit no hreflang alternates.
+let canonicalPath = canonicalPathname ?? Astro.url.pathname;
+if (isBlogOrApi) {
+  canonicalPath = replaceLanguageInPath(canonicalPath, 'en');
+}
+const canonicalUrl = new URL(canonicalPath, Astro.site || Astro.url.origin);
 // Build the OG image URL:
 // - Home pages (no rest segments) use a per-language image: /og/home-{lang}.png
 // - Blog and API pages strip the lang prefix since their content is not translated: /og/blog-{slug}.png
@@ -90,18 +99,16 @@ const lang = getLangFromUrl(Astro.url);
     <link rel="canonical" href={canonicalUrl} />
 
     {
-      languageCodes.map((altLang) => (
-        <link
-          rel="alternate"
-          hreflang={altLang}
-          href={
-            new URL(
-              replaceLanguageInPath(Astro.url.pathname, altLang),
-              Astro.site || Astro.url.origin
-            )
-          }
-        />
-      ))
+      !isBlogOrApi &&
+        languageCodes.map((altLang) => (
+          <link
+            rel="alternate"
+            hreflang={altLang}
+            href={
+              new URL(replaceLanguageInPath(canonicalPath, altLang), Astro.site || Astro.url.origin)
+            }
+          />
+        ))
     }
 
     <title>{pageTitle}</title>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -100,12 +100,15 @@ const lang = getLangFromUrl(Astro.url);
 
     {
       !isBlogOrApi &&
-        languageCodes.map((altLang) => (
+        ['x-default', ...languageCodes].map((altLang) => (
           <link
             rel="alternate"
             hreflang={altLang}
             href={
-              new URL(replaceLanguageInPath(canonicalPath, altLang), Astro.site || Astro.url.origin)
+              new URL(
+                replaceLanguageInPath(canonicalPath, altLang === 'x-default' ? 'en' : altLang),
+                Astro.site || Astro.url.origin
+              )
             }
           />
         ))

--- a/src/pages/[lang]/[...slug].astro
+++ b/src/pages/[lang]/[...slug].astro
@@ -209,6 +209,14 @@ const editUrl = isTranslation
 // Shared collections (api/blog) are compiled once, so their in-content links are
 // baked to the default language. Re-localize them per render-language.
 const isSharedCollection = page.collection === 'api' || page.collection === 'blog';
+
+// Versioned content served at an unversioned URL is a copy of the default
+// version; its canonical is the versioned URL.
+const contentSlug = page.collection === 'api' ? page.id : page.id.split('/').slice(1).join('/');
+const isVersionedContent = VERSION_PREFIXES.some((v) => contentSlug.startsWith(`${v}/`));
+const servedUnversioned =
+  isVersionedContent && !VERSION_PREFIXES.some((v) => slug.startsWith(`${v}/`));
+const canonicalPathname = servedUnversioned ? `/${lang}/${contentSlug}/` : undefined;
 ---
 
 <DocLayout
@@ -219,6 +227,7 @@ const isSharedCollection = page.collection === 'api' || page.collection === 'blo
   isTranslation={isTranslation}
   prev={prev}
   next={next}
+  canonicalPathname={canonicalPathname}
 >
   {isSharedCollection ? <Content components={{ a: LocalizedLink }} /> : <Content />}
 </DocLayout>


### PR DESCRIPTION
Technically, these pages contain the same content, just for i18n purposes. Because of that, we keep a canonical pointing to the English page so Google can index it more effectively.

It would also be good to exclude them from the sitemap, but I'd consider that a future improvement since I haven't found a clean way to do it yet.

Also, the reason I chose the unversioned URLs to point to the latest version (v5) is that Google was already treating the v5 URLs as the canonical ones.

By the way, I have access to Google Search Console, so I can actually verify this.


<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
