### PR TITLE
docs: remove duplicated word in method-override middleware reference

### DIFF
--- a/src/content/pages/en/resources/middleware/method-override.mdx
+++ b/src/content/pages/en/resources/middleware/method-override.mdx
@@ -63,7 +63,7 @@ with the following rules:
 
 #### options.methods
 
-This allows the specification of what methods(s) the request _MUST_ be in in order to check for
+This allows the specification of what methods(s) the request _MUST_ be in order to check for
 the method override value. This defaults to only `POST` methods, which is the only method the
 override should arrive in. More methods may be specified here, but it may introduce security
 issues and cause weird behavior when requests travel through caches. This value is an array

--- a/src/content/pages/fr/resources/middleware/method-override.mdx
+++ b/src/content/pages/fr/resources/middleware/method-override.mdx
@@ -63,7 +63,7 @@ avec les règles suivantes :
 
 #### Méthodes
 
-This allows the specification of what methods(s) the request _MUST_ be in in order to check for
+This allows the specification of what methods(s) the request _MUST_ be in order to check for
 the method override value. Par défaut, seules les méthodes `POST`, qui est la seule méthode dans laquelle la substitution
 devrait arriver. D'autres méthodes peuvent être spécifiées ici, mais cela peut introduire des problèmes de sécurité
 et causer des comportements bizarres lorsque les requêtes voyagent à travers des caches. Cette valeur est un tableau

--- a/src/content/pages/ko/resources/middleware/method-override.mdx
+++ b/src/content/pages/ko/resources/middleware/method-override.mdx
@@ -63,7 +63,7 @@ with the following rules:
 
 #### options.methods
 
-This allows the specification of what methods(s) the request _MUST_ be in in order to check for
+This allows the specification of what methods(s) the request _MUST_ be in order to check for
 the method override value. This defaults to only `POST` methods, which is the only method the
 override should arrive in. More methods may be specified here, but it may introduce security
 issues and cause weird behavior when requests travel through caches. This value is an array

--- a/src/content/pages/zh-cn/resources/middleware/method-override.mdx
+++ b/src/content/pages/zh-cn/resources/middleware/method-override.mdx
@@ -63,7 +63,7 @@ with the following rules:
 
 #### options.methods
 
-This allows the specification of what methods(s) the request _MUST_ be in in order to check for
+This allows the specification of what methods(s) the request _MUST_ be in order to check for
 the method override value. This defaults to only `POST` methods, which is the only method the
 override should arrive in. More methods may be specified here, but it may introduce security
 issues and cause weird behavior when requests travel through caches. This value is an array

--- a/src/content/pages/zh-tw/resources/middleware/method-override.mdx
+++ b/src/content/pages/zh-tw/resources/middleware/method-override.mdx
@@ -63,7 +63,7 @@ with the following rules:
 
 #### options.methods
 
-This allows the specification of what methods(s) the request _MUST_ be in in order to check for
+This allows the specification of what methods(s) the request _MUST_ be in order to check for
 the method override value. This defaults to only `POST` methods, which is the only method the
 override should arrive in. More methods may be specified here, but it may introduce security
 issues and cause weird behavior when requests travel through caches. This value is an array


### PR DESCRIPTION
## Summary

Remove a duplicated word ("in in") in the `method-override` middleware reference. The same English sentence appears across all locale copies, so the fix is applied consistently to each.

| File | Fix |
|------|-----|
| src/content/pages/en/resources/middleware/method-override.mdx | "be in in order" → "be in order" |
| src/content/pages/fr/resources/middleware/method-override.mdx | "be in in order" → "be in order" |
| src/content/pages/ko/resources/middleware/method-override.mdx | "be in in order" → "be in order" |
| src/content/pages/zh-cn/resources/middleware/method-override.mdx | "be in in order" → "be in order" |
| src/content/pages/zh-tw/resources/middleware/method-override.mdx | "be in in order" → "be in order" |

## Test plan

- [x] Verified duplicated word was present before editing
- [x] Residual scan clean on changed files
