### PR TITLE
docs: add missing package.json "type": "module" step to TypeScript in…

### DIFF
--- a/src/content/docs/en/5x/starter/installing.mdx
+++ b/src/content/docs/en/5x/starter/installing.mdx
@@ -52,6 +52,25 @@ for example `@types/cors` alongside `cors`.
 
 </Alert>
 
+Since the `tsconfig.json` below uses `"module": "nodenext"`, TypeScript determines whether each
+file is treated as an ES Module or CommonJS based on the `"type"` field in your `package.json`.
+Add `"type": "module"` to your `package.json` so that ES Module `import`/`export` syntax is
+recognized:
+
+```json title="package.json"
+{
+  "type": "module"
+}
+```
+
+<Alert type="warning">
+
+Without `"type": "module"`, TypeScript will treat `.ts` files as CommonJS and report an error like
+`ECMAScript imports and exports cannot be written in a CommonJS file under 'verbatimModuleSyntax'`
+when you use `import`/`export` syntax.
+
+</Alert>
+
 Add a `tsconfig.json`. These options mirror how Node.js runs TypeScript and make the compiler reject
 non-erasable syntax (such as `enum`s, namespaces, and parameter properties) that Node cannot strip:
 


### PR DESCRIPTION
## Description

The TypeScript setup section provides a `tsconfig.json` using `"module": "nodenext"` and demonstrates ESM `import` syntax in `src/app.ts`, but doesn't mention that `package.json` also needs `"type": "module"` set. Without it, TypeScript treats `.ts` files as CommonJS by default and throws `ECMAScript imports and exports cannot be written in a CommonJS file under 'verbatimModuleSyntax'. (ts1295)` when following the guide as written. This adds the missing step so the example works out of the box.

## Changes

- Added a new step between the middleware-types warning and the `tsconfig.json` block explaining that `"module": "nodenext"` requires `package.json` to declare `"type": "module"`
- Included a `package.json` code snippet showing the required field
- Added a warning callout explaining the exact error users will hit if this step is skipped

## Type of change

- [x] Documentation fix/improvement

<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 
-->
<!--
Developer's Certificate of Origin 1.1
By making a contribution to this project, I certify that:
(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or
(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or
(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.
(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->