### PR TITLE
docs: show route-specific json limits

### DIFF
--- a/src/content/api/4x/api/express/index.mdx
+++ b/src/content/api/4x/api/express/index.mdx
@@ -135,6 +135,22 @@ app.post('/profile', (req: Request, res: Response) => {
 });
 ```
 
+You can mount `express.json()` on specific routes to use different `limit`
+values. Register route-specific parsers before any broader parser that should
+not apply to those routes:
+
+```js
+app.post('/upload', express.json({ limit: '5mb' }), function (req, res) {
+  res.send('upload received');
+});
+
+app.use(express.json({ limit: '100kb' }));
+
+app.post('/profile', function (req, res) {
+  res.json(req.body);
+});
+```
+
 ### express.raw()
 
 <Signature returns="Function" since="v4.17.0">

--- a/src/content/api/5x/api/express/index.mdx
+++ b/src/content/api/5x/api/express/index.mdx
@@ -143,6 +143,22 @@ app.post('/profile', (req: Request, res: Response) => {
 });
 ```
 
+You can mount `express.json()` on specific routes to use different `limit`
+values. Register route-specific parsers before any broader parser that should
+not apply to those routes:
+
+```js
+app.post('/upload', express.json({ limit: '5mb' }), (req, res) => {
+  res.send('upload received');
+});
+
+app.use(express.json({ limit: '100kb' }));
+
+app.post('/profile', (req, res) => {
+  res.json(req.body);
+});
+```
+
 ### express.raw()
 
 <Signature returns="Function">


### PR DESCRIPTION
## Summary

Closes #1421.

Adds a route-specific `express.json()` limit example to the 4.x and 5.x Express object API docs.

The example shows how to:
- mount a larger JSON parser on `/upload`
- mount the default/smaller parser for the rest of the app
- order the route-specific parser before the broader parser so the broader limit does not apply to that route

## Verification

- `npx prettier --check src/content/api/4x/api/express/index.mdx src/content/api/5x/api/express/index.mdx`
- `npx cspell --no-progress src/content/api/4x/api/express/index.mdx src/content/api/5x/api/express/index.mdx`
- `npm run lint -- src/content/api/4x/api/express/index.mdx src/content/api/5x/api/express/index.mdx`
- `git diff --check`
- `npm run build`