### PR TITLE
Update required Node.js version

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 The site is built with [Astro](https://astro.build), TypeScript, and MDX.
 
-**Prerequisites:** Node.js >= 24.13.0 and npm >= 11.0.0
+**Prerequisites:** Node.js >= 24.15.0 and npm >= 11.0.0
 
 ```bash
 npm install


### PR DESCRIPTION
The site actually requires Node >=24.15.0.

If you do `npm install` using Node v24.13.0, you get this error:

```
npm error EBADDEVENGINES   current: { name: 'node', version: 'v24.13.0' },
npm error EBADDEVENGINES   required: { name: 'node', version: '>=24.15.0', onFail: 'error' }
```

<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
