### PR TITLE
Fix 5.x docs drift from 4.x conventions

### DIFF
--- a/src/content/api/5x/api/request/index.mdx
+++ b/src/content/api/5x/api/request/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Request Object
-description: The request object represents the HTTP request and has properties for the request query string, parameters, body, HTTP headers, and so on
+description: The req object represents the HTTP request and has properties for the request query string, parameters, body, HTTP headers, and so on
 ---
 
 import Alert from '@components/primitives/Alert/Alert.astro';
@@ -234,6 +234,27 @@ console.dir(req.fresh);
 // => true
 ```
 
+### req.hostname
+
+<Signature type="String" />
+
+Contains the hostname derived from the `Host` HTTP header.
+
+When the [`trust proxy` setting](/api/application/#options-for-trust-proxy-setting)
+does not evaluate to `false`, this property will instead get the value
+from the `X-Forwarded-Host` header field. This header can be set by
+the client or by the proxy.
+
+If there is more than one `X-Forwarded-Host` header in the request, the
+value of the first header is used. This includes a single header with
+comma-separated values, in which the first value is used.
+
+```js
+// Host: "example.com:3000"
+console.dir(req.hostname);
+// => 'example.com'
+```
+
 ### req.host
 
 <Signature type="String" />
@@ -257,27 +278,6 @@ console.dir(req.host);
 // Host: "[::1]:3000"
 console.dir(req.host);
 // => '[::1]:3000'
-```
-
-### req.hostname
-
-<Signature type="String" />
-
-Contains the hostname derived from the `Host` HTTP header.
-
-When the [`trust proxy` setting](/api/application/#options-for-trust-proxy-setting)
-does not evaluate to `false`, this property will instead get the value
-from the `X-Forwarded-Host` header field. This header can be set by
-the client or by the proxy.
-
-If there is more than one `X-Forwarded-Host` header in the request, the
-value of the first header is used. This includes a single header with
-comma-separated values, in which the first value is used.
-
-```js
-// Host: "example.com:3000"
-console.dir(req.hostname);
-// => 'example.com'
 ```
 
 ### req.ip

--- a/src/content/api/5x/api/response/index.mdx
+++ b/src/content/api/5x/api/response/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Response
-description: The response object represents the HTTP response that an Express app sends when it gets an HTTP request.
+description: The res object represents the HTTP response that an Express app sends when it gets an HTTP request.
 ---
 
 import Alert from '@components/primitives/Alert/Alert.astro';
@@ -1104,7 +1104,7 @@ res.type('.html'); // => 'text/html'
 res.type('html'); // => 'text/html'
 res.type('json'); // => 'application/json'
 res.type('application/json'); // => 'application/json'
-res.type('png'); // => image/png:
+res.type('png'); // => 'image/png'
 ```
 
 Aliased as `res.contentType(type)`.


### PR DESCRIPTION
Addresses part of #1881 — the `req.host`/`req.hostname` ordering and page description items, plus the `res.type()` typo noted inside the comment-style bullet. The broader single-vs-double-quote and `// => sth` inline-vs-newline comment-placement convention in that same bullet is left for a separate PR since it touches many more lines and is a bigger judgment call.

Three small fixes to bring 5.x docs back in line with 4.x conventions:

1. **`res.type()` typo** — `res/index.mdx` had `res.type('png'); // => image/png:` (stray trailing colon, missing quotes). Every sibling example in that block, and the 4.x doc's equivalent line, uses `// => 'image/png'`. Fixed to match.
2. **`req.host` / `req.hostname` order** — 4.x documents `req.hostname` first, then `req.host` (as a deprecated alias). 5.x had them reversed. Reordered to match 4.x; only moved the blocks, didn't touch their content (5.x's `req.host` legitimately documents different behavior — it retains the port — so it's correctly *not* described as a deprecated alias there, unlike 4.x).
3. **Frontmatter `description`** — 5.x request/response docs said "The request/response object represents..."; 4.x says "The req/res object represents...". Changed 5.x to match 4.x's wording.

No content/behavior claims changed beyond what's listed above — pure ordering + wording + one typo.
