### PR TITLE
feat: add signature metadata handling for improved documentation extractio

### DIFF
--- a/scripts/orama-documents.mjs
+++ b/scripts/orama-documents.mjs
@@ -10,13 +10,14 @@ const CONTENT_DIR = fileURLToPath(new URL('../src/content', import.meta.url));
 
 const stripMdxImports = (content) => content.replace(/^import\s+.*$/gm, '');
 
-// The tag-strip only matches real tags (`<name …>` / `</name>`), so comparison
-// text like `<21 || >=22` survives.
+// Strip HTML/JSX tags, then drop any leftover `<` that could still start a tag
+// (e.g. the one `<<a>script>` reconstructs). After the second pass no `<` precedes
+// a letter, so no tag-like content survives, while comparison text such as
+// `<21 || >=22` is preserved.
+const stripTags = (text) => text.replace(/<\/?[A-Za-z][^>]*>/g, '').replace(/<(?=\/?[A-Za-z])/g, '');
+
 const mdToText = (content) =>
-  toString(fromMarkdown(signatureMetaToText(stripMdxImports(content)))).replace(
-    /<\/?[A-Za-z][^>]*>/g,
-    ''
-  );
+  stripTags(toString(fromMarkdown(signatureMetaToText(stripMdxImports(content)))));
 
 // Build the public path segment from a content-relative file path: drop the
 // extension and any trailing `index` so `foo/index.mdx` -> `foo`. This matches

--- a/scripts/orama-documents.mjs
+++ b/scripts/orama-documents.mjs
@@ -4,13 +4,19 @@ import { fileURLToPath, URL } from 'node:url';
 import matter from 'gray-matter';
 import { fromMarkdown } from 'mdast-util-from-markdown';
 import { toString } from 'mdast-util-to-string';
+import { signatureMetaToText } from '../src/utils/signature-meta.mjs';
 
 const CONTENT_DIR = fileURLToPath(new URL('../src/content', import.meta.url));
 
 const stripMdxImports = (content) => content.replace(/^import\s+.*$/gm, '');
 
+// The tag-strip only matches real tags (`<name …>` / `</name>`), so comparison
+// text like `<21 || >=22` survives.
 const mdToText = (content) =>
-  toString(fromMarkdown(stripMdxImports(content))).replace(/<[^>]*>/g, '');
+  toString(fromMarkdown(signatureMetaToText(stripMdxImports(content)))).replace(
+    /<\/?[A-Za-z][^>]*>/g,
+    ''
+  );
 
 // Build the public path segment from a content-relative file path: drop the
 // extension and any trailing `index` so `foo/index.mdx` -> `foo`. This matches

--- a/scripts/orama-documents.mjs
+++ b/scripts/orama-documents.mjs
@@ -14,7 +14,8 @@ const stripMdxImports = (content) => content.replace(/^import\s+.*$/gm, '');
 // (e.g. the one `<<a>script>` reconstructs). After the second pass no `<` precedes
 // a letter, so no tag-like content survives, while comparison text such as
 // `<21 || >=22` is preserved.
-const stripTags = (text) => text.replace(/<\/?[A-Za-z][^>]*>/g, '').replace(/<(?=\/?[A-Za-z])/g, '');
+const stripTags = (text) =>
+  text.replace(/<\/?[A-Za-z][^>]*>/g, '').replace(/<(?=\/?[A-Za-z])/g, '');
 
 const mdToText = (content) =>
   stripTags(toString(fromMarkdown(signatureMetaToText(stripMdxImports(content)))));

--- a/src/utils/llms.ts
+++ b/src/utils/llms.ts
@@ -19,7 +19,8 @@ export function stripMdxSyntax(content: string): string {
       .replace(new RegExp(`<[A-Z]\\w*${JSX_ATTRS}\\/>`, 'g'), '')
       // Remove JSX opening and closing tags like <Alert> </Alert>
       .replace(new RegExp(`<\\/?[A-Z]\\w*${JSX_ATTRS}>`, 'g'), '')
-      // Collapse multiple blank lines
+      // Clear whitespace-only lines left by removed tags, then collapse blank lines
+      .replace(/^[ \t]+$/gm, '')
       .replace(/\n{3,}/g, '\n\n')
       .trim()
   );

--- a/src/utils/llms.ts
+++ b/src/utils/llms.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs/promises';
 import matter from 'gray-matter';
+import { JSX_ATTRS, signatureMetaToText } from './signature-meta.mjs';
 
 export interface ContentEntry {
   id: string;
@@ -9,13 +10,15 @@ export interface ContentEntry {
 
 export function stripMdxSyntax(content: string): string {
   return (
-    content
+    signatureMetaToText(
       // Remove import statements
-      .replace(/^import\s+.*$/gm, '')
-      // Remove JSX self-closing tags like <Alert ... />
-      .replace(/<[A-Z]\w*\s*[^>]*\/>/g, '')
+      content.replace(/^import\s+.*$/gm, '')
+    )
+      // Remove JSX self-closing tags like <Alert ... />. `JSX_ATTRS` tolerates `>`
+      // inside quoted or braced attribute values (e.g. runtime version constraints).
+      .replace(new RegExp(`<[A-Z]\\w*${JSX_ATTRS}\\/>`, 'g'), '')
       // Remove JSX opening and closing tags like <Alert> </Alert>
-      .replace(/<\/?[A-Z]\w*[^>]*>/g, '')
+      .replace(new RegExp(`<\\/?[A-Z]\\w*${JSX_ATTRS}>`, 'g'), '')
       // Collapse multiple blank lines
       .replace(/\n{3,}/g, '\n\n')
       .trim()

--- a/src/utils/signature-meta.mjs
+++ b/src/utils/signature-meta.mjs
@@ -53,7 +53,8 @@ export const signatureMetaToText = (content) => {
     const indent = /^[ \t]*$/.test(beforeTag) ? beforeTag : '';
 
     if (slot) {
-      const title = slot === 'attributes' ? attributesTitle : slot === 'properties' ? 'Properties' : 'Returns';
+      const title =
+        slot === 'attributes' ? attributesTitle : slot === 'properties' ? 'Properties' : 'Returns';
       return `\n\n${indent}${title}:\n\n`;
     }
 

--- a/src/utils/signature-meta.mjs
+++ b/src/utils/signature-meta.mjs
@@ -1,0 +1,67 @@
+// `<Signature>` and `<Param>` carry API metadata (added-in version, deprecation,
+// runtime requirements, types, defaults) as JSX attributes, which plain-text and
+// llms.txt exports would otherwise discard along with the tags. This rewrites each
+// opening tag into the same plain-text sentences the component renders, so the
+// metadata stays readable next to the member's heading.
+
+// Attribute values may contain `>` inside quotes or braces (e.g.
+// `runtime={{ 'Node.js': '>=22.2.0' }}`), so tag matching can't stop at the
+// first `>`.
+export const JSX_ATTRS = `(?:"[^"]*"|'[^']*'|\\{(?:[^{}]|\\{[^{}]*\\})*\\}|[^>"'{])*`;
+
+const JSX_META_TAG = new RegExp(`<(Signature|Param)\\b(${JSX_ATTRS})\\/?>`, 'g');
+
+/**
+ * @param {string} attrs
+ * @param {string} name
+ * @returns {string | undefined}
+ */
+const getAttr = (attrs, name) => {
+  const match = attrs.match(new RegExp(`(?:^|\\s)${name}=(?:"([^"]*)"|'([^']*)')`));
+  return match ? (match[1] ?? match[2]) : undefined;
+};
+
+/**
+ * @param {string} attrs
+ * @param {string} name
+ * @returns {boolean}
+ */
+const hasFlag = (attrs, name) => new RegExp(`(?:^|\\s)${name}(?=\\s|$)`).test(attrs);
+
+/**
+ * Replace `<Signature>`/`<Param>` opening tags with the sentences the component
+ * renders ("Added in v4.16.0.", "options (Object, optional):", …).
+ *
+ * @param {string} content
+ * @returns {string}
+ */
+export const signatureMetaToText = (content) =>
+  content.replace(JSX_META_TAG, (tag, component, attrs) => {
+    const since = getAttr(attrs, 'since');
+    const deprecated = getAttr(attrs, 'deprecated');
+
+    if (component === 'Param') {
+      const name = getAttr(attrs, 'name');
+      if (!name) return tag;
+      const details = [
+        getAttr(attrs, 'type'),
+        hasFlag(attrs, 'optional') && 'optional',
+        getAttr(attrs, 'default') && `default: ${getAttr(attrs, 'default')}`,
+        since && `added in ${since}`,
+        deprecated && `deprecated in ${deprecated}`,
+      ].filter(Boolean);
+      return `\n\n${name}${details.length ? ` (${details.join(', ')})` : ''}:\n\n`;
+    }
+
+    const runtime = [...attrs.matchAll(/['"]([^'"]+)['"]\s*:\s*['"]([^'"]+)['"]/g)]
+      .map(([, engine, constraint]) => `${engine} ${constraint}`)
+      .join(', ');
+    const lines = [
+      getAttr(attrs, 'type') && `Type: ${getAttr(attrs, 'type')}.`,
+      getAttr(attrs, 'returns') && `Returns: ${getAttr(attrs, 'returns')}.`,
+      since && `Added in ${since}.`,
+      deprecated && `Deprecated in ${deprecated}.`,
+      runtime && `Requires runtime: ${runtime}.`,
+    ].filter(Boolean);
+    return lines.length ? `\n\n${lines.join(' ')}\n\n` : tag;
+  });

--- a/src/utils/signature-meta.mjs
+++ b/src/utils/signature-meta.mjs
@@ -9,7 +9,12 @@
 // first `>`.
 export const JSX_ATTRS = `(?:"[^"]*"|'[^']*'|\\{(?:[^{}]|\\{[^{}]*\\})*\\}|[^>"'{])*`;
 
-const JSX_META_TAG = new RegExp(`<(Signature|Param)\\b(${JSX_ATTRS})\\/?>`, 'g');
+// Also matches the component's slot markers, so their section titles ("Arguments",
+// "Properties", "Returns") survive as text.
+const JSX_META_TAG = new RegExp(
+  `<(Signature|Param)\\b(${JSX_ATTRS})\\/?>|<Fragment\\s+slot=["'](attributes|properties|returns)["']\\s*>`,
+  'g'
+);
 
 /**
  * @param {string} attrs
@@ -35,8 +40,17 @@ const hasFlag = (attrs, name) => new RegExp(`(?:^|\\s)${name}(?=\\s|$)`).test(at
  * @param {string} content
  * @returns {string}
  */
-export const signatureMetaToText = (content) =>
-  content.replace(JSX_META_TAG, (tag, component, attrs) => {
+export const signatureMetaToText = (content) => {
+  // Title for the next `attributes` slot; set by the enclosing Signature's
+  // `attributesTitle` prop. Matches are visited in document order, so the
+  // Signature opening tag is always seen before its slots.
+  let attributesTitle = 'Arguments';
+  return content.replace(JSX_META_TAG, (tag, component, attrs, slot) => {
+    if (slot) {
+      const title = slot === 'attributes' ? attributesTitle : slot === 'properties' ? 'Properties' : 'Returns';
+      return `\n\n${title}:\n\n`;
+    }
+
     const since = getAttr(attrs, 'since');
     const deprecated = getAttr(attrs, 'deprecated');
 
@@ -53,6 +67,7 @@ export const signatureMetaToText = (content) =>
       return `\n\n${name}${details.length ? ` (${details.join(', ')})` : ''}:\n\n`;
     }
 
+    attributesTitle = getAttr(attrs, 'attributesTitle') ?? 'Arguments';
     const runtime = [...attrs.matchAll(/['"]([^'"]+)['"]\s*:\s*['"]([^'"]+)['"]/g)]
       .map(([, engine, constraint]) => `${engine} ${constraint}`)
       .join(', ');
@@ -65,3 +80,4 @@ export const signatureMetaToText = (content) =>
     ].filter(Boolean);
     return lines.length ? `\n\n${lines.join(' ')}\n\n` : tag;
   });
+};

--- a/src/utils/signature-meta.mjs
+++ b/src/utils/signature-meta.mjs
@@ -45,10 +45,16 @@ export const signatureMetaToText = (content) => {
   // `attributesTitle` prop. Matches are visited in document order, so the
   // Signature opening tag is always seen before its slots.
   let attributesTitle = 'Arguments';
-  return content.replace(JSX_META_TAG, (tag, component, attrs, slot) => {
+  return content.replace(JSX_META_TAG, (tag, component, attrs, slot, offset, source) => {
+    // Keep the tag's own indentation, which mirrors the nesting depth in the
+    // source, so replacements stay visually grouped under their section.
+    const lineStart = source.lastIndexOf('\n', offset - 1) + 1;
+    const beforeTag = source.slice(lineStart, offset);
+    const indent = /^[ \t]*$/.test(beforeTag) ? beforeTag : '';
+
     if (slot) {
       const title = slot === 'attributes' ? attributesTitle : slot === 'properties' ? 'Properties' : 'Returns';
-      return `\n\n${title}:\n\n`;
+      return `\n\n${indent}${title}:\n\n`;
     }
 
     const since = getAttr(attrs, 'since');
@@ -64,7 +70,7 @@ export const signatureMetaToText = (content) => {
         since && `added in ${since}`,
         deprecated && `deprecated in ${deprecated}`,
       ].filter(Boolean);
-      return `\n\n${name}${details.length ? ` (${details.join(', ')})` : ''}:\n\n`;
+      return `\n\n${indent}- ${name}${details.length ? ` (${details.join(', ')})` : ''}:\n\n`;
     }
 
     attributesTitle = getAttr(attrs, 'attributesTitle') ?? 'Arguments';


### PR DESCRIPTION
This would improve the inputs we provide to Orama and the llms.txt files.

The changes in Orama won't be visible until Orama recovers from its outage, since its portal isn't even accessible right now.

<img width="617" height="220" alt="imagen" src="https://github.com/user-attachments/assets/0931c8cc-a1a5-495c-a660-4e46d8fbb37d" />


-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
