### PR TITLE
feat: differentiate versioned pages metadata for search engines

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -23,10 +23,6 @@ const {
   canonicalPathname,
 } = Astro.props;
 
-const pageTitle = title
-  ? `${title} · Express.js`
-  : 'Express.js · Node.js web application framework';
-
 const pathname = Astro.url.pathname.replace(/\/$/, '');
 const segments = pathname.split('/').filter(Boolean);
 const langSegment = segments[0] || 'en';
@@ -34,6 +30,18 @@ const restSegments = segments.slice(1);
 const isApi =
   restSegments[0] === 'api' || (restSegments[1] === 'api' && /^\dx$/.test(restSegments[0] ?? ''));
 const isBlogOrApi = restSegments[0] === 'blog' || isApi;
+
+// Versioned pages carry the version in title/description so search engines
+// don't treat 4x and 5x as duplicates.
+const versionSegment = /^\dx$/.test(restSegments[0] ?? '') ? restSegments[0] : undefined;
+const versionLabel = versionSegment && `Express.js ${versionSegment[0]}.x`;
+
+const pageTitle = title
+  ? `${title} · ${versionLabel ?? 'Express.js'}`
+  : 'Express.js · Node.js web application framework';
+const pageDescription = versionLabel
+  ? `${description} Documentation for ${versionLabel}.`
+  : description;
 
 // Blog and API content is not translated, so their canonical is the English
 // page and they emit no hreflang alternates.
@@ -94,7 +102,7 @@ const lang = getLangFromUrl(Astro.url);
     <link rel="icon" href="/favicon.ico" sizes="any" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <link rel="manifest" href="/site.webmanifest" />
-    <meta name="description" content={description} />
+    <meta name="description" content={pageDescription} />
 
     <link rel="canonical" href={canonicalUrl} />
 
@@ -128,7 +136,7 @@ const lang = getLangFromUrl(Astro.url);
     <meta property="og:site_name" content="Express.js" />
     <meta property="og:url" content={canonicalUrl} />
     <meta property="og:title" content={pageTitle} />
-    <meta property="og:description" content={description} />
+    <meta property="og:description" content={pageDescription} />
     <meta property="og:image" content={imageUrl} />
     {authors?.map((author) => <meta property="article:author" content={author.name} />)}
 
@@ -136,7 +144,7 @@ const lang = getLangFromUrl(Astro.url);
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="@UseExpressJS" />
     <meta name="twitter:title" content={pageTitle} />
-    <meta name="twitter:description" content={description} />
+    <meta name="twitter:description" content={pageDescription} />
     <meta name="twitter:domain" content="expressjs.com" />
     <meta name="twitter:image" content={imageUrl} />
 


### PR DESCRIPTION
Pages under a version segment (/{lang}/4x|5x/, docs and API) now include the version in the title ("Using middleware · Express.js 4.x") and append a "Documentation for Express.js 4.x." sentence to the meta description, also reflected in the Open Graph and Twitter tags. This keeps the 4x and 5x pages from competing as near-duplicates in search results while both remain indexed with their own canonical.

<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
