### PR TITLE
fix: prevent chat source citation clipping

### DIFF
--- a/src/components/patterns/Searchbox/ChatSources.css
+++ b/src/components/patterns/Searchbox/ChatSources.css
@@ -29,21 +29,19 @@
     gap: var(--space-3);
     margin-top: var(--space-8);
     margin-bottom: 0;
-    overflow-x: scroll;
+    overflow-x: auto;
     scroll-behavior: smooth;
-    -ms-overflow-style: none;
-    scrollbar-width: none;
+    scrollbar-width: thin;
     padding-left: 0;
+    padding-right: var(--space-16);
     list-style: none;
-
-    &::-webkit-scrollbar {
-      display: none;
-    }
   }
 
   .chat-sources-item {
     display: flex;
+    flex: 0 0 auto;
     max-width: 100%;
+    min-width: 0;
     height: 100%;
     align-items: center;
     gap: var(--space-2);
@@ -52,13 +50,15 @@
 
   .chat-sources-link {
     display: block;
-    width: var(--space-64);
+    width: min(var(--space-64), calc(100vw - var(--space-8)));
+    min-width: 0;
     height: 100%;
     border-radius: var(--radius-xl);
     background-color: var(--color-bg-tertiary);
     padding: var(--space-3);
     color: var(--color-text-primary);
     text-decoration: none;
+    overflow-wrap: anywhere;
     cursor: pointer;
     transition: var(--transition-colors);
 
@@ -80,6 +80,7 @@
     font-weight: var(--font-weight-semibold);
     color: var(--color-text-secondary);
     overflow: hidden;
+    min-width: 0;
     -webkit-box-orient: vertical;
     -webkit-line-clamp: 1;
     margin: 0;

--- a/src/components/patterns/Searchbox/ChatSources.css
+++ b/src/components/patterns/Searchbox/ChatSources.css
@@ -50,6 +50,7 @@
     scroll-behavior: smooth;
     scrollbar-width: thin;
     padding-inline: var(--space-16);
+    padding-block: var(--space-4);
     list-style: none;
   }
 

--- a/src/components/patterns/Searchbox/ChatSources.css
+++ b/src/components/patterns/Searchbox/ChatSources.css
@@ -3,14 +3,31 @@
     position: relative;
     overflow: hidden;
 
+    &::before,
     &::after {
       content: '';
       position: absolute;
       top: 0;
-      right: 0;
       bottom: 0;
+      z-index: 1;
       width: var(--space-16);
       pointer-events: none;
+    }
+
+    &::before {
+      left: 0;
+      background: linear-gradient(
+        to left,
+        transparent,
+        color-mix(in oklch, var(--color-bg-primary) 15%, transparent) 20%,
+        color-mix(in oklch, var(--color-bg-primary) 40%, transparent) 40%,
+        color-mix(in oklch, var(--color-bg-primary) 70%, transparent) 65%,
+        var(--color-bg-primary) 90%
+      );
+    }
+
+    &::after {
+      right: 0;
       background: linear-gradient(
         to right,
         transparent,
@@ -32,8 +49,7 @@
     overflow-x: auto;
     scroll-behavior: smooth;
     scrollbar-width: thin;
-    padding-left: 0;
-    padding-right: var(--space-16);
+    padding-inline: var(--space-16);
     list-style: none;
   }
 


### PR DESCRIPTION
## Summary

Closes #2408.

Prevents AI answer source/citation cards from being clipped horizontally by:
- allowing the source list to show a thin horizontal scrollbar instead of hiding the scroll affordance
- preventing individual source cards from shrinking in the flex row
- reserving right-side padding so the final card is not obscured by the fade overlay
- allowing long citation text or URLs to wrap inside the card

## Verification

- `npx prettier --check src/components/patterns/Searchbox/ChatSources.css`
- `npm run lint -- src/components/patterns/Searchbox/ChatSources.css` (exits 0; CSS is ignored by the current ESLint config)
- `git diff --check`
- `npm run build`