### PR TITLE
fix: serve homepage at root instead of meta-refresh redirect to /en/

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -73,13 +73,15 @@ export default defineConfig({
     icon(),
     react(),
     sitemap({
-      // Only the canonical /<locale>/… URLs belong in the sitemap. The catch-all
+      // Only the canonical URLs belong in the sitemap. The catch-all
       // `[...path].astro` also emits `noindex` redirect stubs: language-less ones
-      // (e.g. `/guide/x`, `/` → `/en/`) and per-locale ones for moved pages
+      // (e.g. `/guide/x`) and per-locale ones for moved pages
       // (e.g. `/en/resources/middleware/csurf`). Exclude both.
       // Keep this locale list in sync with `i18n.locales` below.
       filter: (page) => {
         const { pathname } = new URL(page);
+        // The homepage is served at `/` and is the canonical for `/en/`.
+        if (pathname === '/') return true;
         if (!/^\/(de|en|es|fr|it|ja|ko|pt-br|zh-cn|zh-tw)(\/|$)/.test(pathname)) return false;
         const unlocalized = pathname.replace(/^\/[a-z-]+/, '').replace(/\/$/, '');
         return !movedPagePaths.has(unlocalized);

--- a/src/components/HomePage.astro
+++ b/src/components/HomePage.astro
@@ -2,11 +2,11 @@
 import { Hero, Features, AnnouncementBar } from '@components/patterns';
 import { Card, Col } from '@components/primitives';
 import Layout from '@layouts/Layout.astro';
-import { getLangFromUrl, useTranslations } from '@i18n/utils';
+import { getHomePath, getLangFromUrl, useTranslations } from '@i18n/utils';
 
 const lang = getLangFromUrl(Astro.url);
 const t = useTranslations(lang);
-const canonicalPathname = lang === 'en' ? '/' : `/${lang}/`;
+const canonicalPathname = getHomePath(lang);
 ---
 
 <Layout canonicalPathname={canonicalPathname}>

--- a/src/components/HomePage.astro
+++ b/src/components/HomePage.astro
@@ -1,0 +1,29 @@
+---
+import { Hero, Features, AnnouncementBar } from '@components/patterns';
+import { Card, Col } from '@components/primitives';
+import Layout from '@layouts/Layout.astro';
+import { getLangFromUrl, useTranslations } from '@i18n/utils';
+
+const lang = getLangFromUrl(Astro.url);
+const t = useTranslations(lang);
+const canonicalPathname = lang === 'en' ? '/' : `/${lang}/`;
+---
+
+<Layout canonicalPathname={canonicalPathname}>
+  <AnnouncementBar />
+  <Hero />
+  <Features title={t('features.title')}>
+    <Col xs={12} md={6} lg={6} class="features__card-col">
+      <Card title={t('features.webapplication.title')} body={t('features.webapplication.body')} />
+    </Col>
+    <Col xs={12} md={6} lg={6} class="features__card-col">
+      <Card title={t('features.api.title')} body={t('features.api.body')} />
+    </Col>
+    <Col xs={12} md={6} lg={6} class="features__card-col">
+      <Card title={t('features.performance.title')} body={t('features.performance.body')} />
+    </Col>
+    <Col xs={12} md={6} lg={6} class="features__card-col">
+      <Card title={t('features.middleware.title')} body={t('features.middleware.body')} />
+    </Col>
+  </Features>
+</Layout>

--- a/src/components/patterns/Breadcrumbs/Breadcrumbs.astro
+++ b/src/components/patterns/Breadcrumbs/Breadcrumbs.astro
@@ -6,7 +6,7 @@
 import { Body } from '@components/primitives';
 import { Icon } from 'astro-icon/components';
 import type { BreadcrumbItem } from '@utils/content';
-import { getLangFromUrl, useTranslations } from '@/i18n/utils';
+import { getHomePath, getLangFromUrl, useTranslations } from '@/i18n/utils';
 import './Breadcrumbs.css';
 
 interface Props {
@@ -16,6 +16,7 @@ interface Props {
 const { items } = Astro.props;
 const lang = getLangFromUrl(Astro.url);
 const t = useTranslations(lang);
+const homeHref = getHomePath(lang);
 ---
 
 <nav aria-label={t('nav.breadcrumb')}>
@@ -24,7 +25,7 @@ const t = useTranslations(lang);
       <Body
         vMargin={false}
         as="a"
-        href={`/${lang}`}
+        href={homeHref}
         class="breadcrumb-link"
         aria-label={t('nav.home')}
       >

--- a/src/components/patterns/Header/Header.astro
+++ b/src/components/patterns/Header/Header.astro
@@ -10,11 +10,11 @@ import { Icon } from 'astro-icon/components';
 import { Flex } from '@/components/primitives';
 import { ThemeSwitcher, SearchBox, LanguageSelect } from '@components/patterns';
 import { languagesArray } from '@/i18n/locales';
-import { getLangFromUrl, useTranslations } from '@/i18n/utils';
+import { getHomePath, getLangFromUrl, useTranslations } from '@/i18n/utils';
 
 const currentLang = getLangFromUrl(Astro.url);
 const t = useTranslations(currentLang);
-const homeHref = currentLang === 'en' ? '/' : `/${currentLang}/`;
+const homeHref = getHomePath(currentLang);
 ---
 
 <header class="header">

--- a/src/components/patterns/Header/Header.astro
+++ b/src/components/patterns/Header/Header.astro
@@ -14,6 +14,7 @@ import { getLangFromUrl, useTranslations } from '@/i18n/utils';
 
 const currentLang = getLangFromUrl(Astro.url);
 const t = useTranslations(currentLang);
+const homeHref = currentLang === 'en' ? '/' : `/${currentLang}/`;
 ---
 
 <header class="header">
@@ -30,7 +31,7 @@ const t = useTranslations(currentLang);
         <span class="hamburger-line"></span>
         <span class="hamburger-line"></span>
       </button>
-      <a href={`/${currentLang}/`} class="logo-link" aria-label={t('nav.home')}>
+      <a href={homeHref} class="logo-link" aria-label={t('nav.home')}>
         <Image
           src="/images/logos/express-kawaii.webp"
           alt="Express.js kawaii logo"

--- a/src/components/patterns/LanguageSelect/LanguageSelect.astro
+++ b/src/components/patterns/LanguageSelect/LanguageSelect.astro
@@ -58,7 +58,8 @@ const options = languages.map((lang) => ({
         const currentPath = window.location.pathname;
         const newPath = replaceLanguageInPath(currentPath, code);
 
-        window.location.href = newPath;
+        // The English homepage is canonically served at `/`, not `/en/`.
+        window.location.href = newPath === '/en/' ? '/' : newPath;
       }) as EventListener);
     });
   }

--- a/src/components/patterns/Sidebar/SidebarMenu.astro
+++ b/src/components/patterns/Sidebar/SidebarMenu.astro
@@ -6,7 +6,7 @@ import { Body } from '@/components/primitives';
 import { Image } from 'astro:assets';
 import { Icon } from 'astro-icon/components';
 import { VersionSwitcher } from '@/components/patterns';
-import { useTranslations } from '@/i18n/utils';
+import { getHomePath, useTranslations } from '@/i18n/utils';
 import { DEFAULT_VERSION } from '@/config/versions';
 import SidebarItemsList from './SidebarItemsList.astro';
 import {
@@ -78,7 +78,7 @@ const commonItemsListProps = {
   <nav class="sidebar-nav" aria-label={t('nav.mainNavigation')}>
     <ul class="sidebar-nav-list">
       <li class="sidebar-logo-item">
-        <a href={`/${lang}/`} class="logo-link sidebar-nav-item" aria-label={t('nav.home')}>
+        <a href={getHomePath(lang)} class="logo-link sidebar-nav-item" aria-label={t('nav.home')}>
           <Image
             src="/images/logos/express-kawaii.webp"
             alt="Express.js kawaii logo"

--- a/src/i18n/utils.ts
+++ b/src/i18n/utils.ts
@@ -23,6 +23,13 @@ export function useTranslations(lang: keyof typeof ui) {
   };
 }
 /**
+ * Homepage path for a language. English is served at the root.
+ */
+export function getHomePath(lang: string): string {
+  return lang === defaultLang ? '/' : `/${lang}/`;
+}
+
+/**
  * Create a regex pattern to match language prefixes in URLs
  */
 export function createLanguagePathRegex(): RegExp {

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -100,18 +100,14 @@ const lang = getLangFromUrl(Astro.url);
 
     {
       !isBlogOrApi &&
-        ['x-default', ...languageCodes].map((altLang) => (
-          <link
-            rel="alternate"
-            hreflang={altLang}
-            href={
-              new URL(
-                replaceLanguageInPath(canonicalPath, altLang === 'x-default' ? 'en' : altLang),
-                Astro.site || Astro.url.origin
-              )
-            }
-          />
-        ))
+        ['x-default', ...languageCodes].map((altLang) => {
+          let altPath = replaceLanguageInPath(canonicalPath, altLang === 'x-default' ? 'en' : altLang);
+          // The English homepage is canonically served at `/`, not `/en/`.
+          if (altPath === '/en/') altPath = '/';
+          return (
+            <link rel="alternate" hreflang={altLang} href={new URL(altPath, Astro.site || Astro.url.origin)} />
+          );
+        })
     }
 
     <title>{pageTitle}</title>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -101,11 +101,18 @@ const lang = getLangFromUrl(Astro.url);
     {
       !isBlogOrApi &&
         ['x-default', ...languageCodes].map((altLang) => {
-          let altPath = replaceLanguageInPath(canonicalPath, altLang === 'x-default' ? 'en' : altLang);
+          let altPath = replaceLanguageInPath(
+            canonicalPath,
+            altLang === 'x-default' ? 'en' : altLang
+          );
           // The English homepage is canonically served at `/`, not `/en/`.
           if (altPath === '/en/') altPath = '/';
           return (
-            <link rel="alternate" hreflang={altLang} href={new URL(altPath, Astro.site || Astro.url.origin)} />
+            <link
+              rel="alternate"
+              hreflang={altLang}
+              href={new URL(altPath, Astro.site || Astro.url.origin)}
+            />
           );
         })
     }

--- a/src/pages/[...path].astro
+++ b/src/pages/[...path].astro
@@ -95,6 +95,8 @@ if (fallback) {
 } else {
   target = `/en/${slug}`;
 }
+// The English homepage is canonically served at `/`, not `/en/`.
+if (target === '/en/') target = '/';
 const canonical = new URL(target, Astro.site).href;
 ---
 

--- a/src/pages/[lang]/index.astro
+++ b/src/pages/[lang]/index.astro
@@ -6,16 +6,17 @@ import { languageCodes } from '@i18n/locales';
 import { getLangFromUrl, useTranslations } from '@i18n/utils';
 
 export function getStaticPaths() {
-  return languageCodes.map((lang) => ({
+  return ['/', ...languageCodes].map((lang) => ({
     params: { lang },
   }));
 }
 
 const lang = getLangFromUrl(Astro.url);
 const t = useTranslations(lang);
+const canonicalPathname = lang === 'en' ? '/' : `/${lang}/`;
 ---
 
-<Layout>
+<Layout canonicalPathname={canonicalPathname}>
   <AnnouncementBar />
   <Hero />
   <Features title={t('features.title')}>

--- a/src/pages/[lang]/index.astro
+++ b/src/pages/[lang]/index.astro
@@ -1,36 +1,12 @@
 ---
-import { Hero, Features, AnnouncementBar } from '@components/patterns';
-import { Card, Col } from '@components/primitives';
-import Layout from '@layouts/Layout.astro';
+import HomePage from '@components/HomePage.astro';
 import { languageCodes } from '@i18n/locales';
-import { getLangFromUrl, useTranslations } from '@i18n/utils';
 
 export function getStaticPaths() {
-  return ['/', ...languageCodes].map((lang) => ({
+  return languageCodes.map((lang) => ({
     params: { lang },
   }));
 }
-
-const lang = getLangFromUrl(Astro.url);
-const t = useTranslations(lang);
-const canonicalPathname = lang === 'en' ? '/' : `/${lang}/`;
 ---
 
-<Layout canonicalPathname={canonicalPathname}>
-  <AnnouncementBar />
-  <Hero />
-  <Features title={t('features.title')}>
-    <Col xs={12} md={6} lg={6} class="features__card-col">
-      <Card title={t('features.webapplication.title')} body={t('features.webapplication.body')} />
-    </Col>
-    <Col xs={12} md={6} lg={6} class="features__card-col">
-      <Card title={t('features.api.title')} body={t('features.api.body')} />
-    </Col>
-    <Col xs={12} md={6} lg={6} class="features__card-col">
-      <Card title={t('features.performance.title')} body={t('features.performance.body')} />
-    </Col>
-    <Col xs={12} md={6} lg={6} class="features__card-col">
-      <Card title={t('features.middleware.title')} body={t('features.middleware.body')} />
-    </Col>
-  </Features>
-</Layout>
+<HomePage />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,1 +1,0 @@
-<meta http-equiv="refresh" content="0;url=/en/" />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,0 +1,5 @@
+---
+import HomePage from '@components/HomePage.astro';
+---
+
+<HomePage />


### PR DESCRIPTION
I'm restoring the behavior from before the redesign by removing the automatic redirect to English. Google still recommends the root URL by default for obvious reasons, since it was the homepage for many years.

<img width="974" height="309" alt="imagen" src="https://github.com/user-attachments/assets/f79c8574-c245-41b7-acd7-1d80ca9cf530" />


<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
