### PR TITLE
docs: fix typo 'middlware' -> 'middleware' in serve-index

### DIFF
--- a/src/content/pages/en/resources/middleware/serve-index.mdx
+++ b/src/content/pages/en/resources/middleware/serve-index.mdx
@@ -39,7 +39,7 @@ var serveIndex = require('serve-index');
 
 ### serveIndex(path, options)
 
-Returns middlware that serves an index of the directory in the given `path`.
+Returns middleware that serves an index of the directory in the given `path`.
 
 The `path` is based off the `req.url` value, so a `req.url` of `'/some/dir`
 with a `path` of `'public'` will look at `'public/some/dir'`. If you are using


### PR DESCRIPTION
## Summary
- Fixes a typo in the English `serve-index` middleware doc: "middlware" -> "middleware".

## Test plan
- Docs-only change, no build/test impact.