### PR TITLE
Improve affected/patched version readablity in security release blog posts

### DIFF
--- a/src/content/blog/2025-05-19-security-releases.mdx
+++ b/src/content/blog/2025-05-19-security-releases.mdx
@@ -28,7 +28,7 @@ When the HTTP request stream emits an error, the internal `busboy` stream is not
 
 This leads to unclosed streams accumulating over time, consuming memory and file descriptors. Under sustained or repeated failure conditions, this can result in denial of service, requiring manual server restarts to recover. All users of Multer handling file uploads are potentially impacted.
 
-**Affected versions**: `<2.0.0`
+**Affected versions**: `<2.0.0`\
 **Patched version**: `>=2.0.0`
 
 For more details, see [GHSA-44fp-w29j-9vj5](https://github.com/expressjs/multer/security/advisories/GHSA-44fp-w29j-9vj5).
@@ -39,7 +39,7 @@ For more details, see [GHSA-44fp-w29j-9vj5](https://github.com/expressjs/multer/
 
 A specially crafted request can cause an unhandled exception inside Multer, resulting in a crash of the server process.
 
-**Affected versions**: `>=1.4.4-lts.1` and `<2.0.0`
+**Affected versions**: `>=1.4.4-lts.1` and `<2.0.0`\
 **Patched version**: `>=2.0.0`
 
 For more details, see [GHSA-4pg4-qvpc-4q3h](https://github.com/expressjs/multer/security/advisories/GHSA-4pg4-qvpc-4q3h).

--- a/src/content/blog/2025-07-18-security-releases.mdx
+++ b/src/content/blog/2025-07-18-security-releases.mdx
@@ -23,7 +23,7 @@ This release addresses the following vulnerability:
 
 An attacker can trigger this vulnerability by sending an upload request with an empty string as the field name. This malformed request causes an unhandled exception, leading to a crash of the server process.
 
-**Affected versions**: `>=1.4.4-lts.1` and `<2.0.1`
+**Affected versions**: `>=1.4.4-lts.1` and `<2.0.1`\
 **Patched version**: `2.0.1`
 
 For more details, see [GHSA-g5hg-p3ph-g8qg](https://github.com/expressjs/multer/security/advisories/GHSA-g5hg-p3ph-g8qg).

--- a/src/content/blog/2025-12-01-security-releases.mdx
+++ b/src/content/blog/2025-12-01-security-releases.mdx
@@ -19,7 +19,7 @@ We recommend upgrading to the latest version of body-parser to secure your appli
 
 The following vulnerabilities have been addressed:
 
-- [CVE-2025-13466 in body-parser middleware (Moderate)](#cve-2025-13466-in-body-parser-middleware-moderate)
+- [CVE-2025-13466 in Body-parser middleware (Moderate)](#cve-2025-13466-in-body-parser-middleware-moderate)
 
 ## CVE-2025-13466 in Body-parser middleware (Moderate)
 
@@ -27,7 +27,7 @@ The following vulnerabilities have been addressed:
 
 body-parser 2.2.0 is vulnerable to denial of service due to inefficient handling of URL-encoded bodies with very large numbers of parameters. An attacker can send payloads containing thousands of parameters within the default 100KB request size limit, causing elevated CPU and memory usage. This can lead to service slowdown or partial outages under sustained malicious traffic.
 
-**Affected versions**: `2.2.0`
+**Affected versions**: `2.2.0`\
 **Patched version**: `>= 2.2.1`
 
 For more details, see [GHSA-wqch-xfxh-vrr4](https://github.com/expressjs/body-parser/security/advisories/GHSA-wqch-xfxh-vrr4).

--- a/src/content/blog/2026-02-27-security-releases.mdx
+++ b/src/content/blog/2026-02-27-security-releases.mdx
@@ -28,7 +28,7 @@ The following vulnerabilities have been addressed:
 
 A vulnerability in Multer versions `<2.1.0` allows an attacker to trigger a Denial of Service (DoS) by sending malformed requests, potentially causing resource exhaustion.
 
-**Affected versions**: `< 2.1.0`
+**Affected versions**: `< 2.1.0`\
 **Patched version**: `>= 2.1.0`
 
 For more details, see [GHSA-xf7r-hgr6-v32p](https://github.com/expressjs/multer/security/advisories/GHSA-xf7r-hgr6-v32p).
@@ -39,7 +39,7 @@ For more details, see [GHSA-xf7r-hgr6-v32p](https://github.com/expressjs/multer/
 
 A vulnerability in Multer versions `<2.1.0` allows an attacker to trigger a Denial of Service (DoS) by dropping connection during file upload, potentially causing resource exhaustion.
 
-**Affected versions**: `< 2.1.0`
+**Affected versions**: `< 2.1.0`\
 **Patched version**: `>= 2.1.0`
 
 For more details, see [GHSA-v52c-386h-88mc](https://github.com/expressjs/multer/security/advisories/GHSA-v52c-386h-88mc).

--- a/src/content/blog/2026-03-30-security-releases.mdx
+++ b/src/content/blog/2026-03-30-security-releases.mdx
@@ -32,7 +32,7 @@ The following vulnerabilities have been addressed:
 
 A bad regular expression is generated any time you have three or more parameters within a single segment, separated by something that is not a period. For example, `/:a-:b-:c`. The backtrack protection added in v0.1.12 only prevents ambiguity for two parameters. With three or more, the generated lookahead does not block single separator characters, causing catastrophic backtracking.
 
-**Affected versions**: `<= 0.1.12`
+**Affected versions**: `<= 0.1.12`\
 **Patched version**: `>= 0.1.13`
 
 For more details, see [GHSA-37ch-88jc-xwx2](https://github.com/pillarjs/path-to-regexp/security/advisories/GHSA-37ch-88jc-xwx2).
@@ -43,7 +43,7 @@ For more details, see [GHSA-37ch-88jc-xwx2](https://github.com/pillarjs/path-to-
 
 A bad regular expression is generated any time you have multiple sequential optional groups, such as `{a}{b}{c}:z`. The generated regex grows exponentially with the number of groups, causing denial of service. Avoid passing user-controlled input as route patterns.
 
-**Affected versions**: `>= 8.0.0`
+**Affected versions**: `>= 8.0.0`\
 **Patched version**: `>= 8.4.0`
 
 For more details, see [GHSA-j3q9-mxjg-w52f](https://github.com/pillarjs/path-to-regexp/security/advisories/GHSA-j3q9-mxjg-w52f).
@@ -54,7 +54,7 @@ For more details, see [GHSA-j3q9-mxjg-w52f](https://github.com/pillarjs/path-to-
 
 When using multiple wildcards combined with at least one parameter, a regular expression can be generated that is vulnerable to ReDoS. The second wildcard must be somewhere other than the end of the path. For example, `/*foo-*bar-:baz`.
 
-**Affected versions**: `>= 8.0.0, <= 8.3.0`
+**Affected versions**: `>= 8.0.0, <= 8.3.0`\
 **Patched version**: `>= 8.4.0`
 
 For more details, see [GHSA-27v5-c462-wpq7](https://github.com/pillarjs/path-to-regexp/security/advisories/GHSA-27v5-c462-wpq7).

--- a/src/content/blog/2026-05-31-security-releases.mdx
+++ b/src/content/blog/2026-05-31-security-releases.mdx
@@ -33,7 +33,7 @@ The following vulnerabilities have been addressed:
 
 A crafted multipart upload with a long header value can cause regex matching in the Content-Disposition filename parser to take seconds, blocking the Node.js event loop. Any service accepting multipart uploads via multiparty is affected. A small header of around 8 KB is sufficient to trigger the vulnerable backtracking.
 
-**Affected versions**: `<= 4.2.3`
+**Affected versions**: `<= 4.2.3`\
 **Patched version**: `>= 4.3.0`
 
 For more details, see [GHSA-65x3-rw7q-gx94](https://github.com/pillarjs/multiparty/security/advisories/GHSA-65x3-rw7q-gx94).
@@ -44,7 +44,7 @@ For more details, see [GHSA-65x3-rw7q-gx94](https://github.com/pillarjs/multipar
 
 A multipart upload with a field name that collides with an inherited Object.prototype property such as `__proto__`, `constructor`, or `toString` causes the parser to invoke `.push()` on the inherited prototype value rather than an array, throwing a TypeError that propagates as an uncaught exception and crashes the process. Any service accepting multipart uploads via multiparty is affected.
 
-**Affected versions**: `<= 4.2.3`
+**Affected versions**: `<= 4.2.3`\
 **Patched version**: `>= 4.3.0`
 
 For more details, see [GHSA-qxch-whhj-8956](https://github.com/pillarjs/multiparty/security/advisories/GHSA-qxch-whhj-8956).
@@ -55,7 +55,7 @@ For more details, see [GHSA-qxch-whhj-8956](https://github.com/pillarjs/multipar
 
 A multipart upload with a Content-Disposition header whose `filename*` parameter contains a malformed percent-encoding causes the parser to invoke `decodeURI` on the value without try/catch. The resulting URIError propagates as an uncaught exception and crashes the process. Any service accepting multipart uploads via multiparty is affected.
 
-**Affected versions**: `<= 4.2.3`
+**Affected versions**: `<= 4.2.3`\
 **Patched version**: `>= 4.3.0`
 
 For more details, see [GHSA-xh3c-6gcq-g4rv](https://github.com/pillarjs/multiparty/security/advisories/GHSA-xh3c-6gcq-g4rv).

--- a/src/content/blog/2026-06-30-security-releases.mdx
+++ b/src/content/blog/2026-06-30-security-releases.mdx
@@ -44,7 +44,7 @@ For more details, see [GHSA-72gw-mp4g-v24j](https://github.com/expressjs/multer/
 
 Morgan's `:remote-user` token writes the Basic auth username from the `Authorization` header to the log stream without neutralizing control characters. A crafted `Authorization: Basic` header containing CR/LF characters can inject forged log lines, corrupting the one-request-per-line structure of access logs. The built-in `combined`, `common`, `default`, and `short` formats are affected, as well as any custom format that includes `:remote-user`.
 
-**Affected versions**: `>= 1.2.0, <= 1.10.1`
+**Affected versions**: `>= 1.2.0, <= 1.10.1`\
 **Patched version**: `>= 1.11.0`
 
 For more details, see [GHSA-4vj7-5mj6-jm8m](https://github.com/expressjs/morgan/security/advisories/GHSA-4vj7-5mj6-jm8m).
@@ -55,7 +55,7 @@ For more details, see [GHSA-4vj7-5mj6-jm8m](https://github.com/expressjs/morgan/
 
 When multer's `diskStorage` engine is used, aborted or malformed multipart uploads leave orphaned partial files on disk. The cleanup path does not run on every error condition, so an attacker can fill the upload directory by repeatedly opening and dropping connections mid-upload. Over time this exhausts disk space, causing denial of service on the host.
 
-**Affected versions**: `>= 2.0.0-alpha.1, < 2.2.0` and `>= 3.0.0-alpha.1, < 3.0.0-alpha.2`
+**Affected versions**: `>= 2.0.0-alpha.1, < 2.2.0` and `>= 3.0.0-alpha.1, < 3.0.0-alpha.2`\
 **Patched version**: `>= 2.2.0` (stable line) and `>= 3.0.0-alpha.2` (alpha line)
 
 For more details, see [GHSA-3p4h-7m6x-2hcm](https://github.com/expressjs/multer/security/advisories/GHSA-3p4h-7m6x-2hcm).

--- a/src/content/blog/2026-07-31-security-releases.mdx
+++ b/src/content/blog/2026-07-31-security-releases.mdx
@@ -31,7 +31,7 @@ The following vulnerability has been addressed:
 
 When body-parser was configured with an invalid `limit` option value, such as an unparsable string or `NaN`, the internal call to `bytes.parse()` returned `null` and the request body size check was silently skipped. Applications that relied on `limit` as their primary safeguard against oversized request bodies would accept arbitrarily large payloads, leading to excessive memory and CPU usage and denial of service. This affected applications that pass a programmatically computed or user-configurable value to the `limit` option without validating it first. After the fix, invalid `limit` values throw a clear error at parser construction time instead of silently disabling enforcement.
 
-**Affected versions**: `< 1.20.6` and `>= 2.0.0, < 2.3.0`
+**Affected versions**: `< 1.20.6` and `>= 2.0.0, < 2.3.0`\
 **Patched versions**: `>= 1.20.6` and `>= 2.3.0`
 
 For more details, see [GHSA-v422-hmwv-36x6](https://github.com/expressjs/body-parser/security/advisories/GHSA-v422-hmwv-36x6).

--- a/src/content/blog/2026-08-31-security-releases.mdx
+++ b/src/content/blog/2026-08-31-security-releases.mdx
@@ -36,7 +36,7 @@ The following vulnerabilities have been addressed:
 
 hbs did not escape the output of asynchronous helpers the way it does for synchronous helpers, so a helper registered through `registerAsyncHelper` that returned attacker-influenced data emitted that data into the rendered page without neutralization. Applications that used async helpers to render values derived from user input were exposed to cross-site scripting, allowing script execution in the victim's browser. The fix in 4.3.0 escapes async helper output consistently with synchronous helpers.
 
-**Affected versions**: `>= 2.1.0, <= 4.2.1`
+**Affected versions**: `>= 2.1.0, <= 4.2.1`\
 **Patched version**: `>= 4.3.0`
 
 For more details, see [GHSA-rg36-rxv9-2m9q](https://github.com/pillarjs/hbs/security/advisories/GHSA-rg36-rxv9-2m9q).
@@ -49,7 +49,7 @@ For more details, see [GHSA-rg36-rxv9-2m9q](https://github.com/pillarjs/hbs/secu
 
 When a disk-backed upload was aborted or truncated before the write stream finished, multer removed the visible file from the upload directory but did not close the underlying write file descriptor. A remote attacker able to reach an upload route using the built-in disk storage could send repeated aborted or malformed multipart uploads, each one leaking a file descriptor and retaining disk blocks until the process exits, leading to resource exhaustion and denial of service. The fix in 2.3.0 closes the destination write stream on abnormal source termination and defers cleanup until the stream has closed.
 
-**Affected versions**: `= 2.2.0`
+**Affected versions**: `= 2.2.0`\
 **Patched version**: `>= 2.3.0`
 
 For more details, see [GHSA-qfvm-cv95-jqjf](https://github.com/expressjs/multer/security/advisories/GHSA-qfvm-cv95-jqjf).
@@ -62,7 +62,7 @@ For more details, see [GHSA-qfvm-cv95-jqjf](https://github.com/expressjs/multer/
 
 A small multipart request containing two specially crafted text field names caused an uncaught `RangeError` in multer's field parser and terminated the Node.js process. The first field used a very large numeric array index to allocate a maximum-length sparse array, and a second field pushed past that length, which threw inside the append-field dependency and was not caught by multer. A single unauthenticated request was sufficient to crash the server, making this a remotely triggered denial of service. The fix in 2.3.0 handles the parser error and rejects the request instead of crashing.
 
-**Affected versions**: `< 2.3.0`
+**Affected versions**: `< 2.3.0`\
 **Patched version**: `>= 2.3.0`
 
 For more details, see [GHSA-wc9g-mqfw-jrwm](https://github.com/expressjs/multer/security/advisories/GHSA-wc9g-mqfw-jrwm).
@@ -75,7 +75,7 @@ For more details, see [GHSA-wc9g-mqfw-jrwm](https://github.com/expressjs/multer/
 
 A multipart request with a first field using a very large numeric array index made multer allocate a maximum-length sparse array, and a second field with a non-numeric key then triggered a full-length iteration inside the append-field dependency that blocked the event loop and left the process unable to handle other requests. A single request was enough to make the worker unresponsive, so this is a remotely triggered denial of service. multer 2.3.0 adds an opt-in `limits.fieldArrayIndexLimit` option that rejects oversized indexes. We recommend upgrading to 2.3.0 and setting `limits.fieldArrayIndexLimit` to the largest array index your application needs.
 
-**Affected versions**: `< 2.3.0`
+**Affected versions**: `< 2.3.0`\
 **Patched version**: `>= 2.3.0`
 
 For more details, see [GHSA-535w-7cp7-47q4](https://github.com/expressjs/multer/security/advisories/GHSA-535w-7cp7-47q4).
@@ -88,7 +88,7 @@ For more details, see [GHSA-535w-7cp7-47q4](https://github.com/expressjs/multer/
 
 morgan's log-field escaping did not neutralize the Unicode line separator characters U+0085, U+2028, and U+2029. An unauthenticated remote client could place these characters in an attacker-controlled log token, for example a Basic auth username surfaced through the remote-user token, so that Unicode-aware downstream log processing split a single request log into multiple logical records. This is a log forging issue and a follow-up to CVE-2026-5078, which only addressed ASCII control characters. The fix in 1.12.0 extends the escaping set to cover these Unicode line separators.
 
-**Affected versions**: `< 1.12.0`
+**Affected versions**: `< 1.12.0`\
 **Patched version**: `>= 1.12.0`
 
 For more details, see [GHSA-jxfw-x594-9x9m](https://github.com/expressjs/morgan/security/advisories/GHSA-jxfw-x594-9x9m).
@@ -101,7 +101,7 @@ For more details, see [GHSA-jxfw-x594-9x9m](https://github.com/expressjs/morgan/
 
 When an application used an asynchronous `fileFilter` together with the `fileSize` limit, a race condition in multer's file stream handling could allow a file that exceeds the configured size limit to bypass the size-limit rejection. The impact is limited because the underlying multipart parser still truncates the stream at the size limit, so this is a bypass of the limit rejection rather than uncontrolled resource consumption. The fix in 2.3.0 registers the size-limit handling before the asynchronous filter runs.
 
-**Affected versions**: `< 2.3.0`
+**Affected versions**: `< 2.3.0`\
 **Patched version**: `>= 2.3.0`
 
 For more details, see [GHSA-qvfw-j98x-7q72](https://github.com/expressjs/multer/security/advisories/GHSA-qvfw-j98x-7q72).


### PR DESCRIPTION
> [!NOTE]
> This is more of a request for comments than a proper PR.

Recent blog posts about security releases put the list of affected and patched versions in the same line (in rendered docs, source has them separate). On smaller screens the text wrapping makes it look a bit weird and hard to follow.

| ![The text "Affected versions: < 1.12.0 Patched version: >= 1.12.0" that is wrapped after the word "patched"](https://github.com/user-attachments/assets/a81abab3-a05c-4479-b060-bf582302999b) |
| --- |
| CVE-2026-15603 details from the [August 2026 post](https://expressjs.com/en/blog/2026-08-31-security-releases/) viewed on a phone |

| <a name="original-very-long" href=""></a> ![A very long text with affected and patched versions, where the "Patched version:" bold text is somewhere in the middle of paragraph](https://github.com/user-attachments/assets/867b1a9c-13f0-4d97-a098-c704719d2f0b) |
| --- |
| CVE-2026-5038 details from the [June 2026 post](https://expressjs.com/en/blog/2026-06-30-security-releases/) viewed on a phone |

Some older posts follow a slightly different format:

- [September 2024](https://expressjs.com/en/blog/2024-09-29-security-releases/) mixes two different approaches:
  - separate paragraphs
     ![Affected versions and patched versions as separate paragraphs](https://github.com/user-attachments/assets/12e90ecd-37d6-4a1f-9e41-1190cd217b94)
  - lists
    !["Affected versions" text followed by an unordered list of versions and below separately the same for patched versions](https://github.com/user-attachments/assets/b5fd21f3-3511-4e40-abe1-12d77a1088c7)
- [July 2025](https://expressjs.com/en/blog/2025-07-31-security-releases/) has a `<br>` (double space at the end of line in markdown) separating the affected versions and patched versions
  ![Affected versions and patched version in separate line, but same paragraph](https://github.com/user-attachments/assets/90d75e33-081c-4747-a49f-cbb83add71ed)

### Good readable format

At the time of creation of this PR it adds line breaks between all affected and patched version lines that were rendered in one line. It looks better on mobile and desktop, but in cases when there are multiple versions listed I think that a proper list would be more readable.

| ![A very long text with affected versions and separated by a line break a long text with patched versions](https://github.com/user-attachments/assets/9d5ddb62-b0c9-4758-a54b-afef5c621ade) |
| --- |
| This PR version of CVE-2026-5038 details from the [June 2026 post](https://expressjs.com/en/blog/2026-06-30-security-releases/) viewed on a phone (compare to the [original above](#original-very-long)) |

### Question(s)

A few more or less related questions that I had while writing this:

1. Should we decide on one format? Which one?
2. Some multer security-related patches have been cherry picked to the [v3 branch](https://github.com/expressjs/multer/commits/v3/) (June 2026) and released in a new alpha, while others (August 2026) are exclusive to the stable 2.x branch. Is that on purpose?
3. (nitpick) Why do posts from 2025 (and only 2025) capitalise the first letter of all package names?

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
