### PR TITLE
docs: clarify express.json() parses bodies regardless of HTTP method

### DIFF
--- a/src/content/api/4x/api/express/index.mdx
+++ b/src/content/api/4x/api/express/index.mdx
@@ -94,6 +94,17 @@ may not be a function and instead a string or other user-input.
 
 </Alert>
 
+<Alert type="info">
+
+`express.json()` (and other body-parsing middleware) will attempt to parse a request body
+regardless of the HTTP method — including `GET`, `HEAD`, and `DELETE` requests that
+conventionally carry no body. When using body-parsing middleware globally with `app.use()`,
+consider registering any rate-limiting or request-size-limiting middleware **before**
+body-parsing middleware in the chain, and apply body-parsing only to routes that expect a
+request body where possible.
+
+</Alert>
+
 ```cjs title="index.cjs" ins={5}
 var express = require('express');
 var app = express();

--- a/src/content/api/5x/api/express/index.mdx
+++ b/src/content/api/5x/api/express/index.mdx
@@ -102,6 +102,17 @@ may not be a function and instead a string or other user-input.
 
 </Alert>
 
+<Alert type="info">
+
+`express.json()` (and other body-parsing middleware) will attempt to parse a request body
+regardless of the HTTP method — including `GET`, `HEAD`, and `DELETE` requests that
+conventionally carry no body. When using body-parsing middleware globally with `app.use()`,
+consider registering any rate-limiting or request-size-limiting middleware **before**
+body-parsing middleware in the chain, and apply body-parsing only to routes that expect a
+request body where possible.
+
+</Alert>
+
 ```cjs title="index.cjs" ins={5}
 const express = require('express');
 const app = express();


### PR DESCRIPTION
## Summary

This is a documentation-only clarification — no code or tests were changed.

Body-parsing middleware such as `express.json()` is not gated by HTTP method: it will attempt to read and parse a request body on any method, including `GET`, `HEAD`, and `DELETE` requests that conventionally carry no body. Developers who apply body-parsing middleware globally via `app.use()` may not be aware of this, which can affect how they reason about middleware ordering.

## Changes

Added an informational note to the `express.json()` section in both the 4.x and 5.x API reference pages advising developers to:
- Register rate-limiting or request-size-limiting middleware **before** body-parsing middleware in the chain.
- Apply body-parsing only to routes that expect a request body where possible.

## Scope

- Documentation text only, in `src/content/api/4x/api/express/index.mdx` and `src/content/api/5x/api/express/index.mdx`
- No behavior changes, no new tests, no dependency changes.