### PR TITLE
docs: fix ReferenceError in open-redirect example (Url -> URL)

### DIFF
--- a/src/content/pages/en/advanced/best-practice-security.mdx
+++ b/src/content/pages/en/advanced/best-practice-security.mdx
@@ -64,7 +64,7 @@ Here is an example of checking URLs before using `res.redirect` or `res.location
 ```js
 app.use((req, res) => {
   try {
-    if (new Url(req.query.url).host !== 'example.com') {
+    if (new URL(req.query.url).host !== 'example.com') {
       return res.status(400).end(`Unsupported redirect to host: ${req.query.url}`);
     }
   } catch (e) {


### PR DESCRIPTION
## Summary

The open-redirect validation example on *Production Best Practices: Security* calls `new Url(req.query.url)`, but the JavaScript global is `URL`. As written the constructor throws `ReferenceError: Url is not defined` on every request, the `catch` swallows it, and the handler responds `400 "Unsupported redirect"` for every URL — including valid ones — so the redirect never runs. Anyone copying the snippet gets a handler that silently rejects all redirects instead of validating them.

One-line fix: `Url` → `URL`.

The same snippet appears in the translated mirrors, but per `docs/i18n.md` I've only touched the English source so Crowdin can propagate it.

Verified locally: `npm run check` green, unit tests 52/52, and a full `astro build` succeeds with the corrected snippet in the built page.
