### PR TITLE
docs: finish the remaining 5.x/4.x API reference consistency items

### DIFF
--- a/docs/content.md
+++ b/docs/content.md
@@ -134,6 +134,20 @@ src/content/api/
 - Versioned: `/en/5x/api/application` → Express 5.x application API
 - Non-versioned: `/en/api/application` → Defaults to Express 5.x
 
+### Style Conventions
+
+The reference pages for every version follow the same conventions, so that switching between
+Express 4.x and 5.x only shows real API differences:
+
+- Property and method sections are listed alphabetically, so `req.host` comes before `req.hostname`.
+- Result comments in code samples use single quotes, matching the Prettier `singleQuote` setting:
+  `res.type('png'); // => 'image/png'`. Double quotes are kept only where the sample shows JSON or a
+  raw HTTP header.
+- The frontmatter `description` of the request and response pages repeats the opening sentence of the
+  page, which refers to the objects as `req` and `res` rather than spelling out their full names.
+
+`tests/unit/api-docs-style.test.mjs` checks these conventions, and it runs as part of `npm run test:unit`.
+
 ## Versioning
 
 The Express.js documentation supports multiple versions. Content is organized by version in both the `docs` and `api` collections.

--- a/src/content/api/4x/api/application/index.mdx
+++ b/src/content/api/4x/api/application/index.mdx
@@ -560,7 +560,7 @@ app.get('title');
 
 app.set('title', 'My Site');
 app.get('title');
-// => "My Site"
+// => 'My Site'
 ```
 
 ### app.get()

--- a/src/content/api/4x/api/request/index.mdx
+++ b/src/content/api/4x/api/request/index.mdx
@@ -244,6 +244,22 @@ console.dir(req.fresh);
 // => true
 ```
 
+### req.host
+
+<Signature type="String" deprecated="v4.5.0" />
+
+<Alert type="alert">
+
+`req.host` is a deprecated alias of [`req.hostname`](#reqhostname) and returns the same value — the hostname with the port number stripped off. It has emitted a deprecation warning since Express v4.5.0. Use `req.hostname` instead.
+
+</Alert>
+
+```js
+// Host: "example.com:3000"
+console.dir(req.host);
+// => 'example.com'
+```
+
 ### req.hostname
 
 <Signature type="String" />
@@ -269,22 +285,6 @@ more than once.
 ```js
 // Host: "example.com:3000"
 console.dir(req.hostname);
-// => 'example.com'
-```
-
-### req.host
-
-<Signature type="String" deprecated="v4.5.0" />
-
-<Alert type="alert">
-
-`req.host` is a deprecated alias of [`req.hostname`](#reqhostname) and returns the same value — the hostname with the port number stripped off. It has emitted a deprecation warning since Express v4.5.0. Use `req.hostname` instead.
-
-</Alert>
-
-```js
-// Host: "example.com:3000"
-console.dir(req.host);
 // => 'example.com'
 ```
 
@@ -671,17 +671,17 @@ list or array, the method returns the _best_ match (if any).
 ```js
 // Accept: text/html
 req.accepts('html');
-// => "html"
+// => 'html'
 
 // Accept: text/*, application/json
 req.accepts('html');
-// => "html"
+// => 'html'
 req.accepts('text/html');
-// => "text/html"
+// => 'text/html'
 req.accepts(['json', 'text']);
-// => "json"
+// => 'json'
 req.accepts('application/json');
-// => "application/json"
+// => 'application/json'
 
 // Accept: text/*, application/json
 req.accepts('image/png');
@@ -690,7 +690,7 @@ req.accepts('png');
 
 // Accept: text/*;q=.5, application/json
 req.accepts(['html', 'json']);
-// => "json"
+// => 'json'
 ```
 
 For more information, or if you have issues or concerns, see [accepts](https://github.com/expressjs/accepts).
@@ -856,10 +856,10 @@ The `Referrer` and `Referer` fields are interchangeable.
 
 ```js
 req.get('Content-Type');
-// => "text/plain"
+// => 'text/plain'
 
 req.get('content-type');
-// => "text/plain"
+// => 'text/plain'
 
 req.get('Something');
 // => undefined
@@ -943,15 +943,15 @@ Returns the value of param `name` when present.
 ```js
 // ?name=tobi
 req.param('name');
-// => "tobi"
+// => 'tobi'
 
 // POST name=tobi
 req.param('name');
-// => "tobi"
+// => 'tobi'
 
 // /user/tobi for /user/:name
 req.param('name');
-// => "tobi"
+// => 'tobi'
 ```
 
 Lookup is performed in the following order:

--- a/src/content/api/4x/api/response/index.mdx
+++ b/src/content/api/4x/api/response/index.mdx
@@ -572,7 +572,7 @@ The match is case-insensitive.
 
 ```js
 res.get('Content-Type');
-// => "text/plain"
+// => 'text/plain'
 ```
 
 ### res.json()

--- a/src/content/api/5x/api/application/index.mdx
+++ b/src/content/api/5x/api/application/index.mdx
@@ -585,7 +585,7 @@ app.get('title');
 
 app.set('title', 'My Site');
 app.get('title');
-// => "My Site"
+// => 'My Site'
 ```
 
 ### app.get()

--- a/src/content/api/5x/api/request/index.mdx
+++ b/src/content/api/5x/api/request/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Request Object
-description: The request object represents the HTTP request and has properties for the request query string, parameters, body, HTTP headers, and so on
+description: The req object represents the HTTP request and has properties for the request query string, parameters, body, HTTP headers, and so on
 ---
 
 import Alert from '@components/primitives/Alert/Alert.astro';
@@ -211,7 +211,7 @@ contains cookies sent by the request. If the request contains no cookies, it def
 ```js
 // Cookie: name=tj
 console.dir(req.cookies.name);
-// => "tj"
+// => 'tj'
 ```
 
 If the cookie has been signed, you have to use [req.signedCookies](#reqsignedcookies).
@@ -292,7 +292,7 @@ the value of this property is derived from the left-most entry in the
 
 ```js
 console.dir(req.ip);
-// => "127.0.0.1"
+// => '127.0.0.1'
 ```
 
 ### req.ips
@@ -361,7 +361,7 @@ the "mounting" feature of [app.use()](/api/application/#appuse) will rewrite `re
 ```js
 // GET /search?q=something
 console.dir(req.originalUrl);
-// => "/search?q=something"
+// => '/search?q=something'
 ```
 
 `req.originalUrl` is available both in middleware and router objects, and is a
@@ -398,7 +398,7 @@ This property is an object containing properties mapped to the [named route "par
 ```js
 // GET /user/tj
 console.dir(req.params.name);
-// => "tj"
+// => 'tj'
 ```
 
 Properties corresponding to wildcard parameters are arrays containing separate path segments split on `/`:
@@ -433,7 +433,7 @@ When you use a regular expression for the route definition, capture groups are p
 app.use(/^\/file\/(.*)$/, (req, res) => {
   // GET /file/javascripts/jquery.js
   console.dir(req.params[0]);
-  // => "javascripts/jquery.js"
+  // => 'javascripts/jquery.js'
 });
 ```
 
@@ -443,7 +443,7 @@ import { type Request, type Response } from 'express';
 app.use(/^\/file\/(.*)$/, (req: Request, res: Response) => {
   // GET /file/javascripts/jquery.js
   console.dir(req.params[0]);
-  // => "javascripts/jquery.js"
+  // => 'javascripts/jquery.js'
 });
 ```
 
@@ -468,7 +468,7 @@ Contains the path part of the request URL.
 ```js
 // example.com/users?sort=desc
 console.dir(req.path);
-// => "/users"
+// => '/users'
 ```
 
 <Alert type="info">
@@ -490,7 +490,7 @@ This header can be set by the client or by the proxy.
 
 ```js
 console.dir(req.protocol);
-// => "http"
+// => 'http'
 ```
 
 ### req.query
@@ -637,7 +637,7 @@ If no signed cookies are sent, the property defaults to `{}`.
 ```js
 // Cookie: user=tobi.CP7AWaXDfAKIRfH49dQzKJx7sKzzSoPq7/AcBBRVwlI3
 console.dir(req.signedCookies.user);
-// => "tobi"
+// => 'tobi'
 ```
 
 For more information, issues, or concerns, see [cookie-parser](https://github.com/expressjs/cookie-parser).
@@ -663,7 +663,7 @@ An array of subdomains in the domain name of the request.
 ```js
 // Host: "tobi.ferrets.example.com"
 console.dir(req.subdomains);
-// => ["ferrets", "tobi"]
+// => ['ferrets', 'tobi']
 ```
 
 The application property `subdomain offset`, which defaults to 2, is used for determining the
@@ -708,17 +708,17 @@ list or array, the method returns the _best_ match (if any).
 ```js
 // Accept: text/html
 req.accepts('html');
-// => "html"
+// => 'html'
 
 // Accept: text/*, application/json
 req.accepts('html');
-// => "html"
+// => 'html'
 req.accepts('text/html');
-// => "text/html"
+// => 'text/html'
 req.accepts(['json', 'text']);
-// => "json"
+// => 'json'
 req.accepts('application/json');
-// => "application/json"
+// => 'application/json'
 
 // Accept: text/*, application/json
 req.accepts('image/png');
@@ -727,7 +727,7 @@ req.accepts('png');
 
 // Accept: text/*;q=.5, application/json
 req.accepts(['html', 'json']);
-// => "json"
+// => 'json'
 ```
 
 For more information, or if you have issues or concerns, see [accepts](https://github.com/expressjs/accepts).
@@ -832,10 +832,10 @@ The `Referrer` and `Referer` fields are interchangeable.
 
 ```js
 req.get('Content-Type');
-// => "text/plain"
+// => 'text/plain'
 
 req.get('content-type');
-// => "text/plain"
+// => 'text/plain'
 
 req.get('Something');
 // => undefined

--- a/src/content/api/5x/api/response/index.mdx
+++ b/src/content/api/5x/api/response/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Response
-description: The response object represents the HTTP response that an Express app sends when it gets an HTTP request.
+description: The res object represents the HTTP response that an Express app sends when it gets an HTTP request.
 ---
 
 import Alert from '@components/primitives/Alert/Alert.astro';
@@ -564,7 +564,7 @@ The match is case-insensitive.
 
 ```js
 res.get('Content-Type');
-// => "text/plain"
+// => 'text/plain'
 ```
 
 ### res.json()
@@ -1104,7 +1104,7 @@ res.type('.html'); // => 'text/html'
 res.type('html'); // => 'text/html'
 res.type('json'); // => 'application/json'
 res.type('application/json'); // => 'application/json'
-res.type('png'); // => image/png:
+res.type('png'); // => 'image/png'
 ```
 
 Aliased as `res.contentType(type)`.

--- a/tests/unit/api-docs-style.test.mjs
+++ b/tests/unit/api-docs-style.test.mjs
@@ -1,0 +1,73 @@
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync } from 'node:fs';
+import { dirname, join, relative, resolve } from 'node:path';
+import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const API_ROOT = join(ROOT, 'src', 'content', 'api');
+const VERSIONS = ['4x', '5x'];
+
+function collectMdx(dir) {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) return collectMdx(full);
+    return entry.name.endsWith('.mdx') ? [full] : [];
+  });
+}
+
+function findOffendingLines(isOffending) {
+  const offenders = [];
+  for (const file of VERSIONS.flatMap((version) => collectMdx(join(API_ROOT, version)))) {
+    readFileSync(file, 'utf8')
+      .split('\n')
+      .forEach((line, index) => {
+        if (isOffending(line)) {
+          offenders.push(`${relative(ROOT, file)}:${index + 1} ${line.trim()}`);
+        }
+      });
+  }
+  return offenders;
+}
+
+test('result comments quote string values with single quotes', () => {
+  const offenders = findOffendingLines(
+    (line) => /^\s*\/\/\s*=>.*"/.test(line) && !line.includes('{')
+  );
+  assert.deepEqual(offenders, []);
+});
+
+test('result comments do not end with stray punctuation', () => {
+  const offenders = findOffendingLines((line) => /^\s*\/\/\s*=>.*[:;,]\s*$/.test(line));
+  assert.deepEqual(offenders, []);
+});
+
+test('req.host is documented before req.hostname', () => {
+  for (const version of VERSIONS) {
+    const file = join(API_ROOT, version, 'api', 'request', 'index.mdx');
+    const content = readFileSync(file, 'utf8');
+    const host = content.indexOf('### req.host\n');
+    const hostname = content.indexOf('### req.hostname\n');
+    assert.notEqual(host, -1, `req.host heading is missing in ${version}`);
+    assert.notEqual(hostname, -1, `req.hostname heading is missing in ${version}`);
+    assert.ok(host < hostname, `req.host should precede req.hostname in ${version}`);
+  }
+});
+
+test('request and response pages describe themselves as req and res', () => {
+  const pages = [
+    ['request', 'req'],
+    ['response', 'res'],
+  ];
+  for (const version of VERSIONS) {
+    for (const [page, name] of pages) {
+      const file = join(API_ROOT, version, 'api', page, 'index.mdx');
+      const description = readFileSync(file, 'utf8').match(/^description: (.*)$/m);
+      assert.ok(description, `${version}/${page} has no description`);
+      assert.ok(
+        description[1].startsWith(`The ${name} object represents`),
+        `${version}/${page} description should start with 'The ${name} object represents'`
+      );
+    }
+  }
+});


### PR DESCRIPTION
Closes the three remaining unchecked items in #1881.

## Problem

The 4.x and 5.x API reference pages drifted apart after the redesign, which makes it hard to tell a
real API difference from a formatting difference when switching versions:

1. Result comments in code samples use double quotes in many places (`// => "text/html"`) while the
   rest of the site, and the Prettier `singleQuote` setting, use single quotes.
2. The `res.type()` sample had a typo — `res.type('png'); // => image/png:` — with the value unquoted
   and a stray trailing colon (the typo #1881 links to).
3. `req.host` and `req.hostname` were sorted differently: 5.x lists `req.host` first (alphabetical,
   like every other section), 4.x lists `req.hostname` first.
4. The 5.x page `description` frontmatter said "The request object …" / "The response object …" while
   4.x and the opening sentence of both pages say "The `req` object …" / "The `res` object …".

## Fix

- Normalised 33 result comments across the 4.x and 5.x application/request/response pages to single
  quotes. Double quotes are kept where the sample legitimately shows JSON (`// => callback({ "user": "tobi" })`)
  or a raw HTTP header (`// Host: "example.com:3000"`).
- Fixed the `res.type('png')` sample to `res.type('png'); // => 'image/png'`.
- Moved the 4.x `req.host` section above `req.hostname` so both versions are alphabetical. I picked
  the 5.x order because every other section on the page is alphabetical — happy to flip it the other
  way if you prefer the deprecated alias to stay last.
- Aligned the 5.x request/response `description` frontmatter with 4.x and with the first sentence of
  each page.

No prose or behaviour was changed, only formatting, ordering and the one typo.

## Tests

Added `tests/unit/api-docs-style.test.mjs`, which runs in the existing `npm run test:unit` step of
the `lint` job. It walks every `.mdx` file under `src/content/api/4x` and `src/content/api/5x` and
asserts that:

- no result comment quotes a plain string value with double quotes;
- no result comment ends with stray punctuation (this is what would have caught the `image/png:` typo);
- `req.host` is documented before `req.hostname` in both versions;
- the request/response `description` frontmatter starts with "The req object represents" /
  "The res object represents".

Each assertion fails on `main` before this change and passes after it.

## Docs

Added a "Style Conventions" subsection to `docs/content.md` under **API Reference** describing the
three conventions and pointing at the test that enforces them, so the next person editing these pages
knows the rules without having to diff 4.x against 5.x.

<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
