### PR TITLE
fix: upgrade HeroDevs support links to HTTPS for security

### DIFF
--- a/src/content/pages/de/support.md
+++ b/src/content/pages/de/support.md
@@ -20,4 +20,4 @@ Versionen, die EOL (Ende des Lebens) _may_ sind, erhalten Updates für kritische
 
 Wenn Sie nicht in der Lage sind, auf eine unterstützte Version von Express zu aktualisieren, wenden Sie sich bitte an einen unserer Partner, um Sicherheitsaktualisierungen zu erhalten:
 
-- [HeroDevs unendlicher Support](http://www.herodevs.com/support/express-nes?utm_source=expressjs&utm_medium=link&utm_campaign=express_eol_page)
+- [HeroDevs unendlicher Support](https://www.herodevs.com/support/express-nes?utm_source=expressjs&utm_medium=link&utm_campaign=express_eol_page)

--- a/src/content/pages/es/support.md
+++ b/src/content/pages/es/support.md
@@ -20,4 +20,4 @@ Las versiones que son EOL (end-of-life) _pueden_ recibir actualizaciones para vu
 
 Si no puede actualizar a una versión soportada de Express, póngase en contacto con uno de nuestros socios para recibir actualizaciones de seguridad:
 
-- [Soporte de HeroDevs finalizado](http://www.herodevs.com/support/express-nes?utm_source=expressjs&utm_medium=link&utm_campaign=express_eol_page)
+- [Soporte de HeroDevs finalizado](https://www.herodevs.com/support/express-nes?utm_source=expressjs&utm_medium=link&utm_campaign=express_eol_page)

--- a/src/content/pages/fr/support.md
+++ b/src/content/pages/fr/support.md
@@ -20,4 +20,4 @@ Les versions qui sont EdlV (fin de vie) _peuvent_ recevoir des mises à jour pou
 
 Si vous ne pouvez pas mettre à jour une version prise en charge de Express, veuillez contacter l'un de nos partenaires pour recevoir les mises à jour de sécurité :
 
-- [Support des Héros sans fin](http://www.herodevs.com/support/express-nes?utm_source=expressjs&utm_medium=link&utm_campaign=express_eol_page)
+- [Support des Héros sans fin](https://www.herodevs.com/support/express-nes?utm_source=expressjs&utm_medium=link&utm_campaign=express_eol_page)

--- a/src/content/pages/it/support.md
+++ b/src/content/pages/it/support.md
@@ -20,4 +20,4 @@ Versioni che sono EOL (end-of-life) _may_ ricevere aggiornamenti per le vulnerab
 
 Se non riesci ad aggiornare ad una versione supportata di Express, contatta uno dei nostri partner per ricevere aggiornamenti di sicurezza:
 
-- [HeroDevs Never-Ending Support](http://www.herodevs.com/support/express-nes?utm_source=expressjs&utm_medium=link&utm_campaign=express_eol_page)
+- [HeroDevs Never-Ending Support](https://www.herodevs.com/support/express-nes?utm_source=expressjs&utm_medium=link&utm_campaign=express_eol_page)

--- a/src/content/pages/ja/support.md
+++ b/src/content/pages/ja/support.md
@@ -20,4 +20,4 @@ EOL (終了) _may_ のバージョンは、重大なセキュリティ脆弱性�
 
 サポートされているバージョンの Express にアップデートできない場合は、以下のいずれかのパートナーにお問い合わせください:
 
-- [HeroDevs Never-Ending Support](http://www.herodevs.com/support/express-nes?utm_source=expressjs&utm_medium=link&utm_campaign=express_eol_page)
+- [HeroDevs Never-Ending Support](https://www.herodevs.com/support/express-nes?utm_source=expressjs&utm_medium=link&utm_campaign=express_eol_page)

--- a/src/content/pages/ko/support.md
+++ b/src/content/pages/ko/support.md
@@ -20,4 +20,4 @@ Versions that are EOL (end-of-life) _may_ receive updates for critical security 
 
 If you are unable to update to a supported version of Express, please contact one of our partners to receive security updates:
 
-- [HeroDevs Never-Ending Support](http://www.herodevs.com/support/express-nes?utm_source=expressjs&utm_medium=link&utm_campaign=express_eol_page)
+- [HeroDevs Never-Ending Support](https://www.herodevs.com/support/express-nes?utm_source=expressjs&utm_medium=link&utm_campaign=express_eol_page)

--- a/src/content/pages/pt-br/support.md
+++ b/src/content/pages/pt-br/support.md
@@ -20,4 +20,4 @@ Versões que são EOL (fim de vida) _pode_ receber atualizações de vulnerabili
 
 Se você não puder atualizar para uma versão suportada do Express, entre em contato com um de nossos parceiros para receber atualizações de segurança:
 
-- [Suporte para HeroDevs Final Interminável](http://www.herodevs.com/support/express-nes?utm_source=expressjs&utm_medium=link&utm_campaign=express_eol_page)
+- [Suporte para HeroDevs Final Interminável](https://www.herodevs.com/support/express-nes?utm_source=expressjs&utm_medium=link&utm_campaign=express_eol_page)

--- a/src/content/pages/zh-cn/support.md
+++ b/src/content/pages/zh-cn/support.md
@@ -20,4 +20,4 @@ description: 了解不同 Express.js 版本的支持计划，包括当前仍受�
 
 如果你无法升级到受支持的 Express 版本，请联系以下合作伙伴获取安全更新：
 
-- [HeroDevs Never-Ending Support](http://www.herodevs.com/support/express-nes?utm_source=expressjs&utm_medium=link&utm_campaign=express_eol_page)
+- [HeroDevs Never-Ending Support](https://www.herodevs.com/support/express-nes?utm_source=expressjs&utm_medium=link&utm_campaign=express_eol_page)

--- a/src/content/pages/zh-tw/support.md
+++ b/src/content/pages/zh-tw/support.md
@@ -20,4 +20,4 @@ Versions that are EOL (end-of-life) _may_ receive updates for critical security 
 
 If you are unable to update to a supported version of Express, please contact one of our partners to receive security updates:
 
-- [HeroDevs Never-Ending Support](http://www.herodevs.com/support/express-nes?utm_source=expressjs&utm_medium=link&utm_campaign=express_eol_page)
+- [HeroDevs Never-Ending Support](https://www.herodevs.com/support/express-nes?utm_source=expressjs&utm_medium=link&utm_campaign=express_eol_page)


### PR DESCRIPTION
<!--
## Security Fix

Upgrades insecure HTTP links to HTTPS for the HeroDevs Never-Ending Support partnership link across all translated support documentation pages.

## Issue
The English version (`en/support.mdx`) uses HTTPS for the HeroDevs link, but 9 translated language versions were using HTTP instead of HTTPS, creating a security inconsistency.

## Files Changed (9 total)
- `src/content/pages/de/support.md` (German)
- `src/content/pages/es/support.md` (Spanish)
- `src/content/pages/fr/support.md` (French)
- `src/content/pages/it/support.md` (Italian)
- `src/content/pages/ja/support.md` (Japanese)
- `src/content/pages/ko/support.md` (Korean)
- `src/content/pages/pt-br/support.md` (Portuguese-Brazil)
- `src/content/pages/zh-cn/support.md` (Chinese-Simplified)
- `src/content/pages/zh-tw/support.md` (Chinese-Traditional)

## Change Type
- Single-line update per file (HTTP → HTTPS)
- Aligns with English version standard
- No breaking changes

Signed-off-by: REAPER2705 <your-email@users.noreply.github.com>
