### PR TITLE
docs: add lint-time security checks section to security best practices

### DIFF
--- a/src/content/pages/en/advanced/best-practice-security.mdx
+++ b/src/content/pages/en/advanced/best-practice-security.mdx
@@ -31,6 +31,7 @@ Security best practices for Express applications in production include:
 - [Prevent brute-force attacks against authorization](#prevent-brute-force-attacks-against-authorization)
 - [Ensure your dependencies are secure](#ensure-your-dependencies-are-secure)
   - [Avoid other known vulnerabilities](#avoid-other-known-vulnerabilities)
+- [Lint your code for security issues](#lint-your-code-for-security-issues)
 - [Additional considerations](#additional-considerations)
 
 ## Don't use deprecated or vulnerable versions of Express
@@ -303,6 +304,19 @@ $ snyk test
 Keep an eye out for [GitHub Advisory Database](https://github.com/advisories?query=ecosystem%3Anpm) or [Snyk](https://security.snyk.io/vuln/npm) advisories that may affect Express or other modules that your app uses. In general, these databases are excellent resources for knowledge and tools about Node security.
 
 Finally, Express apps&mdash;like any other web apps&mdash;can be vulnerable to a variety of web-based attacks. Familiarize yourself with known [web vulnerabilities](https://owasp.org/www-project-top-ten/) and take precautions to avoid them.
+
+## Lint your code for security issues
+
+Dependency scanning (as described above) checks the packages you install, but not the code you write. Static analysis tools catch insecure code patterns at lint time&mdash;before the code ships&mdash;such as:
+
+- Hardcoded secrets and credentials in source code
+- Unsafe redirects (see [Prevent open redirects](#prevent-open-redirects))
+- Missing cookie security flags (see [Use cookies securely](#use-cookies-securely))
+- Injection-prone string building for SQL queries or shell commands
+
+Most Express apps already run [ESLint](https://eslint.org/) for code quality, and several ESLint plugins add security-focused rules on top of it. Run these checks in CI alongside your tests so that new violations fail the build.
+
+Static analysis complements, but does not replace, the runtime protections described on this page, such as Helmet and dependency scanning.
 
 ## Additional considerations
 


### PR DESCRIPTION
## Description

Adds a short **"Lint your code for security issues"** section to the *Production Best Practices: Security* page, placed after the dependency-scanning section so the page flows from "check your dependencies" → "check your own code".

The section:

- explains that dependency scanning does not cover the app's own source code
- lists concrete insecure patterns catchable at lint time (hardcoded secrets, unsafe redirects, missing cookie flags, injection-prone string building), cross-linked to the existing open-redirect and cookie-security sections
- stays **tool-neutral** per the discussion in #2471 — it mentions ESLint as the common base and notes plugins exist, without endorsing any specific plugin
- recommends running these checks in CI, and clarifies static analysis complements rather than replaces runtime protections like Helmet

## Motivation

Resolves #2471. Most Express apps already run ESLint, so adding security rules is usually a one-dependency change; the page previously covered runtime protections and `npm audit`/Snyk but not this layer.

## Testing

- Prettier check passes on the modified file
- CSpell passes (0 issues)
- Anchor added to the page TOC
