### PR TITLE
docs(routing): clarify wildcard behavior and restructure route parameters

### DIFF
--- a/src/content/api/4x/api/request/index.mdx
+++ b/src/content/api/4x/api/request/index.mdx
@@ -399,12 +399,6 @@ app.use('/admin', function (req: Request, res: Response, next: NextFunction) {
 
 ### req.params
 
-<Alert type="alert">
-
-In Express 4, wildcards (`*`) are unnamed, whereas in Express 5, wildcards must be explicitly named (e.g., `/*splat`). Please check the [migration guide to 5.x](https://expressjs.com/en/guide/migrating-5/#path-route-matching-syntax) before upgrading your routes.
-
-</Alert>
-
 <Signature type="Object" />
 
 This property is an object containing properties mapped to the [named route "parameters"](/guide/routing/#route-parameters). For example, if you have the route `/user/:name`, then the "name" property is available as `req.params.name`. This object defaults to `{}`.

--- a/src/content/api/4x/api/request/index.mdx
+++ b/src/content/api/4x/api/request/index.mdx
@@ -401,7 +401,7 @@ app.use('/admin', function (req: Request, res: Response, next: NextFunction) {
 
 <Alert type="alert">
 
-Wildcard parameters (`*`) are introduced in Express 5. See the [migration guide to Express 5](https://expressjs.com/en/guide/migrating-5/#path-route-matching-syntax) for details.
+In Express 4, wildcard matches are exposed as unnamed parameters (for example, `req.params[0]`) and return a string. Express 5 introduces named wildcard parameters that are exposed as arrays. See the [migration guide](https://expressjs.com/en/guide/migrating-5/#path-route-matching-syntax) for details.
 
 </Alert>
 

--- a/src/content/api/4x/api/request/index.mdx
+++ b/src/content/api/4x/api/request/index.mdx
@@ -399,9 +399,9 @@ app.use('/admin', function (req: Request, res: Response, next: NextFunction) {
 
 ### req.params
 
-<Alert type="alert">
+<Alert type="info">
 
-In Express 4, wildcard matches are exposed as unnamed parameters (for example, `req.params[0]`) and return a string. Express 5 introduces named wildcard parameters that are exposed as arrays. See the [migration guide](https://expressjs.com/en/guide/migrating-5/#path-route-matching-syntax) for details.
+In Express 4, wildcards (`*`) are unnamed, whereas in Express 5, wildcards must be explicitly named (e.g., `/*splat`). Please check the [migration guide to 5.x](https://expressjs.com/en/guide/migrating-5/#path-route-matching-syntax) before upgrading your routes.
 
 </Alert>
 

--- a/src/content/api/4x/api/request/index.mdx
+++ b/src/content/api/4x/api/request/index.mdx
@@ -399,7 +399,7 @@ app.use('/admin', function (req: Request, res: Response, next: NextFunction) {
 
 ### req.params
 
-<Alert type="info">
+<Alert type="alert">
 
 In Express 4, wildcards (`*`) are unnamed, whereas in Express 5, wildcards must be explicitly named (e.g., `/*splat`). Please check the [migration guide to 5.x](https://expressjs.com/en/guide/migrating-5/#path-route-matching-syntax) before upgrading your routes.
 

--- a/src/content/api/4x/api/request/index.mdx
+++ b/src/content/api/4x/api/request/index.mdx
@@ -399,6 +399,12 @@ app.use('/admin', function (req: Request, res: Response, next: NextFunction) {
 
 ### req.params
 
+<Alert type="alert">
+
+Wildcard parameters (`*`) are introduced in Express 5. See the [migration guide to Express 5](https://expressjs.com/en/guide/migrating-5/#path-route-matching-syntax) for details.
+
+</Alert>
+
 <Signature type="Object" />
 
 This property is an object containing properties mapped to the [named route "parameters"](/guide/routing/#route-parameters). For example, if you have the route `/user/:name`, then the "name" property is available as `req.params.name`. This object defaults to `{}`.

--- a/src/content/api/5x/api/request/index.mdx
+++ b/src/content/api/5x/api/request/index.mdx
@@ -391,12 +391,6 @@ app.use('/admin', (req: Request, res: Response, next: NextFunction) => {
 
 ### req.params
 
-<Alert type="info">
-
-Wildcard parameters (`*`) capture one or more path segments and expose them as an array in `req.params`. See the [migration guide](https://expressjs.com/en/guide/migrating-5/#path-route-matching-syntax) for details.
-
-</Alert>
-
 <Signature type="Object" />
 
 This property is an object containing properties mapped to the [named route "parameters"](/guide/routing/#route-parameters). For example, if you have the route `/user/:name`, then the "name" property is available as `req.params.name`. This object defaults to `Object.create(null)` when using string paths, but remains a standard object with a normal prototype when the path is defined with a regular expression.

--- a/src/content/api/5x/api/request/index.mdx
+++ b/src/content/api/5x/api/request/index.mdx
@@ -393,7 +393,7 @@ app.use('/admin', (req: Request, res: Response, next: NextFunction) => {
 
 <Alert type="info">
 
-Wildcard parameters (`*`) are only supported in Express 5. Unlike named parameters (`:`), they capture one or more path segments and expose them as an array in `req.params`. See the [migration guide](https://expressjs.com/en/guide/migrating-5/#path-route-matching-syntax) for details.
+Wildcard parameters (`*`) capture one or more path segments and expose them as an array in `req.params`. See the [migration guide](https://expressjs.com/en/guide/migrating-5/#path-route-matching-syntax) for details.
 
 </Alert>
 

--- a/src/content/api/5x/api/request/index.mdx
+++ b/src/content/api/5x/api/request/index.mdx
@@ -391,6 +391,12 @@ app.use('/admin', (req: Request, res: Response, next: NextFunction) => {
 
 ### req.params
 
+<Alert type="info">
+
+Wildcard parameters (`*`) are only supported in Express 5. Unlike named parameters (`:`), they capture one or more path segments and expose them as an array in `req.params`. See the [migration guide](https://expressjs.com/en/guide/migrating-5/#path-route-matching-syntax) for details.
+
+</Alert>
+
 <Signature type="Object" />
 
 This property is an object containing properties mapped to the [named route "parameters"](/guide/routing/#route-parameters). For example, if you have the route `/user/:name`, then the "name" property is available as `req.params.name`. This object defaults to `Object.create(null)` when using string paths, but remains a standard object with a normal prototype when the path is defined with a regular expression.

--- a/src/content/api/5x/api/request/index.mdx
+++ b/src/content/api/5x/api/request/index.mdx
@@ -425,6 +425,8 @@ app.get('/files/*file', (req: Request, res: Response) => {
 });
 ```
 
+Parameters defined in [optional segments](/guide/routing/#optional-segments) that are not present in the request URL are omitted from `req.params` entirely.
+
 When you use a regular expression for the route definition, capture groups are provided as integer keys using `req.params[n]`, where `n` is the n<sup>th</sup> capture group.
 
 ```js

--- a/src/content/docs/en/4x/guide/routing.mdx
+++ b/src/content/docs/en/4x/guide/routing.mdx
@@ -235,6 +235,26 @@ app.get('/ab(cd)?e', (req: Request, res: Response) => {
 });
 ```
 
+A wildcard (`*`) on its own matches any path segment. For example, this route path will match `/file/javascripts/jquery.js`, `/file/style.css`, and so on. Wildcards are unnamed, so the matched value is available as `req.params[0]` instead of a named parameter.
+
+```js
+app.get('/file/*', (req, res) => {
+  // GET /file/javascripts/jquery.js
+  res.send(req.params[0]);
+  // => 'javascripts/jquery.js'
+});
+```
+
+```ts
+import { type Request, type Response } from 'express';
+
+app.get('/file/*', (req: Request, res: Response) => {
+  // GET /file/javascripts/jquery.js
+  res.send(req.params[0]);
+  // => 'javascripts/jquery.js'
+});
+```
+
 ### Route paths based on regular expressions
 
 <Alert type="alert">

--- a/src/content/docs/en/4x/guide/routing.mdx
+++ b/src/content/docs/en/4x/guide/routing.mdx
@@ -572,7 +572,7 @@ The methods on the response object (`res`) in the following table can send a res
 ## app.route()
 
 You can create chainable route handlers for a route path by using `app.route()`.
-Because the path is specified at a single location, creating modular routes is helpful, as is reducing redundancy and typos. For more information about routes, see: [Router() documentation](/api/router).
+Because the path is specified in a single location, this helps to create modular routes and reduces redundancy and typos. For more information about routes, see the [Router() documentation](/api/router).
 
 Here is an example of chained route handlers that are defined by using `app.route()`.
 
@@ -705,7 +705,7 @@ app.use('/birds', birds);
 
 The app will now be able to handle requests to `/birds` and `/birds/about`, as well as call the `timeLog` middleware function that is specific to the route.
 
-But if the parent route `/birds` has path parameters, it will not be accessible by default from the sub-routes. To make it accessible, you will need to pass the `mergeParams` option to the Router constructor [reference](/api/application#appuse).
+But if the parent route `/birds` has path parameters, it will not be accessible by default from the sub-routes. To make it accessible, you will need to pass the `mergeParams` option to the [Router constructor](/api/express/#expressrouter).
 
 ```js
 const router = express.Router({ mergeParams: true });

--- a/src/content/docs/en/4x/guide/routing.mdx
+++ b/src/content/docs/en/4x/guide/routing.mdx
@@ -370,6 +370,12 @@ The [`*`](https://github.com/expressjs/express/issues/2495) character in regular
 
 Unlike named route parameters, wildcard (`*`) matches in [string patterns](#route-paths-based-on-string-patterns) and capture groups in regular expressions are unnamed: their values are available by position, as `req.params[0]`, `req.params[1]`, and so on.
 
+```
+Route path: /file/*/size/*
+Request URL: http://localhost:3000/file/javascripts/jquery.js/size/large
+req.params: { "0": "javascripts/jquery.js", "1": "large" }
+```
+
 ## Route handlers
 
 You can provide multiple callback functions that behave like [middleware](/guide/using-middleware) to handle a request. The only exception is that these callbacks might invoke `next('route')` to bypass the remaining route callbacks. You can use this mechanism to impose pre-conditions on a route, then pass control to subsequent routes if there's no reason to proceed with the current route.

--- a/src/content/docs/en/4x/guide/routing.mdx
+++ b/src/content/docs/en/4x/guide/routing.mdx
@@ -108,7 +108,7 @@ app.all('/secret', (req: Request, res: Response, next: NextFunction) => {
 
 ## Route paths
 
-Route paths, in combination with a request method, define the endpoints at which requests can be made. Route paths can be strings, string patterns, or regular expressions.
+Route paths, in combination with a request method, define the endpoints at which requests can be made. Route paths can be strings, string patterns, or regular expressions. They can also capture values from the URL, as described in [Route parameters](#route-parameters) below.
 
 <Alert type="info">
 
@@ -367,6 +367,8 @@ characters with an additional backslash, for example `\\d+`.
 <Alert type="warning">
 The [`*`](https://github.com/expressjs/express/issues/2495) character in regular expressions is not interpreted in the usual way. As a workaround, use `{0,}` instead of `*`.
 </Alert>
+
+Unlike named route parameters, wildcard (`*`) matches in [string patterns](#route-paths-based-on-string-patterns) and capture groups in regular expressions are unnamed: their values are available by position, as `req.params[0]`, `req.params[1]`, and so on.
 
 ## Route handlers
 

--- a/src/content/docs/en/4x/guide/routing.mdx
+++ b/src/content/docs/en/4x/guide/routing.mdx
@@ -235,7 +235,7 @@ app.get('/ab(cd)?e', (req: Request, res: Response) => {
 });
 ```
 
-A wildcard (`*`) on its own matches any path segment. For example, this route path will match `/file/javascripts/jquery.js`, `/file/style.css`, and so on. Wildcards are unnamed, so the matched value is available as `req.params[0]` instead of a named parameter.
+A wildcard (`*`) on its own matches anything at its position, including entire subpaths. For example, this route path will match `/file/style.css` as well as `/file/javascripts/jquery.js`. Wildcards are unnamed, so the matched value is available as `req.params[0]` instead of a named parameter.
 
 ```js
 app.get('/file/*', (req, res) => {

--- a/src/content/docs/en/5x/guide/routing.mdx
+++ b/src/content/docs/en/5x/guide/routing.mdx
@@ -554,7 +554,7 @@ The methods on the response object (`res`) in the following table can send a res
 ## app.route()
 
 You can create chainable route handlers for a route path by using `app.route()`.
-Because the path is specified at a single location, creating modular routes is helpful, as is reducing redundancy and typos. For more information about routes, see: [Router() documentation](/api/router).
+Because the path is specified in a single location, this helps to create modular routes and reduces redundancy and typos. For more information about routes, see the [Router() documentation](/api/router).
 
 Here is an example of chained route handlers that are defined by using `app.route()`.
 
@@ -687,7 +687,7 @@ app.use('/birds', birds);
 
 The app will now be able to handle requests to `/birds` and `/birds/about`, as well as call the `timeLog` middleware function that is specific to the route.
 
-But if the parent route `/birds` has path parameters, it will not be accessible by default from the sub-routes. To make it accessible, you will need to pass the `mergeParams` option to the Router constructor [reference](/api/application#appuse).
+But if the parent route `/birds` has path parameters, it will not be accessible by default from the sub-routes. To make it accessible, you will need to pass the `mergeParams` option to the [Router constructor](/api/express/#expressrouter).
 
 ```js
 const router = express.Router({ mergeParams: true });

--- a/src/content/docs/en/5x/guide/routing.mdx
+++ b/src/content/docs/en/5x/guide/routing.mdx
@@ -277,7 +277,7 @@ app.get('/users/:userId/books/:bookId', (req, res) => {
 
 <Alert type="info">
 
-Wildcard parameters (`*`) are only supported in Express 5. Unlike named parameters (`:`), they capture one or more path segments and expose them as an array in `req.params`. See the [Wildcards](#wildcards) section above or the [migration guide](https://expressjs.com/en/guide/migrating-5/#path-route-matching-syntax) for details and examples.
+Wildcard parameters (`*`) capture one or more path segments and expose them as an array in `req.params`. See the [Wildcards](#wildcards) section above or the [migration guide](https://expressjs.com/en/guide/migrating-5/#path-route-matching-syntax) for details and examples.
 
 </Alert>
 

--- a/src/content/docs/en/5x/guide/routing.mdx
+++ b/src/content/docs/en/5x/guide/routing.mdx
@@ -108,7 +108,7 @@ app.all('/secret', (req: Request, res: Response, next: NextFunction) => {
 
 ## Route paths
 
-Route paths, in combination with a request method, define the endpoints at which requests can be made. Route paths can be strings or regular expressions.
+Route paths, in combination with a request method, define the endpoints at which requests can be made. Route paths can be strings or regular expressions. They can also capture values from the URL, as described in [Route parameters](#route-parameters) below.
 
 <Alert type="info">
 
@@ -153,9 +153,110 @@ app.get('/random.text', (req: Request, res: Response) => {
 });
 ```
 
+<Alert type="alert">
+
+The characters `?`, `+`, `*`, `[]`, and `()` are reserved and cannot be used as literal characters in route paths. Use `\` to escape them if needed.
+
+</Alert>
+
+### Regular expressions
+
+You can also use regular expressions as route paths. This is useful when you need more complex matching logic.
+
+```js
+// Matches any path containing "a"
+app.get(/a/, (req, res) => {
+  res.send('/a/');
+});
+
+// Matches paths ending with "fly" (butterfly, dragonfly, etc.)
+app.get(/.*fly$/, (req, res) => {
+  res.send('/.*fly$/');
+});
+```
+
+```ts
+import { type Request, type Response } from 'express';
+
+// Matches any path containing "a"
+app.get(/a/, (req: Request, res: Response) => {
+  res.send('/a/');
+});
+
+// Matches paths ending with "fly" (butterfly, dragonfly, etc.)
+app.get(/.*fly$/, (req: Request, res: Response) => {
+  res.send('/.*fly$/');
+});
+```
+
+## Route parameters
+
+Route parameters are named URL segments that are used to capture the values specified at their position in the URL. The captured values are populated in the `req.params` object, with the name of the route parameter specified in the path as their respective keys. They come in three forms: [named parameters](#named-parameters) (`:name`), [wildcards](#wildcards) (`*name`), and [optional segments](#optional-segments) (`{...}`).
+
+### Named parameters
+
+Named parameters capture a single path segment at their position in the URL.
+
+```
+Route path: /users/:userId/books/:bookId
+Request URL: http://localhost:3000/users/34/books/8989
+req.params: { "userId": "34", "bookId": "8989" }
+```
+
+To define routes with route parameters, simply specify the route parameters in the path of the route as shown below.
+
+```js
+app.get('/users/:userId/books/:bookId', (req, res) => {
+  res.send(req.params);
+});
+```
+
+In TypeScript, `@types/express` infers the parameters from the route path, so in the handler above
+`req.params.userId` and `req.params.bookId` are already typed as `string` with no extra annotation.
+Reading a name that is not in the route (such as `req.params.other`) is a type error. You only need
+to annotate the parameters when the handler is defined separately from the route, because the type
+checker can no longer see the path. In that case, pass them as the first type argument of `Request`:
+
+```ts
+import { type Request, type Response } from 'express';
+
+const sendParams = (req: Request<{ userId: string; bookId: string }>, res: Response) => {
+  res.send(req.params);
+};
+
+app.get('/users/:userId/books/:bookId', sendParams);
+```
+
+<Alert type="alert">
+
+The name of route parameters must be made up of "word characters" ([A-Za-z0-9_]).
+
+</Alert>
+
+Since the hyphen (`-`) and the dot (`.`) are interpreted literally, they can be used along with route parameters for useful purposes.
+
+```
+Route path: /flights/:from-:to
+Request URL: http://localhost:3000/flights/LAX-SFO
+req.params: { "from": "LAX", "to": "SFO" }
+```
+
+```
+Route path: /plantae/:genus.:species
+Request URL: http://localhost:3000/plantae/Prunus.persica
+req.params: { "genus": "Prunus", "species": "persica" }
+```
+
+<Alert type="alert">
+
+Regexp characters are not supported in route paths. Use an array of paths or regular expressions instead.
+See the [path route matching syntax](/guide/migrating-5#path-route-matching-syntax) for more information.
+
+</Alert>
+
 ### Wildcards
 
-Wildcards match any path after a prefix. They must have a name, just like route parameters, and are captured as arrays of path segments.
+Wildcards match any path after a prefix. Like other route parameters they must have a name, but they are captured as an array of path segments instead of a string.
 
 ```js
 app.get('/files/*filepath', (req, res) => {
@@ -220,109 +321,6 @@ app.get('/:file{.:ext}', (req: Request, res: Response) => {
   res.send('ok');
 });
 ```
-
-<Alert type="alert">
-
-The characters `?`, `+`, `*`, `[]`, and `()` are reserved and cannot be used as literal characters in route paths. Use `\` to escape them if needed.
-
-</Alert>
-
-### Regular expressions
-
-You can also use regular expressions as route paths. This is useful when you need more complex matching logic.
-
-```js
-// Matches any path containing "a"
-app.get(/a/, (req, res) => {
-  res.send('/a/');
-});
-
-// Matches paths ending with "fly" (butterfly, dragonfly, etc.)
-app.get(/.*fly$/, (req, res) => {
-  res.send('/.*fly$/');
-});
-```
-
-```ts
-import { type Request, type Response } from 'express';
-
-// Matches any path containing "a"
-app.get(/a/, (req: Request, res: Response) => {
-  res.send('/a/');
-});
-
-// Matches paths ending with "fly" (butterfly, dragonfly, etc.)
-app.get(/.*fly$/, (req: Request, res: Response) => {
-  res.send('/.*fly$/');
-});
-```
-
-## Route parameters
-
-Route parameters are named URL segments that are used to capture the values specified at their position in the URL. The captured values are populated in the `req.params` object, with the name of the route parameter specified in the path as their respective keys.
-
-```
-Route path: /users/:userId/books/:bookId
-Request URL: http://localhost:3000/users/34/books/8989
-req.params: { "userId": "34", "bookId": "8989" }
-```
-
-To define routes with route parameters, simply specify the route parameters in the path of the route as shown below.
-
-```js
-app.get('/users/:userId/books/:bookId', (req, res) => {
-  res.send(req.params);
-});
-```
-
-<Alert type="info">
-
-Wildcard parameters (`*`) capture one or more path segments and expose them as an array in `req.params`. See the [Wildcards](#wildcards) section above or the [migration guide](https://expressjs.com/en/guide/migrating-5/#path-route-matching-syntax) for details and examples.
-
-</Alert>
-
-In TypeScript, `@types/express` infers the parameters from the route path, so in the handler above
-`req.params.userId` and `req.params.bookId` are already typed as `string` with no extra annotation.
-Reading a name that is not in the route (such as `req.params.other`) is a type error. You only need
-to annotate the parameters when the handler is defined separately from the route, because the type
-checker can no longer see the path. In that case, pass them as the first type argument of `Request`:
-
-```ts
-import { type Request, type Response } from 'express';
-
-const sendParams = (req: Request<{ userId: string; bookId: string }>, res: Response) => {
-  res.send(req.params);
-};
-
-app.get('/users/:userId/books/:bookId', sendParams);
-```
-
-<Alert type="alert">
-
-The name of route parameters must be made up of "word characters" ([A-Za-z0-9_]).
-
-</Alert>
-
-Since the hyphen (`-`) and the dot (`.`) are interpreted literally, they can be used along with route parameters for useful purposes.
-
-```
-Route path: /flights/:from-:to
-Request URL: http://localhost:3000/flights/LAX-SFO
-req.params: { "from": "LAX", "to": "SFO" }
-```
-
-```
-Route path: /plantae/:genus.:species
-Request URL: http://localhost:3000/plantae/Prunus.persica
-req.params: { "genus": "Prunus", "species": "persica" }
-```
-
-<Alert type="alert">
-
-Regexp characters are not supported in route paths. Use an array of paths or regular expressions instead.
-See the [path route matching syntax](/guide/migrating-5#path-route-matching-syntax) for more information.
-
-</Alert>
 
 ## Route handlers
 

--- a/src/content/docs/en/5x/guide/routing.mdx
+++ b/src/content/docs/en/5x/guide/routing.mdx
@@ -283,7 +283,7 @@ To also match the root path, wrap the wildcard in braces:
 ```js
 // Matches / , /foo , /foo/bar , etc.
 app.get('/{*splat}', (req, res) => {
-  // GET / => req.params.splat = []
+  // GET / => req.params = {}, splat is omitted
   // GET /foo/bar => req.params.splat = [ 'foo', 'bar' ]
   res.send('ok');
 });
@@ -294,7 +294,7 @@ import { type Request, type Response } from 'express';
 
 // Matches / , /foo , /foo/bar , etc.
 app.get('/{*splat}', (req: Request, res: Response) => {
-  // GET / => req.params.splat = []
+  // GET / => req.params = {}, splat is omitted
   // GET /foo/bar => req.params.splat = [ 'foo', 'bar' ]
   res.send('ok');
 });
@@ -318,6 +318,40 @@ import { type Request, type Response } from 'express';
 app.get('/:file{.:ext}', (req: Request, res: Response) => {
   // GET /image.png => req.params = { file: 'image', ext: 'png' }
   // GET /image => req.params = { file: 'image' }
+  res.send('ok');
+});
+```
+
+The braces can also wrap a whole parameter to make it optional. Note that everything inside the braces is optional, so the position of the slash matters:
+
+```js
+app.get('/user/{:id}', (req, res) => {
+  // GET /user/42 => req.params = { id: '42' }
+  // GET /user/ => req.params = {}
+  // GET /user => 404, only the parameter is optional
+  res.send('ok');
+});
+
+app.get('/order{/:id}', (req, res) => {
+  // GET /order/42 => req.params = { id: '42' }
+  // GET /order => req.params = {}, the whole segment is optional
+  res.send('ok');
+});
+```
+
+```ts
+import { type Request, type Response } from 'express';
+
+app.get('/user/{:id}', (req: Request, res: Response) => {
+  // GET /user/42 => req.params = { id: '42' }
+  // GET /user/ => req.params = {}
+  // GET /user => 404, only the parameter is optional
+  res.send('ok');
+});
+
+app.get('/order{/:id}', (req: Request, res: Response) => {
+  // GET /order/42 => req.params = { id: '42' }
+  // GET /order => req.params = {}, the whole segment is optional
   res.send('ok');
 });
 ```

--- a/src/content/docs/en/5x/guide/routing.mdx
+++ b/src/content/docs/en/5x/guide/routing.mdx
@@ -191,7 +191,7 @@ app.get(/.*fly$/, (req: Request, res: Response) => {
 
 ## Route parameters
 
-Route parameters are named URL segments that are used to capture the values specified at their position in the URL. The captured values are populated in the `req.params` object, with the name of the route parameter specified in the path as their respective keys. They come in three forms: [named parameters](#named-parameters) (`:name`), [wildcards](#wildcards) (`*name`), and [optional segments](#optional-segments) (`{...}`).
+Route parameters are named URL segments that are used to capture the values specified at their position in the URL. The captured values are populated in the `req.params` object, with the name of the route parameter specified in the path as their respective keys. They come in three forms: [named parameters](#named-parameters) (`:name`), [wildcards](#wildcards) (`*name`), and [optional segments](#optional-segments), which wrap either of them in braces.
 
 ### Named parameters
 

--- a/src/content/docs/en/5x/guide/routing.mdx
+++ b/src/content/docs/en/5x/guide/routing.mdx
@@ -195,7 +195,7 @@ Route parameters are named URL segments that are used to capture the values spec
 
 ### Named parameters
 
-Named parameters capture a single path segment at their position in the URL.
+Named parameters capture a single path segment at their position in the URL, or part of one when combined with literal characters, as shown further below.
 
 ```
 Route path: /users/:userId/books/:bookId
@@ -249,7 +249,7 @@ req.params: { "genus": "Prunus", "species": "persica" }
 
 <Alert type="alert">
 
-Regexp characters are not supported in route paths. Use an array of paths or regular expressions instead.
+Regexp characters are not supported inside string paths, so a parameter cannot be restricted with a suffix such as `:userId(\d+)`. Use an array of paths or a full regular expression instead.
 See the [path route matching syntax](/guide/migrating-5#path-route-matching-syntax) for more information.
 
 </Alert>

--- a/src/content/docs/en/5x/guide/routing.mdx
+++ b/src/content/docs/en/5x/guide/routing.mdx
@@ -275,6 +275,8 @@ app.get('/users/:userId/books/:bookId', (req, res) => {
 });
 ```
 
+Wildcard parameters (`*`) are also supported in Express 5. Unlike named parameters (`:`), they capture one or more path segments and expose them as an array in `req.params`. See the [Wildcards](#wildcards) section above for details and examples.
+
 In TypeScript, `@types/express` infers the parameters from the route path, so in the handler above
 `req.params.userId` and `req.params.bookId` are already typed as `string` with no extra annotation.
 Reading a name that is not in the route (such as `req.params.other`) is a type error. You only need

--- a/src/content/docs/en/5x/guide/routing.mdx
+++ b/src/content/docs/en/5x/guide/routing.mdx
@@ -356,6 +356,8 @@ app.get('/order{/:id}', (req: Request, res: Response) => {
 });
 ```
 
+The examples above behave the same regardless of the [`strict routing` setting](/api/application/#application-settings). As with any other route, that setting only changes whether a trailing slash (such as `/order/`) is treated as a different path.
+
 ## Route handlers
 
 You can provide multiple callback functions that behave like [middleware](/guide/using-middleware) to handle a request. The only exception is that these callbacks might invoke `next('route')` to bypass the remaining route callbacks. You can use this mechanism to impose pre-conditions on a route, then pass control to subsequent routes if there's no reason to proceed with the current route.

--- a/src/content/docs/en/5x/guide/routing.mdx
+++ b/src/content/docs/en/5x/guide/routing.mdx
@@ -356,7 +356,7 @@ app.get('/order{/:id}', (req: Request, res: Response) => {
 });
 ```
 
-The examples above behave the same regardless of the [`strict routing` setting](/api/application/#application-settings). As with any other route, that setting only changes whether a trailing slash (such as `/order/`) is treated as a different path.
+Do not confuse the position of the slash in the route path with the [`strict routing` setting](/api/application/#application-settings), which is about the request URL: it controls whether a URL ending in a slash that the route path does not require still matches. For example, a request for `/order/` matches the `/order{/:id}` route by default, but returns a 404 error when strict routing is enabled; the trailing slash of `/user/` is unaffected because the `/user/{:id}` route requires it. All the requests commented in the examples above behave the same regardless of that setting.
 
 ## Route handlers
 

--- a/src/content/docs/en/5x/guide/routing.mdx
+++ b/src/content/docs/en/5x/guide/routing.mdx
@@ -275,7 +275,11 @@ app.get('/users/:userId/books/:bookId', (req, res) => {
 });
 ```
 
-Wildcard parameters (`*`) are also supported in Express 5. Unlike named parameters (`:`), they capture one or more path segments and expose them as an array in `req.params`. See the [Wildcards](#wildcards) section above for details and examples.
+<Alert type="info">
+
+Wildcard parameters (`*`) are only supported in Express 5. Unlike named parameters (`:`), they capture one or more path segments and expose them as an array in `req.params`. See the [Wildcards](#wildcards) section above or the [migration guide](https://expressjs.com/en/guide/migrating-5/#path-route-matching-syntax) for details and examples.
+
+</Alert>
 
 In TypeScript, `@types/express` infers the parameters from the route path, so in the handler above
 `req.params.userId` and `req.params.bookId` are already typed as `string` with no extra annotation.

--- a/src/content/docs/en/5x/guide/routing.mdx
+++ b/src/content/docs/en/5x/guide/routing.mdx
@@ -155,7 +155,7 @@ app.get('/random.text', (req: Request, res: Response) => {
 
 <Alert type="alert">
 
-The characters `?`, `+`, `*`, `[]`, and `()` are reserved and cannot be used as literal characters in route paths. Use `\` to escape them if needed.
+The characters `?`, `+`, `*`, `[]`, `()`, and `!` are reserved and cannot be used as literal characters in route paths, and braces are reserved for [optional segments](#optional-segments). Use `\` to escape them if needed.
 
 </Alert>
 
@@ -229,7 +229,7 @@ app.get('/users/:userId/books/:bookId', sendParams);
 
 <Alert type="alert">
 
-The name of route parameters must be made up of "word characters" ([A-Za-z0-9_]).
+The name of route parameters must be a valid JavaScript identifier. Other names can be used by quoting them, for example `:"user-name"`.
 
 </Alert>
 


### PR DESCRIPTION
## Summary

This PR improves the discoverability of wildcard parameters in the Express 5 **Route parameters** documentation.

Instead of duplicating the existing wildcard documentation, it adds a short note that points readers to the existing **Wildcards** section.

Fixes #1891