### PR TITLE
docs: add router callable API

### DIFF
--- a/src/content/api/4x/api/router/index.mdx
+++ b/src/content/api/4x/api/router/index.mdx
@@ -121,6 +121,31 @@ router.get('/events', (req: Request, res: Response) => {
 app.use('/calendar', router);
 ```
 
+### router(req, res, [next])
+
+<Signature>
+  <Fragment slot="attributes">
+    <Param name="req" type="Request">
+      The request object.
+    </Param>
+    <Param name="res" type="Response">
+      The response object.
+    </Param>
+    <Param name="next" type="Function" optional>
+      The callback to pass control to the next matching middleware.
+    </Param>
+  </Fragment>
+</Signature>
+
+Dispatches `req` and `res` through the router's middleware and route stack.
+Express uses this callable form when a router is mounted with `app.use()` or
+`router.use()`.
+
+If no middleware ends the response, or if a middleware passes control by calling
+`next()`, the optional `next` callback receives control. If a middleware calls
+`next(err)`, Express skips the remaining non-error handlers and calls `next` with
+the error.
+
 ### router.all()
 
 <Signature returns="Router">

--- a/src/content/api/5x/api/router/index.mdx
+++ b/src/content/api/5x/api/router/index.mdx
@@ -121,6 +121,31 @@ router.get('/events', (req: Request, res: Response) => {
 app.use('/calendar', router);
 ```
 
+### router(req, res, [next])
+
+<Signature>
+  <Fragment slot="attributes">
+    <Param name="req" type="Request">
+      The request object.
+    </Param>
+    <Param name="res" type="Response">
+      The response object.
+    </Param>
+    <Param name="next" type="Function" optional>
+      The callback to pass control to the next matching middleware.
+    </Param>
+  </Fragment>
+</Signature>
+
+Dispatches `req` and `res` through the router's middleware and route stack.
+Express uses this callable form when a router is mounted with `app.use()` or
+`router.use()`.
+
+If no middleware ends the response, or if a middleware passes control by calling
+`next()`, the optional `next` callback receives control. If a middleware calls
+`next(err)`, Express skips the remaining non-error handlers and calls `next` with
+the error.
+
 ### router.all()
 
 <Signature returns="Router">


### PR DESCRIPTION
## Summary

Closes #1151.

Adds API documentation for the callable `router(req, res, [next])` middleware interface in both the Express 4.x and 5.x Router API pages.

The new section documents:
- the `req`, `res`, and optional `next` parameters
- that Express uses this callable form when routers are mounted with `app.use()` or `router.use()`
- how control and errors are passed through `next()` / `next(err)`

## Verification

- `npx prettier --check src/content/api/4x/api/router/index.mdx src/content/api/5x/api/router/index.mdx`
- `npx cspell --no-progress src/content/api/4x/api/router/index.mdx src/content/api/5x/api/router/index.mdx`
- `npm run lint -- src/content/api/4x/api/router/index.mdx src/content/api/5x/api/router/index.mdx`
- `git diff --check`
- `npm run build`