### PR TITLE
Security best practices: Remove duplicate page TOC

### DIFF
--- a/src/content/pages/de/advanced/best-practice-security.mdx
+++ b/src/content/pages/de/advanced/best-practice-security.mdx
@@ -17,22 +17,6 @@ Richtlinien und Prozeduren.
 
 </Alert>
 
-Best Practices für Express-Anwendungen in der Produktion beinhalten:
-
-- [Veraltete oder verwundbare Versionen von Express](#dont-use-deprecated-or-vulnerable-versions-of-express)
-- [Benutze TLS](#use-tls)
-- [Nicht auf Benutzereingabe vertrauen](#do-not-trust-user-input)
-  - [Verhindere offene Weiterleitungen](#prevent-open-redirects)
-- [Helm verwenden](#use-helmet)
-- [Fingerabdruck reduzieren](#reduce-fingerprinting)
-- [Cookies sicher verwenden](#use-cookies-securely)
-  - [Benutze nicht den Standard-Sitzungs-Cookie Name](#dont-use-the-default-session-cookie-name)
-  - [Cookie Sicherheitseinstellungen setzen](#set-cookie-security-options)
-- [Verhindere Brute-Force-Angriffe gegen Autorisierung](#prevent-brute-force-attacks-against-authorization)
-- [Vergewissern Sie sich, dass Ihre Abhängigkeiten sicher sind](#ensure-your-dependencies-are-secure)
-  - [Vermeide andere bekannte Schwachstellen aus](#avoid-other-known-vulnerabilities)
-- [Zusätzliche Überlegungen](#additional-considerations)
-
 ## Veraltete oder verwundbare Versionen von Express nicht verwenden
 
 Express 2.x und 3.x werden nicht mehr gewartet. Sicherheits- und Leistungsprobleme in diesen Versionen werden nicht behoben. Verwenden Sie sie nicht! Wenn Sie nicht auf Version 4 umgezogen sind, folgen Sie der [Migrationsanleitung](/guide/migrating-4) oder überlegen Sie [Handelsunterstützungsoptionen](/support#commercial-support-options).

--- a/src/content/pages/en/advanced/best-practice-security.mdx
+++ b/src/content/pages/en/advanced/best-practice-security.mdx
@@ -17,22 +17,6 @@ Policies and Procedures](/resources/contributing#security-policies-and-procedure
 
 </Alert>
 
-Security best practices for Express applications in production include:
-
-- [Don't use deprecated or vulnerable versions of Express](#dont-use-deprecated-or-vulnerable-versions-of-express)
-- [Use TLS](#use-tls)
-- [Do not trust user input](#do-not-trust-user-input)
-  - [Prevent open redirects](#prevent-open-redirects)
-- [Use Helmet](#use-helmet)
-- [Reduce fingerprinting](#reduce-fingerprinting)
-- [Use cookies securely](#use-cookies-securely)
-  - [Don't use the default session cookie name](#dont-use-the-default-session-cookie-name)
-  - [Set cookie security options](#set-cookie-security-options)
-- [Prevent brute-force attacks against authorization](#prevent-brute-force-attacks-against-authorization)
-- [Ensure your dependencies are secure](#ensure-your-dependencies-are-secure)
-  - [Avoid other known vulnerabilities](#avoid-other-known-vulnerabilities)
-- [Additional considerations](#additional-considerations)
-
 ## Don't use deprecated or vulnerable versions of Express
 
 Express 2.x and 3.x are no longer maintained. Security and performance issues in these versions won't be fixed. Do not use them! If you haven't moved to version 4, follow the [migration guide](/guide/migrating-4) or consider [Commercial Support Options](/support#commercial-support-options).

--- a/src/content/pages/es/advanced/best-practice-security.mdx
+++ b/src/content/pages/es/advanced/best-practice-security.mdx
@@ -17,22 +17,6 @@ Políticas y procedimientos.
 
 </Alert>
 
-Las mejores prácticas de seguridad para aplicaciones Express en producción incluyen:
-
-- [No usar versiones obsoletas o vulnerables de Express](#dont-use-deprecated-or-vulnerable-versions-of-express)
-- [Usar TLS](#use-tls)
-- [No confiar en la entrada del usuario](#do-not-trust-user-input)
-  - [Prevenir redirecciones abiertas](#prevent-open-redirects)
-- [Casco de Uso](#use-helmet)
-- [Reducir la huella dactilar](#reduce-fingerprinting)
-- [Usar cookies de forma segura](#use-cookies-securely)
-  - [No usar el nombre de cookie de sesión predeterminado](#dont-use-the-default-session-cookie-name)
-  - [Establecer opciones de seguridad de cookies](#set-cookie-security-options)
-- [Prevenir ataques de fuerza bruta contra autorización](#prevent-brute-force-attacks-against-authorization)
-- [Asegúrate de que tus dependencias son seguras](#ensure-your-dependencies-are-secure)
-  - [Evitar otras vulnerabilidades conocidas](#avoid-other-known-vulnerabilities)
-- [Examen adicional](#additional-considerations)
-
 ## No utilizar versiones obsoletas o vulnerables de Express
 
 Las exprés 2.x y 3.x ya no están mantenidas. No se solucionarán problemas de seguridad y rendimiento en estas versiones. ¡No los utilices! Si no has movido a la versión 4, sigue la [guía de migración](/guide/migrating-4) o considera [Opciones de Soporte Comercial](/support#commercial-support-options).

--- a/src/content/pages/fr/advanced/best-practice-security.mdx
+++ b/src/content/pages/fr/advanced/best-practice-security.mdx
@@ -17,22 +17,6 @@ de sécurité [/en/resources/contributing#security-policies-and-procedures).
 
 </Alert>
 
-Les meilleures pratiques de sécurité pour les applications Express en production comprennent:
-
-- [Ne pas utiliser de versions obsolètes ou vulnérables d'Express](#dont-use-deprecated-or-vulnerable-versions-of-express)
-- [Utiliser TLS](#use-tls)
-- [Ne pas faire confiance à la saisie de l'utilisateur](#do-not-trust-user-input)
-  - [Empêcher les redirections ouvertes](#prevent-open-redirects)
-- [Utiliser le casque](#use-helmet)
-- [Réduire l'empreinte digitale](#reduce-fingerprinting)
-- (#use-cookies-securely)
-  - [Ne pas utiliser le nom du cookie de session par défaut](#dont-use-the-default-session-cookie-name)
-  - (#set-cookie-security-options)
-- [Empêcher les attaques par force brute contre l'autorisation](#prevent-brute-force-attacks-against-authorization)
-- [Assurez-vous que vos dépendances sont sécurisées](#ensure-your-dependencies-are-secure)
-  - [Éviter les autres vulnérabilités connues](#avoid-other-known-vulnerabilities)
-- [Considérations supplémentaires](#additional-considerations)
-
 ## Ne pas utiliser les versions obsolètes ou vulnérables de Express
 
 Express 2.x et 3.x ne sont plus maintenus. Les problèmes de sécurité et de performance dans ces versions ne seront pas résolus. Ne les utilisez pas ! Si vous n'avez pas déménagé vers la version 4, suivez le [guide de migration](/en/guide/migrating-4) ou envisagez [Options de support commercial](/en/support#commercial-support-options).

--- a/src/content/pages/it/advanced/best-practice-security.mdx
+++ b/src/content/pages/it/advanced/best-practice-security.mdx
@@ -17,22 +17,6 @@ Policies and Procedures.
 
 </Alert>
 
-Le migliori pratiche di sicurezza per le applicazioni Express in produzione includono:
-
-- [Non utilizzare versioni deprecate o vulnerabili di Express](#dont-use-deprecated-or-vulnerable-versions-of-express)
-- [Usa TLS](#use-tls)
-- [Non fidarti dell'input dell'utente](#do-not-trust-user-input)
-  - [Previene reindirizzamenti aperti](#prevent-open-redirects)
-- [Usa Elmet](#use-helmet)
-- [Riduci l'impronta digitale](#reduce-fingerprinting)
-- [Usa i cookie in modo sicuro](#use-cookies-securely)
-  - [Non utilizzare il nome predefinito del cookie di sessione](#dont-use-the-default-session-cookie-name)
-  - [Imposta opzioni di sicurezza dei cookie](#set-cookie-security-options)
-- [Prevenire attacchi di forza brutale contro l'autorizzazione](#prevent-brute-force-attacks-against-authorization)
-- [Assicurati che le tue dipendenze siano sicure](#ensure-your-dependencies-are-secure)
-  - [Evitare altre vulnerabilità conosciute](#avoid-other-known-vulnerabilities)
-- [Ulteriori considerazioni](#additional-considerations)
-
 ## Non utilizzare versioni deprecate o vulnerabili di Express
 
 Express 2.x e 3.x non sono più mantenuti. Problemi di sicurezza e prestazioni in queste versioni non saranno risolti. Non usarli! Se non hai spostato nella versione 4, segui la [guida alla migrazione](/guide/migrating-4) o prendi in considerazione [Opzioni di supporto commerciale](/support#commercial-support-options).

--- a/src/content/pages/ja/advanced/best-practice-security.mdx
+++ b/src/content/pages/ja/advanced/best-practice-security.mdx
@@ -17,22 +17,6 @@ Express でセキュリティ上の脆弱性を発見したと思われる場合
 
 </Alert>
 
-実稼働中の Express アプリケーションのセキュリティのベスト プラクティスは以下のとおりです。
-
-- [Expressの非推奨バージョンや脆弱バージョンを使用しないでください](#dont-use-deprecated-or-vulnerable-versions-of-express)
-- [Use TLS](#use-tls)
-- [Do not trust user input](#do-not-trust-user-input)
-  - [Prevent open redirects](#prevent-open-redirects)
-- [Use Helmet](#use-helmet)
-- [Reduce fingerprinting](#reduce-fingerprinting)
-- [Use cookies securely](#use-cookies-securely)
-  - [Don't use the default session cookie name](#dont-use-the-default-session-cookie-name)
-  - [Set cookie security options](#set-cookie-security-options)
-- [Prevent brute-force attacks against authorization](#prevent-brute-force-attacks-against-authorization)
-- [Ensure your dependencies are secure](#ensure-your-dependencies-are-secure)
-  - [Avoid other known vulnerabilities](#avoid-other-known-vulnerabilities)
-- [Additional considerations](#additional-considerations)
-
 ## 非推奨または脆弱なバージョンの Express を使用しない
 
 Express 2.x と 3.x はメンテナンスされなくなりました。 これらのバージョンのセキュリティとパフォーマンスの問題は修正されません。 それらを使用しないでください! これらのバージョンのセキュリティとパフォーマンスの問題は修正されません。 それらを使用しないでください! If you haven't moved to version 4, follow the [migration guide](/guide/migrating-4) or consider [Commercial Support Options](/support#commercial-support-options).

--- a/src/content/pages/ko/advanced/best-practice-security.mdx
+++ b/src/content/pages/ko/advanced/best-practice-security.mdx
@@ -17,22 +17,6 @@ Policies and Procedures.
 
 </Alert>
 
-Security best practices for Express applications in production include:
-
-- [Don't use deprecated or vulnerable versions of Express](#dont-use-deprecated-or-vulnerable-versions-of-express)
-- [Use TLS](#use-tls)
-- [Do not trust user input](#do-not-trust-user-input)
-  - [Prevent open redirects](#prevent-open-redirects)
-- [Use Helmet](#use-helmet)
-- [Reduce fingerprinting](#reduce-fingerprinting)
-- [Use cookies securely](#use-cookies-securely)
-  - [Don't use the default session cookie name](#dont-use-the-default-session-cookie-name)
-  - [Set cookie security options](#set-cookie-security-options)
-- [Prevent brute-force attacks against authorization](#prevent-brute-force-attacks-against-authorization)
-- [Ensure your dependencies are secure](#ensure-your-dependencies-are-secure)
-  - [Avoid other known vulnerabilities](#avoid-other-known-vulnerabilities)
-- [Additional considerations](#additional-considerations)
-
 ## Don't use deprecated or vulnerable versions of Express
 
 Express 2.x and 3.x are no longer maintained. Security and performance issues in these versions won't be fixed. Do not use them! If you haven't moved to version 4, follow the [migration guide](/guide/migrating-4) or consider [Commercial Support Options](/support#commercial-support-options).

--- a/src/content/pages/pt-br/advanced/best-practice-security.mdx
+++ b/src/content/pages/pt-br/advanced/best-practice-security.mdx
@@ -17,22 +17,6 @@ Políticas e Procedimentos.
 
 </Alert>
 
-As melhores práticas de segurança para aplicações Expressas na produção incluem:
-
-- [Não usar versões descontinuadas ou vulneráveis do Express](#dont-use-deprecated-or-vulnerable-versions-of-express)
-- [Usar TLS](#use-tls)
-- [Não confie na entrada do usuário](#do-not-trust-user-input)
-  - [Impedir redirecionamentos abertos](#prevent-open-redirects)
-- [Usar capacete](#use-helmet)
-- [Reduzir impressão digital](#reduce-fingerprinting)
-- [Usar cookies de forma segura](#use-cookies-securely)
-  - [Não usar o nome padrão de cookie da sessão](#dont-use-the-default-session-cookie-name)
-  - [Definir opções de segurança de cookies](#set-cookie-security-options)
-- [Impedir ataques brute-force contra a autorização](#prevent-brute-force-attacks-against-authorization)
-- [Garanta que suas dependências sejam seguras](#ensure-your-dependencies-are-secure)
-  - [Evitar outras vulnerabilidades conhecidas](#avoid-other-known-vulnerabilities)
-- [Considerações adicionais](#additional-considerations)
-
 ## Não usar versões obsoletas ou vulneráveis do Express
 
 Expresso 2,x e 3.x já não são mantidos. Problemas de segurança e desempenho nestas versões não serão corrigidos. Não os utilize! Se você não se moveu para a versão 4, siga o [guia de migração](/guide/migrating-4) ou considere [Opções de Suporte Comercial](/support#commercial-support-options).

--- a/src/content/pages/zh-cn/advanced/best-practice-security.mdx
+++ b/src/content/pages/zh-cn/advanced/best-practice-security.mdx
@@ -17,22 +17,6 @@ Policies and Procedures.
 
 </Alert>
 
-Express 应用生产环境安全最佳实践包含：
-
-- [请勿使用已弃用或存在漏洞的 Express 版本](#请勿使用已弃用或存在漏洞的-express-版本)
-- [启用TLS](#use-tls)
-- [切勿信任用户输入](#切勿信任用户输入)
-  - [防止开放重定向](#防止开放重定向)
-- [使用 Helmet](#use-helmet)
-- [减少指纹信息泄露](#reduce-fingerprinting)
-- [安全使用 Cookie](#use-cookies-securely)
-  - [不使用默认会话 cookie 名称](#dont-use-the-default-session-cookie-name)
-  - [设置 cookie 安全选项](#set-cookie-security-options)
-- [防止使用暴力攻击授权](#prevent-brute-force-attacks-against-authorization)
-- [确保您的依赖是安全的](#ensure-your-dependencies-are-secure)
-  - [避免其他已知漏洞](#avoid-other-known-vulnerabilities)
-- [其他考虑](#additional-considerations)
-
 ## 请勿使用已弃用或存在漏洞的 Express 版本
 
 Express 2.x 与 3.x 版本已不再维护。 这些版本中的安全与性能问题将不再进行修复。 不要使用它们！ If you haven't moved to version 4, follow the [migration guide](/guide/migrating-4) or consider [Commercial Support Options](/support#commercial-support-options).

--- a/src/content/pages/zh-tw/advanced/best-practice-security.mdx
+++ b/src/content/pages/zh-tw/advanced/best-practice-security.mdx
@@ -17,22 +17,6 @@ Policies and Procedures.
 
 </Alert>
 
-Security best practices for Express applications in production include:
-
-- [Don't use deprecated or vulnerable versions of Express](#dont-use-deprecated-or-vulnerable-versions-of-express)
-- [Use TLS](#use-tls)
-- [Do not trust user input](#do-not-trust-user-input)
-  - [Prevent open redirects](#prevent-open-redirects)
-- [Use Helmet](#use-helmet)
-- [Reduce fingerprinting](#reduce-fingerprinting)
-- [Use cookies securely](#use-cookies-securely)
-  - [Don't use the default session cookie name](#dont-use-the-default-session-cookie-name)
-  - [Set cookie security options](#set-cookie-security-options)
-- [Prevent brute-force attacks against authorization](#prevent-brute-force-attacks-against-authorization)
-- [Ensure your dependencies are secure](#ensure-your-dependencies-are-secure)
-  - [Avoid other known vulnerabilities](#avoid-other-known-vulnerabilities)
-- [Additional considerations](#additional-considerations)
-
 ## Don't use deprecated or vulnerable versions of Express
 
 Express 2.x and 3.x are no longer maintained. Security and performance issues in these versions won't be fixed. Do not use them! If you haven't moved to version 4, follow the [migration guide](/guide/migrating-4) or consider [Commercial Support Options](/support#commercial-support-options).


### PR DESCRIPTION
The manually-written page TOC is left over from the old site and is no longer needed since it duplicates the automatically-generated TOC.  It doesn't add any value and simply takes up screen real estate.

I made the same change in `en` and all the localized pages.

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
