### PR TITLE
fix: keep footer social icons from shrinking below 16px

### DIFF
--- a/src/components/patterns/Footer/Footer.astro
+++ b/src/components/patterns/Footer/Footer.astro
@@ -109,7 +109,7 @@ import { BodyMd, Button, Col, Container, Grid } from '@/components/primitives';
                 aria-label="expressjs on GitHub"
                 target="_blank"
               >
-                <Icon name="github" />
+                <Icon name="github" size="16" />
               </a>
             </li>
             <li>
@@ -118,12 +118,12 @@ import { BodyMd, Button, Col, Container, Grid } from '@/components/primitives';
                 aria-label="expressjs channel on Youtube"
                 target="_blank"
               >
-                <Icon name="youtube" />
+                <Icon name="youtube" size="16" />
               </a>
             </li>
             <li>
               <a href="https://x.com/UseExpressJS" aria-label="follow expressjs on X account">
-                <Icon name="x" />
+                <Icon name="x" size="16" />
               </a>
             </li>
             <li>
@@ -131,7 +131,7 @@ import { BodyMd, Button, Col, Container, Grid } from '@/components/primitives';
                 href="https://slack-invite.openjsf.org"
                 aria-label="Join openjs foundation slack group"
               >
-                <Icon name="slack" />
+                <Icon name="slack" size="16" />
               </a>
             </li>
             <li>
@@ -139,7 +139,7 @@ import { BodyMd, Button, Col, Container, Grid } from '@/components/primitives';
                 href="https://opencollective.com/express"
                 aria-label="support expressjs on Open Collective"
               >
-                <Icon name="open-collective" />
+                <Icon name="open-collective" size="16" />
               </a>
             </li>
             <li>
@@ -147,12 +147,12 @@ import { BodyMd, Button, Col, Container, Grid } from '@/components/primitives';
                 href="https://bsky.app/profile/expressjs.bsky.social"
                 aria-label="follow expressjs on bluesky"
               >
-                <Icon name="bsky" />
+                <Icon name="bsky" size="16" />
               </a>
             </li>
             <li>
               <a href="/feed.xml" aria-label="RSS Feed">
-                <Icon name="rss" />
+                <Icon name="rss" size="16" />
               </a>
             </li>
           </ul>

--- a/src/components/patterns/Footer/Footer.css
+++ b/src/components/patterns/Footer/Footer.css
@@ -68,16 +68,32 @@
     padding: 0;
     margin: 0;
     display: flex;
+    flex-wrap: wrap;
     align-items: center;
     justify-content: center;
     gap: var(--space-6);
 
     li {
-      display: inline;
+      display: inline-flex;
+      flex-shrink: 0;
+    }
+
+    a {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      /* Keep a usable hit area even when icons are 16px */
+      min-width: var(--size-6);
+      min-height: var(--size-6);
     }
 
     svg {
       color: var(--color-icon-primary);
+      flex-shrink: 0;
+      /* Override reset max-width:100% so flex layout cannot shrink icons */
+      width: var(--size-4);
+      height: var(--size-4);
+      max-width: none;
     }
 
     svg path {
@@ -126,6 +142,8 @@
 
   .kawaii-toggle {
     font-size: var(--font-size-sm);
+    flex-shrink: 0;
+    white-space: nowrap;
   }
 
   .kawaii-toggle[aria-pressed='true'] {


### PR DESCRIPTION
## Summary
- Prevent footer social icons from shrinking on narrow viewports when the Kawaii toggle shares the same flex row
- Pin icons to 16px and keep a usable hit area on the links
- Allow the social row to wrap instead of compressing items

Fixes #2456

## Test plan
- [ ] Open the site footer at a viewport under 400px wide
- [ ] Confirm social icons stay at least 16px and do not collapse beside the Kawaii button
- [ ] Confirm icons remain clickable and the Kawaii toggle still works
- [ ] Spot-check desktop footer layout is unchanged