### PR TITLE
docs: fix 'allows to' grammar in urlencoded options

### DIFF
--- a/src/content/api/4x/api/express/index.mdx
+++ b/src/content/api/4x/api/express/index.mdx
@@ -567,7 +567,7 @@ app.post('/', (req: Request, res: Response) => {
 
       <Fragment slot="properties">
         <Param name="extended" type="Boolean" default="true">
-          This option allows to choose between parsing the URL-encoded data with the `querystring`
+          This option allows you to choose between parsing the URL-encoded data with the `querystring`
           library (when `false`) or the `qs` library (when `true`). The "extended" syntax allows for
           rich objects and arrays to be encoded into the URL-encoded format, allowing for a
           JSON-like experience with URL-encoded. For more information, please [see the qs

--- a/src/content/api/5x/api/express/index.mdx
+++ b/src/content/api/5x/api/express/index.mdx
@@ -574,7 +574,7 @@ app.post('/', (req: Request, res: Response) => {
 
       <Fragment slot="properties">
         <Param name="extended" type="Boolean" default="false">
-          This option allows to choose between parsing the URL-encoded data with the `querystring`
+          This option allows you to choose between parsing the URL-encoded data with the `querystring`
           library (when `false`) or the `qs` library (when `true`). The "extended" syntax allows for
           rich objects and arrays to be encoded into the URL-encoded format, allowing for a
           JSON-like experience with URL-encoded. For more information, please [see the qs


### PR DESCRIPTION
Tiny docs fix: `allows to choose` → `allows you to choose` in the Express `urlencoded` options docs (API 4.x and 5.x).