### PR TITLE
ci: treat 418 as success

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,5 +103,6 @@ jobs:
             --exclude-loopback
             --remap "https://expressjs\.com\/((?:[^\/]+\/)*[^\/\.]+)\/?$ file://$PWD/dist/\$1/index.html"
             --remap "https://expressjs\.com\/(.*\.html)$ file://$PWD/dist/\$1"
+            --accept 100..=103,200..=299,418
             dist/
           fail: true


### PR DESCRIPTION
freedesktop.org responds with "418 I'm a teapot" when rate limit is exceeded. This should reduce the frequency of CI failures.

`100..=103,200..=299` is the [default range](https://lychee.cli.rs/guides/cli/#-a---accept).

<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
