### PR TITLE
fix: preserve footer social target sizes

### DIFF
--- a/src/components/patterns/Footer/Footer.css
+++ b/src/components/patterns/Footer/Footer.css
@@ -72,12 +72,23 @@
     justify-content: center;
     gap: var(--space-6);
 
+    a {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-width: var(--size-6);
+      min-height: var(--size-6);
+    }
+
     li {
       display: inline;
     }
 
     svg {
       color: var(--color-icon-primary);
+      width: var(--size-4);
+      height: var(--size-4);
+      flex-shrink: 0;
     }
 
     svg path {
@@ -86,6 +97,8 @@
 
     @media (--xs-only) {
       padding: var(--space-4) 0 var(--space-6);
+      flex-wrap: wrap;
+      gap: var(--space-3);
     }
 
     @media (--md-up) {

--- a/tests/e2e/homepage.spec.ts
+++ b/tests/e2e/homepage.spec.ts
@@ -242,4 +242,40 @@ test.describe('Homepage Content', () => {
     await expect(blueskyLink).toBeVisible();
     await expect(rssLink).toBeVisible();
   });
+
+  test('should preserve minimum social icon and target sizes on narrow screens', async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+
+    const footer = page.getByTestId('footer');
+    const measurementTolerance = 0.01;
+    const socialLinks = [
+      footer.getByRole('link', { name: /GitHub/i }),
+      footer.getByRole('link', { name: /Youtube/i }),
+      footer.getByRole('link', { name: /X account/i }),
+      footer.getByRole('link', { name: /slack/i }),
+      footer.getByRole('link', { name: /Open Collective/i }),
+      footer.getByRole('link', { name: /bluesky/i }),
+      footer.getByRole('link', { name: /RSS Feed/i }),
+    ];
+
+    for (const link of socialLinks) {
+      const linkBox = await link.boundingBox();
+      const iconBox = await link.locator('svg').boundingBox();
+
+      expect(linkBox).not.toBeNull();
+      expect(iconBox).not.toBeNull();
+      expect(linkBox!.width).toBeGreaterThanOrEqual(24 - measurementTolerance);
+      expect(linkBox!.height).toBeGreaterThanOrEqual(24 - measurementTolerance);
+      expect(iconBox!.width).toBeGreaterThanOrEqual(16 - measurementTolerance);
+      expect(iconBox!.height).toBeGreaterThanOrEqual(16 - measurementTolerance);
+    }
+
+    const viewport = await page.evaluate(() => ({
+      clientWidth: document.documentElement.clientWidth,
+      scrollWidth: document.documentElement.scrollWidth,
+    }));
+    expect(viewport.scrollWidth).toBeLessThanOrEqual(viewport.clientWidth);
+  });
 });


### PR DESCRIPTION
## Summary

- keep all footer social icon boxes at 16 by 16 pixels on narrow screens
- give each social link a minimum 24 by 24 pixel target
- wrap and tighten the narrow-screen social row instead of compressing its icons

Fixes #2456

## Validation

- `npm run check`
- `npm run test:unit` (52 passed)
- `npm run build` (2,307 pages built)
- focused 390 by 844 Playwright regression in Chromium, Firefox, and WebKit (3 passed)
- measured all seven social links at 24 by 24 pixels and all seven SVG boxes at 16 by 16 pixels, with no horizontal overflow

The complete local homepage run passed all 24 non-locale cases. Its 27 locale-switch cases reproduced the known local dev-server 404 mismatch; the supported Netlify preview workflow will run the complete browser suite.

## AI assistance

OpenAI Codex assisted with implementation, test authoring, validation, and pull request preparation.

<!--
Thank you for your pull request. Please provide a description and
note the Certificate of Origin below.

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
