### PR TITLE
docs: clarify app.render view resolution

### DIFF
--- a/src/content/api/4x/api/application/index.mdx
+++ b/src/content/api/4x/api/application/index.mdx
@@ -1286,7 +1286,7 @@ app.put('/', function (req: Request, res: Response) {
 <Signature>
   <Fragment slot="attributes">
     <Param name="view" type="String">
-      The name of the view to render.
+      The file path of the view to render (absolute or relative to the `views` setting).
     </Param>
     <Param name="locals" type="Object" optional>
       An object whose properties define local variables for the view.
@@ -1300,6 +1300,12 @@ app.put('/', function (req: Request, res: Response) {
 Returns the rendered HTML of a view via the `callback` function. It accepts an optional parameter
 that is an object containing local variables for the view. It is like [res.render()](/api/response/#resrender),
 except it cannot send the rendered view to the client on its own.
+
+The `view` argument is resolved the same way as [res.render()](/api/response/#resrender). It can be
+an absolute path, or a path relative to the `views` setting. If the path does not include an
+extension, Express uses the `view engine` setting to determine the template file extension. For
+example, with `app.set('views', './views')` and `app.set('view engine', 'pug')`, `app.render('email')`
+renders the template at `views/email.pug`.
 
 <Alert type="info">
 

--- a/src/content/api/5x/api/application/index.mdx
+++ b/src/content/api/5x/api/application/index.mdx
@@ -1195,7 +1195,7 @@ app.query('/search', (req: Request, res: Response) => {
 <Signature>
   <Fragment slot="attributes">
     <Param name="view" type="String">
-      The name of the view to render.
+      The file path of the view to render (absolute or relative to the `views` setting).
     </Param>
     <Param name="locals" type="Object" optional>
       An object whose properties define local variables for the view.
@@ -1209,6 +1209,12 @@ app.query('/search', (req: Request, res: Response) => {
 Returns the rendered HTML of a view via the `callback` function. It accepts an optional parameter
 that is an object containing local variables for the view. It is like [res.render()](/api/response/#resrender),
 except it cannot send the rendered view to the client on its own.
+
+The `view` argument is resolved the same way as [res.render()](/api/response/#resrender). It can be
+an absolute path, or a path relative to the `views` setting. If the path does not include an
+extension, Express uses the `view engine` setting to determine the template file extension. For
+example, with `app.set('views', './views')` and `app.set('view engine', 'pug')`, `app.render('email')`
+renders the template at `views/email.pug`.
 
 <Alert type="info">
 


### PR DESCRIPTION
## Summary

Closes #1457.

Clarifies how `app.render()` resolves the `view` argument in the 4.x and 5.x Application API docs. The docs now match the existing `res.render()` wording and explain that a name like `email` resolves through the app `views` directory and `view engine` setting, for example `views/email.pug`.

## Verification

- `npx prettier --check src/content/api/4x/api/application/index.mdx src/content/api/5x/api/application/index.mdx`
- `npx cspell --no-progress src/content/api/4x/api/application/index.mdx src/content/api/5x/api/application/index.mdx`
- `npm run lint -- src/content/api/4x/api/application/index.mdx src/content/api/5x/api/application/index.mdx` (exits 0; MDX files are ignored by current ESLint config)
- `git diff --check`
- `npm run build` (2307 pages built)