### PR TITLE
docs: fix max-age and quote typos in response documentation

### DIFF
--- a/src/content/api/4x/api/response/index.mdx
+++ b/src/content/api/4x/api/response/index.mdx
@@ -750,7 +750,7 @@ or the referring URL, and the URL specified in the `Location` header; and redire
 
 Redirects to the URL derived from the specified `path`, with specified `status`, a positive integer
 that corresponds to an [HTTP status code](https://www.rfc-editor.org/rfc/rfc9110#name-status-codes) .
-If not specified, `status` defaults to "302 "Found".
+If not specified, `status` defaults to 302 "Found".
 
 ```js
 res.redirect('/foo/bar');

--- a/src/content/api/5x/api/response/index.mdx
+++ b/src/content/api/5x/api/response/index.mdx
@@ -242,7 +242,7 @@ Clears the cookie with the specified `name` by sending a `Set-Cookie` header tha
 This instructs the client that the cookie has expired and is no longer valid. For more information
 about available `options`, see [res.cookie()](#rescookie).
 
-<Alert type="alert">The `expires` and `max-age` options are being ignored completely.</Alert>
+<Alert type="alert">The `expires` and `maxAge` options are being ignored completely.</Alert>
 
 <Alert type="alert">
 


### PR DESCRIPTION
### Description
This PR fixes two small typos in the response documentation:
1. In `src/content/api/5x/api/response/index.mdx`: Corrected `max-age` to `maxAge` in the `res.clearCookie()` alert. Express option naming uses camelCase (`maxAge`), so writing `max-age` with a hyphen was inconsistent with the surrounding docs and API.
2. In `src/content/api/4x/api/response/index.mdx`: Removed an erroneous extra opening double quote in the default status code description for `res.redirect()` (`"302 "Found"` → `302 "Found"`).

### Checklist
- [x] Documentation typo fixes only (no logic changes)